### PR TITLE
Error messages on 'could not sync' and data corruption on empty repo #877

### DIFF
--- a/src/main/java/util/Utility.java
+++ b/src/main/java/util/Utility.java
@@ -85,7 +85,8 @@ public class Utility {
     private static boolean processFileGrowth(long sizeAfterWrite, int issueCount, String fileName) {
         // The average issue is about 0.75KB in size. If the total filesize is more than (2 * issueCount KB),
         // we consider the json to have exploded as the file is unusually large.
-        if (sizeAfterWrite > ((long) issueCount * 2000)) {
+        if ((issueCount > 0) &&
+                (sizeAfterWrite > ((long) issueCount * 2000))) {
             UI.events.triggerEvent(new ShowErrorDialogEvent("Possible data corruption detected",
                     fileName + " is unusually large.\n\n"
                             + "Now proceeding to delete the file and redownload the repository to prevent "

--- a/src/test/java/tests/ErrorJsonTests.java
+++ b/src/test/java/tests/ErrorJsonTests.java
@@ -2,6 +2,7 @@ package tests;
 
 import backend.interfaces.RepoStore;
 import guitests.UITest;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,7 +36,8 @@ public class ErrorJsonTests {
     public void testJsonExplosionDetection() throws ExecutionException, InterruptedException {
         // Expect 0KB file is issueCount is 0. A non-empty file will fail this check.
         UI.events.registerEvent((ShowErrorDialogEventHandler) e -> eventCount++);
-        boolean corruptedJson = Utility.writeFile("store/test/dummy1-dummy1.json", "abcde", 0);
+        String largeDummy2Kb = StringUtils.leftPad("foobar", 2100, '*');
+        boolean corruptedJson = Utility.writeFile("store/test/dummy1-dummy1.json", largeDummy2Kb, 1);
         assertEquals(true, corruptedJson);
         assertEquals(1, eventCount);
 


### PR DESCRIPTION
Fixes #877 - false error when repo has no issue