### PR TITLE
Start the Chrome browser on HubTurbo startup #604

### DIFF
--- a/src/browserview/BrowserComponent.java
+++ b/src/browserview/BrowserComponent.java
@@ -94,8 +94,11 @@ public class BrowserComponent {
 	 */
 	public void initialise() {
 		assert driver == null;
-		driver = createChromeDriver();
-		logger.info("Successfully initialised browser component and ChromeDriver");
+		executor.execute(() -> {
+			driver = createChromeDriver();
+			logger.info("Successfully initialised browser component and ChromeDriver");
+        });
+		login();
 	}
 	
 	/**

--- a/src/ui/UI.java
+++ b/src/ui/UI.java
@@ -134,6 +134,7 @@ public class UI extends Application implements EventDispatcher {
 				repoSelector.refreshComboBoxContents(ServiceManager.getInstance().getRepoId().generateId());
 				triggerEvent(new BoardSavedEvent());
 				ensureSelectedPanelHasFocus();
+				browserComponent.initialise();
 			} else {
 				quit();
 			}


### PR DESCRIPTION
Fixes #604 

Now the Chrome browser starts after HubTurbo has verified the login credentials of the user and synchronized the local data with the GitHub repo.

The browser launch can even be moved before the GitHub repo sync is initiated (but after the login credentials of the user has been verified), but as the repo sync will also be asynchronous after the architectural changes are applied in #595, the order does not matter.