### PR TITLE
When using the updated filter, every IssueSelectedEvent re-downloads the metadata #703

### DIFF
--- a/src/main/java/filter/expression/Qualifier.java
+++ b/src/main/java/filter/expression/Qualifier.java
@@ -366,13 +366,13 @@ public class Qualifier implements FilterExpression {
         }
     }
 
-    public Comparator<TurboIssue> getCompoundSortComparator(IModel model, boolean metadataRefresh) {
+    public Comparator<TurboIssue> getCompoundSortComparator(IModel model, boolean nonSelfSortable) {
         if (sortKeys.isEmpty()) {
             return (a, b) -> 0;
         }
         return (a, b) -> {
             for (SortKey key : sortKeys) {
-                Comparator<TurboIssue> comparator = getSortComparator(model, key.key, key.inverted, metadataRefresh);
+                Comparator<TurboIssue> comparator = getSortComparator(model, key.key, key.inverted, nonSelfSortable);
                 int result = comparator.compare(a, b);
                 if (result != 0) {
                     return result;
@@ -383,7 +383,9 @@ public class Qualifier implements FilterExpression {
     }
 
     public static Comparator<TurboIssue> getSortComparator(IModel model,
-                                                           String key, boolean inverted, boolean metadataRefresh) {
+                                                           String key,
+                                                           boolean inverted,
+                                                           boolean nonSelfSortable) {
         Comparator<TurboIssue> comparator = (a, b) -> 0;
 
         boolean isLabelGroup = false;
@@ -400,7 +402,7 @@ public class Qualifier implements FilterExpression {
                 comparator = (a, b) -> a.getUpdatedAt().compareTo(b.getUpdatedAt());
                 break;
             case "nonSelfUpdate":
-                if (metadataRefresh) {
+                if (nonSelfSortable) {
                     comparator = (a, b) ->
                         a.getMetadata().getNonSelfUpdatedAt().compareTo(b.getMetadata().getNonSelfUpdatedAt());
                 } else {

--- a/src/main/java/ui/issuepanel/IssuePanel.java
+++ b/src/main/java/ui/issuepanel/IssuePanel.java
@@ -144,8 +144,9 @@ public class IssuePanel extends IssueColumn {
             // (if it was there before)
             issueCommentCounts.put(issue.getId(), issue.getCommentCount());
             issueNonSelfCommentCounts.put(issue.getId(), issue.getMetadata().getNonSelfCommentCount());
-            // We don't need to get metadata here, so we pass false.
-            refreshItems(false);
+            // We assume we already have metadata, so we pass true to avoid refreshItems from trying to get
+            // metadata after clicking.
+            refreshItems(true);
         });
     }
 


### PR DESCRIPTION
Fixes #703