### PR TITLE
Fixed wrong hotkey assigned to create panel to left #656

### DIFF
--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -88,7 +88,7 @@ public class MenuControl extends MenuBar {
             columns.createNewPanelAtStart();
             setHvalue(columnsScrollPane.getHmin());
         });
-        createLeft.setAccelerator(new KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN,
+        createLeft.setAccelerator(new KeyCodeCombination(KeyCode.P, KeyCombination.CONTROL_DOWN,
                 KeyCombination.SHIFT_DOWN));
 
         MenuItem createRight = new MenuItem("Create");


### PR DESCRIPTION
Fixes #656

Key combination was set to Ctrl+Shift+N. Fixed to Ctrl+Shift+P.