### PR TITLE
Bring browser window to the front (mac osx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ chromedriver_linux
 chromedriver.exe
 .hubturbocache/
 
+.idea
+HubTurbo.iml

--- a/src/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,1 @@
+apple.applescript.AppleScriptEngineFactory

--- a/src/browserview/BrowserComponent.java
+++ b/src/browserview/BrowserComponent.java
@@ -430,7 +430,7 @@ public class BrowserComponent {
 			try {
 				if (scriptEngine == null) {
 					ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
-					scriptEngine = scriptEngineManager.getEngineByName("AppleScript");
+					scriptEngine = scriptEngineManager.getEngineByName("AppleScriptEngine");
 				}
 				scriptEngine.eval("tell application \"System Events\" to repeat with p in (every application process whose name contains \"Chrome\" and name does not contain \"Helper\")\nif (title of window of p as string) contains \"" + driver.getTitle() + "\" then tell process p to perform action \"AXRaise\" of window 1 of p\nend repeat");
 			} catch (ScriptException e) {

--- a/src/browserview/BrowserComponent.java
+++ b/src/browserview/BrowserComponent.java
@@ -355,9 +355,6 @@ public class BrowserComponent {
 	private static void setupJNA() {
 		if (PlatformSpecific.isOnWindows()) {
 			user32 = User32.INSTANCE;
-		} else if (PlatformSpecific.isOnMac()) {
-			ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
-			scriptEngine = scriptEngineManager.getEngineByName("AppleScript");
 		}
 	}
 	
@@ -431,6 +428,10 @@ public class BrowserComponent {
 	public void bringToFront() {
 		if (PlatformSpecific.isOnMac()) {
 			try {
+				if (scriptEngine == null) {
+					ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
+					scriptEngine = scriptEngineManager.getEngineByName("AppleScript");
+				}
 				scriptEngine.eval("tell application \"System Events\" to repeat with p in (every application process whose name contains \"Chrome\" and name does not contain \"Helper\")\nif (title of window of p as string) contains \"" + driver.getTitle() + "\" then tell process p to perform action \"AXRaise\" of window 1 of p\nend repeat");
 			} catch (ScriptException e) {
 				logger.info("Bring browser window to front script exception! " + e.getLocalizedMessage());


### PR DESCRIPTION
Partially fixes #442 

I'm only able to bring HT's chrome window to the front by using AppleScript to check and bring up the chrome window that matches the page title
Assumes that HT's chrome driver only has one tab and window, and is in the same space
Works with multiple instances of chrome (even if they are in the same space)

Original script is below:
```applescript
tell application "System Events" to repeat with p in (every application process whose name contains "Chrome" and name does not contain "Helper")
    if (title of window of p as string) contains "{insert page name here}" then tell process p to perform action "AXRaise" of window 1 of p
end repeat
```