### PR TITLE
No error notification or recovery on corrupted repo JSON #700

### DIFF
--- a/src/main/java/backend/RepoIO.java
+++ b/src/main/java/backend/RepoIO.java
@@ -64,7 +64,7 @@ public class RepoIO {
                 .exceptionally(ex -> {
                     try {
                         return downloadRepositoryFromSource(repoId).get();
-                    } catch (ExecutionException|InterruptedException e) {
+                    } catch (ExecutionException | InterruptedException e) {
                         logger.info("Error while downloading " + repoId);
                         logger.error(e.getLocalizedMessage());
 

--- a/src/main/java/backend/json/ReadTask.java
+++ b/src/main/java/backend/json/ReadTask.java
@@ -34,7 +34,7 @@ class ReadTask extends StoreTask {
             Model model = load(repoId);
             response.complete(model);
         } catch (RepoStoreException e) {
-            logger.error(HTLog.format(repoId, "Failed to load from store"));
+            logger.error(HTLog.format(repoId, "Unable to load from store"));
             response.completeExceptionally(e);
         }
     }
@@ -53,7 +53,7 @@ class ReadTask extends StoreTask {
             logger.error("Unable to load " + repoId + " from JSON cache");
             throw new JSONLoadException();
         } else {
-            logger.info(HTLog.format(repoId, "Loaded from JSON cache"));
+            logger.info(HTLog.format(repoId, "Data loaded from JSON cache"));
 
             try {
                 SerializableModel sModel = new Gson().fromJson(input.get(),

--- a/src/main/java/backend/json/ReadTask.java
+++ b/src/main/java/backend/json/ReadTask.java
@@ -40,16 +40,17 @@ class ReadTask extends StoreTask {
     }
 
     /**
-     * Load repository data from RepoStore into a new Model.
+     * Loads repository data from RepoStore into a new Model.
      * @param repoId the string id of the repository to be loaded
      * @return a new Model containing data for the requested repository.
-     * @throws JSONLoadException
+     * @throws JSONLoadException when the repository's JSON data cannot be
+     *         retrieved from the local store or is corrupted
      */
     private Model load(String repoId) throws RepoStoreException {
         Optional<String> input = RepoStore.read(repoId);
 
         if (!input.isPresent()) {
-            logger.error("Unable to load " + repoId + " from JSON cache; defaulting to an empty Model");
+            logger.error("Unable to load " + repoId + " from JSON cache");
             throw new JSONLoadException();
         } else {
             logger.info(HTLog.format(repoId, "Loaded from JSON cache"));

--- a/src/main/java/util/exceptions/JSONLoadException.java
+++ b/src/main/java/util/exceptions/JSONLoadException.java
@@ -1,0 +1,7 @@
+package util.exceptions;
+
+public class JSONLoadException extends RepoStoreException {
+
+    private static final long serialVersionUID = -1065196203996159915L;
+
+}

--- a/src/main/java/util/exceptions/RepoStoreException.java
+++ b/src/main/java/util/exceptions/RepoStoreException.java
@@ -1,0 +1,7 @@
+package util.exceptions;
+
+public class RepoStoreException extends Exception {
+
+    private static final long serialVersionUID = -8776773905604880063L;
+
+}

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -1,19 +1,21 @@
 package guitests;
 
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
-import org.junit.After;
-import org.junit.Test;
-import org.loadui.testfx.utils.FXTestUtils;
-import prefs.Preferences;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+
+import org.junit.After;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import prefs.Preferences;
 
 public class UseGlobalConfigsTest extends UITest {
 
@@ -40,7 +42,7 @@ public class UseGlobalConfigsTest extends UITest {
         type("test").push(KeyCode.TAB);
         type("test");
         click("Sign in");
-        sleep(2000);
+        sleep(3000);
         ComboBox<String> repositorySelector = find("#repositorySelector");
         assertEquals(repositorySelector.getValue(), "dummy/dummy");
 
@@ -59,7 +61,7 @@ public class UseGlobalConfigsTest extends UITest {
         press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
         type("dummy2/dummy2");
         push(KeyCode.ENTER);
-        sleep(2000);
+        sleep(3000);
 
         // Make a new board
         click("Boards");

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -104,6 +104,12 @@ public class StoreTests {
         f.delete();
     }
 
+    @Test(expected = ExecutionException.class)
+    public void testNonExistedJSON() throws InterruptedException, ExecutionException {
+        JSONStore jsonStore = new JSONStore();
+        jsonStore.loadRepository("nonexist/nonexist").get();
+    }
+
     @Test
     public void testLoadCorruptedRepository() throws InterruptedException, ExecutionException {
         RepoStore.write("testrepo/testrepo", "abcde");
@@ -115,6 +121,14 @@ public class StoreTests {
 
         File f = new File("store/test/testrepo/testrepo");
         f.delete();
+    }
+
+    @Test
+    public void testLoadNonExistRepo() throws InterruptedException, ExecutionException {
+        RepoIO repoIO = new RepoIO(false, false);
+        Model model = repoIO.openRepository("nonexist/nonexist").get();
+
+        assertTrue(model.getIssues().isEmpty());
     }
 
     /**

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -1,6 +1,7 @@
 package tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -98,6 +99,19 @@ public class StoreTests {
 
         JSONStore jsonStore = new JSONStore();
         jsonStore.loadRepository("testrepo/testrepo").get();
+
+        File f = new File("store/test/testrepo/testrepo");
+        f.delete();
+    }
+
+    @Test
+    public void testLoadCorruptedRepository() throws InterruptedException, ExecutionException {
+        RepoStore.write("testrepo/testrepo", "abcde");
+
+        RepoIO repoIO = new RepoIO(false, false);
+        Model model = repoIO.openRepository("testrepo/testrepo").get();
+
+        assertTrue(model.getIssues().isEmpty());
 
         File f = new File("store/test/testrepo/testrepo");
         f.delete();

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -92,7 +92,7 @@ public class StoreTests {
         assertEquals(11, dummy2.getIssues().size());
     }
 
-    @Test(expected=ExecutionException.class)
+    @Test(expected = ExecutionException.class)
     public void testCorruptedJSON() throws InterruptedException, ExecutionException {
         RepoStore.write("testrepo/testrepo", "abcde");
 

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -124,7 +124,7 @@ public class StoreTests {
     }
 
     @Test
-    public void testLoadNonExistRepo() throws InterruptedException, ExecutionException {
+    public void testLoadNonExistedRepo() throws InterruptedException, ExecutionException {
         RepoIO repoIO = new RepoIO(false, false);
         Model model = repoIO.openRepository("nonexist/nonexist").get();
 

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -105,7 +105,7 @@ public class StoreTests {
     }
 
     @Test(expected = ExecutionException.class)
-    public void testNonExistedJSON() throws InterruptedException, ExecutionException {
+    public void testNonExistentJSON() throws InterruptedException, ExecutionException {
         JSONStore jsonStore = new JSONStore();
         jsonStore.loadRepository("nonexist/nonexist").get();
     }
@@ -124,7 +124,7 @@ public class StoreTests {
     }
 
     @Test
-    public void testLoadNonExistedRepo() throws InterruptedException, ExecutionException {
+    public void testLoadNonExistentRepo() throws InterruptedException, ExecutionException {
         RepoIO repoIO = new RepoIO(false, false);
         Model model = repoIO.openRepository("nonexist/nonexist").get();
 

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -10,12 +10,14 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import backend.RepoIO;
-import backend.resource.Model;
 import ui.UI;
 import ui.components.StatusUIStub;
 import util.events.EventDispatcherStub;
 import util.events.testevents.UpdateDummyRepoEvent;
+import backend.RepoIO;
+import backend.interfaces.RepoStore;
+import backend.json.JSONStore;
+import backend.resource.Model;
 
 public class StoreTests {
 
@@ -88,6 +90,17 @@ public class StoreTests {
         // But since we are indeed loading from the test JSON store, we would end up with 11 issues.
         Model dummy2 = alternateIO.openRepository("dummy1/dummy1").get();
         assertEquals(11, dummy2.getIssues().size());
+    }
+
+    @Test(expected=ExecutionException.class)
+    public void testCorruptedJSON() throws InterruptedException, ExecutionException {
+        RepoStore.write("testrepo/testrepo", "abcde");
+
+        JSONStore jsonStore = new JSONStore();
+        jsonStore.loadRepository("testrepo/testrepo").get();
+
+        File f = new File("store/test/testrepo/testrepo");
+        f.delete();
     }
 
     /**


### PR DESCRIPTION
Fixes #700 

This only resolves the case in which the JSON data is arbitrarily corrupted. If the file is changed but still syntactically correct and fit into a Model object (likely from deliberate manipulation), the program won't be able to detect the mismatch.

Lol, the coveralls thing is so demanding :P