### PR TITLE
Logout doesn't work #624

### DIFF
--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -68,8 +68,8 @@ public class MenuControl extends MenuBar {
     }
 
     private Menu createPreferencesMenu() {
-    	Menu preferences = new Menu("Preferences");
-    	
+        Menu preferences = new Menu("Preferences");
+        
         MenuItem logout = new MenuItem("Logout");
         logout.setOnAction(e -> {
             logger.info("Logging out of HT");
@@ -79,8 +79,8 @@ public class MenuControl extends MenuBar {
         
         MenuItem quit = new MenuItem("Quit");
         quit.setOnAction(e -> {
-        	logger.info("Quitting HT");
-        	ui.quit();
+            logger.info("Quitting HT");
+            ui.quit();
         });
         
         preferences.getItems().addAll(logout, quit);

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -74,7 +74,6 @@ public class MenuControl extends MenuBar {
             logger.info("Logging out of HT");
             prefs.setLastLoginCredentials("", "");
             ui.quit();
-            ui.main(null);
         });
         return logout;
 

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -74,6 +74,7 @@ public class MenuControl extends MenuBar {
             logger.info("Logging out of HT");
 //          DataManager.getInstance().setLastLoginPassword("");
             ui.quit();
+            // Need to do: clear the login credentials and return to login window
         });
         return logout;
 

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -62,20 +62,30 @@ public class MenuControl extends MenuBar {
             createForceRefreshMenuItem(),
             createDocumentationMenuItem());
 
-        Menu preferences = new Menu("Preferences");
-        preferences.getItems().add(createPreferencesMenu());
+        Menu preferences = createPreferencesMenu();
 
         getMenus().addAll(newMenu, panels, boards, view, preferences);
     }
 
-    private MenuItem createPreferencesMenu() {
+    private Menu createPreferencesMenu() {
+    	Menu preferences = new Menu("Preferences");
+    	
         MenuItem logout = new MenuItem("Logout");
         logout.setOnAction(e -> {
             logger.info("Logging out of HT");
             prefs.setLastLoginCredentials("", "");
             ui.quit();
         });
-        return logout;
+        
+        MenuItem quit = new MenuItem("Quit");
+        quit.setOnAction(e -> {
+        	logger.info("Quitting HT");
+        	ui.quit();
+        });
+        
+        preferences.getItems().addAll(logout, quit);
+        
+        return preferences;
 
     }
 

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -72,7 +72,7 @@ public class MenuControl extends MenuBar {
         MenuItem logout = new MenuItem("Logout");
         logout.setOnAction(e -> {
             logger.info("Logging out of HT");
-//          DataManager.getInstance().setLastLoginPassword("");
+            prefs.setLastLoginCredentials("", "");
             ui.quit();
             // Need to do: clear the login credentials and return to login window
         });

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -74,7 +74,7 @@ public class MenuControl extends MenuBar {
             logger.info("Logging out of HT");
             prefs.setLastLoginCredentials("", "");
             ui.quit();
-            // Need to do: clear the login credentials and return to login window
+            ui.main(null);
         });
         return logout;
 

--- a/src/test/java/guitests/LogoutTest.java
+++ b/src/test/java/guitests/LogoutTest.java
@@ -21,7 +21,7 @@ public class LogoutTest extends UITest {
 
     @Override
     public void launchApp() {
-    FXTestUtils.launchApp(TestUI.class, "--testconfig=true");
+    	FXTestUtils.launchApp(TestUI.class, "--testconfig=true");
     }
 
     @Test
@@ -53,5 +53,4 @@ public class LogoutTest extends UITest {
         File testConfig = new File(configFileDirectory, testConfigFileName);
         if (testConfig.exists() && testConfig.isFile()) testConfig.delete();
     }
-
 }

--- a/src/test/java/guitests/LogoutTest.java
+++ b/src/test/java/guitests/LogoutTest.java
@@ -21,7 +21,7 @@ public class LogoutTest extends UITest {
 
     @Override
     public void launchApp() {
-    	FXTestUtils.launchApp(TestUI.class, "--testconfig=true");
+        FXTestUtils.launchApp(TestUI.class, "--testconfig=true");
     }
 
     @Test

--- a/src/test/java/guitests/LogoutTest.java
+++ b/src/test/java/guitests/LogoutTest.java
@@ -1,0 +1,57 @@
+package guitests;
+
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+
+import org.junit.After;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import prefs.Preferences;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class LogoutTest extends UITest {
+
+    String configFileDirectory = Preferences.DIRECTORY;
+    String testConfigFileName = Preferences.TEST_CONFIG_FILE;
+
+    @Override
+    public void launchApp() {
+    FXTestUtils.launchApp(TestUI.class, "--testconfig=true");
+    }
+
+    @Test
+    public void logoutFunctionTest() {
+        TextField repoOwnerField = find("#repoOwnerField");
+        doubleClick(repoOwnerField);
+        doubleClick(repoOwnerField);
+        type("dummy").push(KeyCode.TAB);
+        type("dummy").push(KeyCode.TAB);
+        type("test").push(KeyCode.TAB);
+        type("test");
+        click("Sign in");
+        sleep(2000);
+        
+        click("Preferences");
+        click("Logout");
+
+        // checking that the json file exists and the saved credentials have been emptied
+        File testConfig = new File(configFileDirectory, testConfigFileName);
+        if (!(testConfig.exists() && testConfig.isFile())) fail();
+
+        Preferences testPref = new Preferences(true);
+        assertEquals("", testPref.getLastLoginUsername());
+        assertEquals("", testPref.getLastLoginPassword());
+    }
+
+    @After
+    public void teardown() {
+        File testConfig = new File(configFileDirectory, testConfigFileName);
+        if (testConfig.exists() && testConfig.isFile()) testConfig.delete();
+    }
+
+}

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -69,7 +69,7 @@ public class UseGlobalConfigsTest extends UITest {
 
         // Then exit program...
         click("Preferences");
-        click("Logout");
+        click("Quit");
 
         // ...and check if the test JSON is still there...
         File testConfig = new File(configFileDirectory, testConfigFileName);

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -99,17 +99,6 @@ public class UseGlobalConfigsTest extends UITest {
         assertEquals("", dummyBoard.get(0));
         assertEquals("repo:dummy2/dummy2", dummyBoard.get(1));
     }
-    
-    @Test
-    public void testLogout() {
-        launchApp();
-        click("Preferences");
-        click("Logout");
-        
-        Preferences testPref = new Preferences(true);
-        assertEquals("", testPref.getLastLoginUsername());
-        assertEquals("", testPref.getLastLoginPassword());
-    }
 
     @After
     public void teardown() {

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -99,6 +99,17 @@ public class UseGlobalConfigsTest extends UITest {
         assertEquals("", dummyBoard.get(0));
         assertEquals("repo:dummy2/dummy2", dummyBoard.get(1));
     }
+    
+    @Test
+    public void testLogout() {
+        launchApp();
+        click("Preferences");
+        click("Logout");
+        
+        Preferences testPref = new Preferences(true);
+        assertEquals("", testPref.getLastLoginUsername());
+        assertEquals("", testPref.getLastLoginPassword());
+    }
 
     @After
     public void teardown() {


### PR DESCRIPTION
Fixes #624 

Fixed by invoking setLastLoginCredentials method in Preferences class to set saved credentials to empty strings. Re-running the jar after logging out will no longer cause automatic login.

I attempted to add another code to automatically bring back the login screen after logging out, but I think it can't be done without changing the accessibility of one or more of the methods in UI class, which I was wary of doing.