### PR TITLE
 Re-enable or remove Force Refresh #670 

### DIFF
--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -59,7 +59,6 @@ public class MenuControl extends MenuBar {
         Menu view = new Menu("View");
         view.getItems().addAll(
             createRefreshMenuItem(),
-            createForceRefreshMenuItem(),
             createDocumentationMenuItem());
 
         Menu preferences = new Menu("Preferences");
@@ -248,45 +247,6 @@ public class MenuControl extends MenuBar {
         });
         refreshMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.F5));
         return refreshMenuItem;
-    }
-
-    private MenuItem createForceRefreshMenuItem() {
-        MenuItem forceRefreshMenuItem = new MenuItem("Force Refresh");
-        forceRefreshMenuItem.setOnAction((e) -> triggerForceRefreshProgressDialog());
-
-        forceRefreshMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.F5, KeyCombination.CONTROL_DOWN));
-        return forceRefreshMenuItem;
-    }
-
-    private void triggerForceRefreshProgressDialog() {
-        Task<Boolean> task = new Task<Boolean>() {
-            @Override
-            protected Boolean call() throws IOException {
-                try {
-                    logger.info("Menu: View > Force Refresh");
-
-                    updateProgress(0, 1);
-//                  updateMessage(String.format("Reloading %s...",
-//                      ServiceManager.getInstance().getRepoId().generateId()));
-
-                    // TODO
-//                  ServiceManager.getInstance().forceRefresh((message, progress) -> {
-//                      updateProgress(progress * 100, 100);
-//                      updateMessage(message);
-//                  });
-                    PlatformEx.runAndWait(columns::recreateColumns);
-                } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
-                    return false;
-                }
-                logger.info("Menu: View > Force Refresh completed");
-                return true;
-            }
-        };
-        DialogMessage.showProgressDialog(task, "Reloading repoistory...");
-        Thread thread = new Thread(task);
-        thread.setDaemon(true);
-        thread.start();
     }
 
     private MenuItem[] createNewMenuItems() {

--- a/src/test/java/guitests/MenuControlTest.java
+++ b/src/test/java/guitests/MenuControlTest.java
@@ -43,6 +43,5 @@ public class MenuControlTest extends UITest {
         click("View");
         click("Refresh");
         press(KeyCode.F5).release(KeyCode.F5);
-        click("View");
     }
 }

--- a/src/test/java/guitests/MenuControlTest.java
+++ b/src/test/java/guitests/MenuControlTest.java
@@ -44,7 +44,5 @@ public class MenuControlTest extends UITest {
         click("Refresh");
         press(KeyCode.F5).release(KeyCode.F5);
         click("View");
-        click("Force Refresh");
-        press(KeyCode.CONTROL).press(KeyCode.F5).release(KeyCode.F5).release(KeyCode.CONTROL);
     }
 }


### PR DESCRIPTION
Fixes #670 
Removed the menu item and trigger for force refresh, as well as a reference to said menu item on the menu. I believe these are all the codes related to force refresh.