### PR TITLE
Add separator for existing labels in label picker #875

### DIFF
--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -1,25 +1,20 @@
 package ui.components.pickers;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import backend.resource.TurboIssue;
+import backend.resource.TurboLabel;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.control.ButtonBar;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
-import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import backend.resource.TurboIssue;
-import backend.resource.TurboLabel;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class LabelPickerDialog extends Dialog<List<String>> {
 
@@ -81,20 +76,24 @@ public class LabelPickerDialog extends Dialog<List<String>> {
 
     private void ______POPULATION______() {}
 
-    protected void populatePanes(
-            List<PickerLabel> topLabels, List<PickerLabel> bottomLabels, Map<String, Boolean> groups) {
-        populateTopPane(topLabels);
+    protected void populatePanes(List<PickerLabel> existingLabels, List<PickerLabel> newTopLabels,
+            List<PickerLabel> bottomLabels, Map<String, Boolean> groups) {
+        populateTopPane(existingLabels, newTopLabels);
         populateBottomBox(bottomLabels, groups);
     }
 
-    private void populateTopPane(List<PickerLabel> topLabels) {
+    private void populateTopPane(List<PickerLabel> existingLabels, List<PickerLabel> newTopLabels) {
         topPane.getChildren().clear();
-        if (topLabels.size() == 0) {
+        if (existingLabels.size() == 0 && newTopLabels.size() == 0) {
             Label label = new Label("No currently selected labels. ");
             label.setPadding(new Insets(2, 5, 2, 5));
             topPane.getChildren().add(label);
         } else {
-            topLabels.forEach(label -> topPane.getChildren().add(label.getNode()));
+            existingLabels.forEach(label -> topPane.getChildren().add(label.getNode()));
+            if (newTopLabels.size() > 0) {
+                topPane.getChildren().add(new Label("|"));
+                newTopLabels.forEach(label -> topPane.getChildren().add(label.getNode()));
+            }
         }
     }
 

--- a/src/main/java/ui/components/pickers/LabelPickerUILogic.java
+++ b/src/main/java/ui/components/pickers/LabelPickerUILogic.java
@@ -349,7 +349,7 @@ public class LabelPickerUILogic {
                 .isPresent();
     }
 
-    public Optional<PickerLabel> getHighlightedLabelName() {
+    private Optional<PickerLabel> getHighlightedLabelName() {
         return bottomLabels.stream()
                 .filter(PickerLabel::isHighlighted)
                 .findAny();

--- a/src/main/java/ui/components/pickers/LabelPickerUILogic.java
+++ b/src/main/java/ui/components/pickers/LabelPickerUILogic.java
@@ -55,7 +55,7 @@ public class LabelPickerUILogic {
     }
 
     private void populatePanes() {
-        if (dialog != null) dialog.populatePanes(topLabels, bottomLabels, groups);
+        if (dialog != null) dialog.populatePanes(getExistingLabels(), getNewTopLabels(), bottomLabels, groups);
     }
 
     public void toggleLabel(String name) {
@@ -359,6 +359,18 @@ public class LabelPickerUILogic {
 
     public Map<String, Boolean> getResultList() {
         return resultList;
+    }
+
+    private List<PickerLabel> getExistingLabels() {
+        return topLabels.stream()
+                .filter(label -> issue.getLabels().contains(label.getActualName()))
+                .collect(Collectors.toList());
+    }
+
+    private List<PickerLabel> getNewTopLabels() {
+        return topLabels.stream()
+                .filter(label -> !issue.getLabels().contains(label.getActualName()))
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
Fixes #875

<img width="430" alt="edit_labels_for_issue__10_in_dummy_dummy" src="https://cloud.githubusercontent.com/assets/1589121/9356071/d6055438-46b0-11e5-9a3f-d73faac89829.png">
