### PR TITLE
Documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+
+# Contributing
+
+Contributions are very welcome. The [developer guide](docs/developerGuide.md) contains all the information you need. Check out the [workflow](docs/workflow.md) and open a pull request!
+
+Happy contributing!

--- a/docs/codingConventions.md
+++ b/docs/codingConventions.md
@@ -1,0 +1,14 @@
+
+# Coding Conventions
+
+We use a coding standard derived from [TEAMMATES'](https://docs.google.com/document/pub?id=1iAESIXM0zSxEa5OY7dFURam_SgLiSMhPQtU0drQagrs&embedded=true), which is a customised variant of Google's.
+
+We've tweaked a few of the rules for our needs:
+
+- Conventions we don't follow: Google copyright notice, named TODOs
+- Import order matches Eclipse's default (no priority given to Google-specific package names)
+- Such `__METHOD_NAMES__` are allowed
+- Line length is increased to 120
+- `if` and `else` blocks don't need to have braces. This is useful for guard clauses and automatically-generated equals methods.
+
+These changes are documented in our [CheckStyle configuration](../config/checkstyle/checkstyle.xml).

--- a/docs/developerGuide.md
+++ b/docs/developerGuide.md
@@ -6,6 +6,7 @@ For contributors:
 - [Testing instructions](testing.md)
 - [Design](design.md)
 - [Decision rationales and guidelines](designRationalesAndGuidelines.md)
+- [Java coding conventions](codingConventions.md)
 
 For core team members:
 - [Creating a Release](creatingARelease.md)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,6 @@
+
+# Documentation
+
+All of HubTurbo's documentation is here.
+
+Start at the [user guide](userGuide.md), and hopefully progress to the [developer guide](developerGuide.md)!

--- a/docs/settingUpDevEnvironment.md
+++ b/docs/settingUpDevEnvironment.md
@@ -1,33 +1,26 @@
 # Development Environment
 
-## Tool stack
-
-- [**JDK**](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 1.8u40 or later
-- [**Eclipse** Luna](https://www.eclipse.org/downloads/) or later
+- [Oracle JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 1.8u40 or later
+- [Eclipse Luna](https://www.eclipse.org/downloads/) or later
     - For Eclipse, please install [Buildship Gradle Integration](http://marketplace.eclipse.org/content/buildship-gradle-integration)
     - (Alternative IDE) [IntelliJ IDEA 14](https://www.jetbrains.com/idea/) or later
-- [**Chrome**](http://www.google.com/chrome/) 43 or later
-- **log4j**
-- **controlsfx**
-- **Gson**
-- **Guava**
-- **JNA**
-- **Markdown4j**
-- **OpenJFX**
-- **eGit**
-- **PrettyTime**
-- **Selenium** : Used to instantiate and control a Browser window (for the Browser view)
-- **Junit**
-- **TestFx**
+- [Google Chrome](http://www.google.com/chrome/) 43 or later
 
-## Useful background knowledge
+## Tool Stack
+
+Most of HubTurbo is written in Java. [ControlsFX](http://fxexperience.com/controlsfx/) extends JavaFX with lots of useful components. [EGit](https://github.com/eclipse/egit-github) helps us interface with GitHub. We also make use of [PrettyTime](https://github.com/ocpsoft/prettytime/), [Guava](https://github.com/google/guava), [Gson](https://github.com/google/gson), and [log4j](http://logging.apache.org/log4j/2.x/) for essential tasks, and [JUnit](http://junit.org/) and [TestFx](https://github.com/TestFX/TestFX) for testing.
+
+We use a few platform-specific components: [Selenium](http://www.seleniumhq.org/) to instantiate and control a browser window, and [JNA](https://github.com/twall/jna) for Windows integration.
+
+## Useful Background Knowledge
 
 **Must have**: Basic Java programming skills, basic Git knowledge
 
 **Good to have** (you may not need these at the beginning, but be prepared to learn these along the way):
-- Java FX 
-- Java Threading 
-- Java 8 features: streams, lambda expressions
+
+- JavaFX
+- Java threading
+- Familiarity with Java 8 features: streams, lambda expressions
 
 ## Environment Setup
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,18 +18,40 @@ Most GUI Tests extend [`UITest`](../src/test/java/guitests/UITest.java) which in
 - Override `launchApp` to define your own program arguments for the test
 - Override `setupMethod` to add any pre-test configuration/setup before the stage is launched
 
-Ensure that anything that causes the UI to change is wrapped in a `Platform.runLater` (if not you will get a `not on FX thread` error). You may need to specify a delay (using `sleep(X)`) to ensure that the wrapped command has been executed before proceeding on to the next line. Alternatively you can consider using `PlatformEx.runAndWait`. 
+**Interacting with the `Stage`**
+
+Subclasses of the JavaFX [`Node`](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/Node.html) can be referenced via their id (similar to a HTML id attribute). A `Node`'s id is set using `setId("<id>")`, and it can then be selected using `find("#<id>")`, and interacted with using `click("#<id>")`.
+
+Follow the conventions for existing ids when assigning ids to new elements.
+
+**Concurrency**
+
+Any code that changes the UI from a thread other than the JavaFX Application Thread must be wrapped in `Platform.runLater` (see guidelines on [thread safety](designRationalesAndGuidelines.md#thread-safety), specifically the part on thread confinement).
+
+Note, however, that `Platform.runLater` does not provide any guarantees as to *when* your code actually executes. If you need another thread to wait until a UI operation is finished, use `PlatformEx.runAndWait`, or one of the synchronisation aids in [java.util.concurrent](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/package-summary.html), if `PlatformEx.runAndWait` isn't what you need. A latch or barrier should work in most cases.
+
+Do not use `Thread.sleep` to sequence the execution of threads with respect to each other. It is unreliable due to the semantics of `Platform.runLater` and can result in slow, brittle, and/or nondeterministic code as tests get more complex.
+
+In general, ensure as far as possible that tests are deterministic. Make all inputs to tests (such as global state) explicit.
+
+**Events**
 
 To test for events, you can create new events for the test in [`util.events.testevents`](../src/main/java/util/events/testevents), ensure that you also create the corresponding event handler. You can then test for event triggering using [`UI.events.registerEvent((EventHandler))`](../src/main/java/ui/UI.java). 
 
-When testing certain GUI components, if they are children of the JavaFX [`Node`](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/Node.html) class, they can be interacted directly within the test using their identifier. Make sure that the component's identifier has been set using `setId(<identifier>)` and then you can use `find(#<identifier>)` select it. Any method that uses identifiers can also be used such as `click(#<identifier>)`. 
-
-In order to interact with a text field within a pop-up/dialog window within the CI, the main stage must be hidden first. See [`LabelPickerTests`](../src/test/java/guitests/LabelPickerTests.java) for an example of this. 
-
 ## CI Quirks
 
-HubTurbo uses Travis as a CI and even the GUI Tests are run on it. This does expose a few unintended behaviours. If a build fails on the CI with certain errors from the GUI portion such as `NoNodesVisibleException` and so on, try restarting the build. If you do not have the proper permissions to restart the build, you can always try pushing another commit that does not change any functional code (e.g. refactor, write more comments, etc) to get the CI to run the build again. Alternatively, you can comment on the PR to signal to the dev team that the PR is ready to be reviewed. We will ascertain if the build fails due to the aforementioned quirks, and if yes restart the build on the CI until it is successful.
+HubTurbo runs GUI tests on Travis as well. As its testing environment may differ from your development environment, tests which pass on your end may fail on Travis. Do troubleshoot with the following points, and feel free to add on to the list if you encounter problems.
+
+- In order to interact with a text field within a pop-up/dialog window on the CI, the main stage must be hidden first. See [`LabelPickerTests`](../src/test/java/guitests/LabelPickerTests.java) for an example of this.
+- Builds may fail with JavaFX exceptions, such as `NoNodesVisibleException`. Try restarting the build in this case.
+
+**Restarting Builds**
+
+- If you do not have the proper permissions to restart the build, you can:
+    + Push an empty commit, i.e. `git commit --allow-empty -m "Trigger CI"` to get the build to trigger. Squash these later.
+    + Open and close the pull request. The downside is that this leaves traces on GitHub.
+- Alternatively, you can comment on the PR to signal to the dev team that the PR is ready to be reviewed. We will ascertain if the build failed due to the aforementioned quirks and/or nondeterminism, and if yes restart the CI build until it is successful.
 
 ## Unit Tests
 
-Unit tests are meant to extensively test the functionality of a HubTurbo component. In most cases, this should be done without the use of File I/O. When testing file I/O components, however, do remember to include code to clean up the project directory at the end of the test, such as through [`UITest.clearTestFolder`](../src/test/java/guitests/UITest.java).
+Unit tests are meant to extensively test the functionality of a HubTurbo component. In most cases, this should be done without the use of File I/O. When testing file I/O components, however, do remember to include code to clean up the project directory at the end of the test, such as through [`UITest.clearTestFolder()`](../src/test/java/guitests/UITest.java).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,8 +14,8 @@ First,
 Fixing issues:
 
 1. Select an issue to handle. For your first issue, select an issue labelled `difficulty.beginner`. Optionally, you may discuss the issue using the issue tracker to see if your intended solution is suitable. 
-2. Create a branch off the [`master`](https://github.com/HubTurbo/HubTurbo) branch. The branch should be named "IssueX", where `X` is the number of the issue. e.g. `Issue123`
-3. Implement your changes in the created branch. Run tests locally and ensure that there are no failures or style violations (use the `test` and `check` tasks in Gradle). 
+2. Create a branch off the current `master` named "X-short-description", where `X` is the issue number. For example, `2342-remove-println` for an issue named `Remove all unnecessary println statements`.
+3. Implement your changes in the created branch. Run tests locally and ensure that there are no failures or style violations (use the `test` and `check` tasks in Gradle).
 4. Push your changes to your fork.
 5. Create a pull request against the [`master`](https://github.com/HubTurbo/HubTurbo) branch of the main repo.
     - The name of the PR should be in the format "TITLE #X", where `TITLE` is the title of the issue you selected, and `X` is its number. e.g. `Sorting order is incorrect #123`


### PR DESCRIPTION
Fixes #852, fixes #830.

Made the tool stack section less tall by formatting it into a paragraph.

Added a simple coding conventions page, which should be further refined in #745, and a landing page for the docs folder.

A link to CONTRIBUTING.md will show up when creating an issue or PR.