### PR TITLE
Initialize label picker dialog's position

### DIFF
--- a/src/main/java/ui/components/pickers/LabelPicker.java
+++ b/src/main/java/ui/components/pickers/LabelPicker.java
@@ -31,12 +31,6 @@ public class LabelPicker {
         List<TurboLabel> allLabels = ui.logic.getRepo(issue.getRepoId()).getLabels();
         // create new LabelPickerDialog
         LabelPickerDialog labelPickerDialog = new LabelPickerDialog(issue, allLabels, stage);
-
-        // Needs this since dialog's size is not available before the blocking showAndWait
-        Platform.runLater(() -> {
-            labelPickerDialog.positionDialog(stage);
-        });
-
         // show LabelPickerDialog and wait for result
         Optional<List<String>> result = labelPickerDialog.showAndWait();
         stage.show(); // ensures stage is showing after label picker is closed (mostly for tests)

--- a/src/main/java/ui/components/pickers/LabelPicker.java
+++ b/src/main/java/ui/components/pickers/LabelPicker.java
@@ -31,6 +31,12 @@ public class LabelPicker {
         List<TurboLabel> allLabels = ui.logic.getRepo(issue.getRepoId()).getLabels();
         // create new LabelPickerDialog
         LabelPickerDialog labelPickerDialog = new LabelPickerDialog(issue, allLabels, stage);
+
+        // Needs this since dialog's size is not available before the blocking showAndWait
+        Platform.runLater(() -> {
+            labelPickerDialog.positionDialog(stage);
+        });
+
         // show LabelPickerDialog and wait for result
         Optional<List<String>> result = labelPickerDialog.showAndWait();
         stage.show(); // ensures stage is showing after label picker is closed (mostly for tests)

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -9,6 +9,7 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 import java.util.Collections;
@@ -132,6 +133,18 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         initModality(Modality.APPLICATION_MODAL); // TODO change to NONE for multiple dialogs
         setTitle("Edit Labels for " + (issue.isPullRequest() ? "PR #" : "Issue #") +
                 issue.getId() + " in " + issue.getRepoId());
+        positionDialog(stage);
+    }
+
+    private void positionDialog(Stage stage) {
+        double totalScreenWidth = Screen.getScreens().stream()
+                .mapToDouble(screen -> {
+                    return screen.getVisualBounds().getWidth();
+                }).sum();
+        double maxX = Math.max(0, totalScreenWidth - stage.getMinWidth());
+
+        setX(Math.min(maxX, stage.getX() + stage.getScene().getWidth()));
+        setY(stage.getY() + stage.getScene().getY());
     }
 
     private void createButtons() {

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -42,13 +42,21 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         textField = createTextField();
         bottomBox = createBottomBox();
 
-        setupKeyEvents();
+        setupEvents(stage);
         uiLogic = new LabelPickerUILogic(issue, repoLabels, this);
 
         vBox.getChildren().addAll(titleLabel, topPane, textField, bottomBox);
         getDialogPane().setContent(vBox);
 
         Platform.runLater(textField::requestFocus);
+    }
+
+    private void setupEvents(Stage stage) {
+        setupKeyEvents();
+
+        heightProperty().addListener(e -> {
+            positionDialog(stage);
+        });
     }
 
     private void setupKeyEvents() {
@@ -137,12 +145,13 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         initModality(Modality.APPLICATION_MODAL); // TODO change to NONE for multiple dialogs
         setTitle("Edit Labels for " + (issue.isPullRequest() ? "PR #" : "Issue #") +
                 issue.getId() + " in " + issue.getRepoId());
-        positionDialog(stage);
     }
 
     private void positionDialog(Stage stage) {
         setX(stage.getX() + stage.getScene().getX());
-        setY(stage.getY() + stage.getScene().getY());
+        setY(stage.getY() +
+             stage.getScene().getY() +
+             (stage.getScene().getHeight() - getHeight()) / 2);
     }
 
     private void createButtons() {

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -54,7 +54,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
     private void setupEvents(Stage stage) {
         setupKeyEvents();
 
-        heightProperty().addListener(e -> {
+        showingProperty().addListener(e -> {
             positionDialog(stage);
         });
     }
@@ -145,8 +145,6 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         initModality(Modality.APPLICATION_MODAL); // TODO change to NONE for multiple dialogs
         setTitle("Edit Labels for " + (issue.isPullRequest() ? "PR #" : "Issue #") +
                 issue.getId() + " in " + issue.getRepoId());
-        // MacOS may need this call here to position the dialog properly
-        positionDialog(stage);
     }
 
     public void positionDialog(Stage stage) {

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -147,7 +147,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
                 issue.getId() + " in " + issue.getRepoId());
     }
 
-    private void positionDialog(Stage stage) {
+    public void positionDialog(Stage stage) {
         setX(stage.getX() + stage.getScene().getX());
         setY(stage.getY() +
              stage.getScene().getY() +

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -145,13 +145,17 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         initModality(Modality.APPLICATION_MODAL); // TODO change to NONE for multiple dialogs
         setTitle("Edit Labels for " + (issue.isPullRequest() ? "PR #" : "Issue #") +
                 issue.getId() + " in " + issue.getRepoId());
+        // MacOS may need this call here to position the dialog properly
+        positionDialog(stage);
     }
 
     public void positionDialog(Stage stage) {
-        setX(stage.getX() + stage.getScene().getX());
-        setY(stage.getY() +
-             stage.getScene().getY() +
-             (stage.getScene().getHeight() - getHeight()) / 2);
+        if (!Double.isNaN(getHeight())) {
+            setX(stage.getX() + stage.getScene().getX());
+            setY(stage.getY() +
+                 stage.getScene().getY() +
+                 (stage.getScene().getHeight() - getHeight()) / 2);
+        }
     }
 
     private void createButtons() {

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -1,21 +1,25 @@
 package ui.components.pickers;
 
-import backend.resource.TurboIssue;
-import backend.resource.TurboLabel;
-import javafx.application.Platform;
-import javafx.geometry.Insets;
-import javafx.scene.control.*;
-import javafx.scene.input.KeyCode;
-import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.VBox;
-import javafx.stage.Modality;
-import javafx.stage.Screen;
-import javafx.stage.Stage;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import backend.resource.TurboIssue;
+import backend.resource.TurboLabel;
 
 public class LabelPickerDialog extends Dialog<List<String>> {
 
@@ -137,13 +141,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
     }
 
     private void positionDialog(Stage stage) {
-        double totalScreenWidth = Screen.getScreens().stream()
-                .mapToDouble(screen -> {
-                    return screen.getVisualBounds().getWidth();
-                }).sum();
-        double maxX = Math.max(0, totalScreenWidth - stage.getMinWidth());
-
-        setX(Math.min(maxX, stage.getX() + stage.getScene().getWidth()));
+        setX(stage.getX() + stage.getScene().getX());
         setY(stage.getY() + stage.getScene().getY());
     }
 


### PR DESCRIPTION
Fixes #814

Label picker's dialog is now positioned at the middle of the pView, aligning its left edge with pView's left edge.

![image](https://cloud.githubusercontent.com/assets/5065989/9149110/16a0152a-3dcc-11e5-94e1-1abd0aa41e8f.png)
