### PR TITLE
User can undo a change to the label #870

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,14 +35,13 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
-        maven {
-            url "https://repo.eclipse.org/content/repositories/egit-releases/"
-        }
+        maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     project.ext {
         log4jVersion = '2.3'
-        controlsfxVersion = '8.40.9'
+        controlsfxVersion = '8.40.10-SNAPSHOT'
         gsonVersion = '2.3.1'
         guavaVersion = '18.0'
         jnaVersion = '4.1.0'

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -4,14 +4,13 @@ import backend.Logic;
 import backend.UIManager;
 import browserview.BrowserComponent;
 import browserview.BrowserComponentStub;
-
 import com.google.common.eventbus.EventBus;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef.HWND;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
@@ -24,10 +23,10 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.controlsfx.control.NotificationPane;
+import org.controlsfx.control.action.Action;
 import prefs.Preferences;
 import ui.components.HTStatusBar;
 import ui.components.KeyboardShortcuts;
@@ -62,6 +61,7 @@ public class UI extends Application implements EventDispatcher {
     private static HWND mainWindowHandle;
 
     private static final int REFRESH_PERIOD = 60;
+    private static final int NOTIFICATION_PANE_VISIBLE_PERIOD = 5;
 
     // Application-level state
 
@@ -73,6 +73,7 @@ public class UI extends Application implements EventDispatcher {
     public EventBus eventBus;
     private HashMap<String, String> commandLineArgs;
     private TickingTimer refreshTimer;
+    private TickingTimer notificationPaneTimer;
     public GUIController guiController;
 
     // Main UI elements
@@ -84,6 +85,7 @@ public class UI extends Application implements EventDispatcher {
     private RepositorySelector repoSelector;
     private LabelPicker labelPicker;
     private Label apiBox;
+    private NotificationPane notificationPane;
 
     public static void main(String[] args) {
         Application.launch(args);
@@ -203,6 +205,9 @@ public class UI extends Application implements EventDispatcher {
         refreshTimer = new TickingTimer("Refresh Timer", REFRESH_PERIOD,
             status::updateTimeToRefresh, logic::refresh, TimeUnit.SECONDS);
         refreshTimer.start();
+        notificationPaneTimer = new TickingTimer("Notification Pane Timer", NOTIFICATION_PANE_VISIBLE_PERIOD,
+                integer -> {}, this::hideNotificationPane, TimeUnit.SECONDS);
+        notificationPaneTimer.start();
     }
 
     private void initUI(Stage stage) {
@@ -215,7 +220,7 @@ public class UI extends Application implements EventDispatcher {
         panels = new PanelControl(this, prefs);
         guiController = new GUIController(this, panels, apiBox);
 
-        Scene scene = new Scene(createRoot());
+        Scene scene = new Scene(createRootNode());
         setupMainStage(scene);
 
         loadFonts();
@@ -340,7 +345,7 @@ public class UI extends Application implements EventDispatcher {
         return new HashMap<>(params.getNamed());
     }
 
-    private Parent createRoot() {
+    private Parent createRootNode() {
 
         VBox top = new VBox();
 
@@ -366,7 +371,9 @@ public class UI extends Application implements EventDispatcher {
         root.setCenter(panelsScrollPane);
         root.setBottom((HTStatusBar) status);
 
-        return root;
+        notificationPane = new NotificationPane(root);
+
+        return notificationPane;
     }
 
     /**
@@ -542,6 +549,30 @@ public class UI extends Application implements EventDispatcher {
 
     public HWND getMainWindowHandle() {
         return mainWindowHandle;
+    }
+
+    public void showNotificationPane(Node graphic, String text, Action action) {
+        hideNotificationPane();
+        Platform.runLater(() -> {
+            notificationPane.setGraphic(graphic);
+            notificationPane.setText(text);
+            notificationPane.getActions().clear();
+            notificationPane.getActions().add(action);
+            notificationPane.show();
+            notificationPaneTimer.restart();
+            if (notificationPaneTimer.isPaused()) {
+                notificationPaneTimer.resume();
+            }
+        });
+    }
+
+    public void hideNotificationPane() {
+        Platform.runLater(() -> {
+            if (notificationPane.isShowing()) {
+                notificationPaneTimer.pause();
+                notificationPane.hide();
+            }
+        });
     }
 
 }

--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -65,6 +65,8 @@ public class KeyboardShortcuts {
             new KeyCodeCombination(KeyCode.D, KeyCombination.CONTROL_DOWN);
     public static final KeyCombination SWITCH_DEFAULT_REPO =
             new KeyCodeCombination(KeyCode.R, KeyCombination.CONTROL_DOWN);
+    public static final KeyCombination UNDO_LABEL_CHANGES =
+                new KeyCodeCombination(KeyCode.Z, KeyCombination.CONTROL_DOWN);
 
     public static final KeyCode FIRST_ISSUE = KeyCode.HOME;
     public static final KeyCode LAST_ISSUE = KeyCode.END;

--- a/src/main/java/ui/components/pickers/LabelPicker.java
+++ b/src/main/java/ui/components/pickers/LabelPicker.java
@@ -3,7 +3,13 @@ package ui.components.pickers;
 import backend.resource.TurboIssue;
 import backend.resource.TurboLabel;
 import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;
+import org.controlsfx.control.action.Action;
 import ui.UI;
 import util.DialogMessage;
 import util.GitHubURL;
@@ -11,8 +17,11 @@ import util.events.ShowLabelPickerEventHandler;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class LabelPicker {
+
+    private static final String OCTICON_INFO = "\uf059";
 
     private UI ui;
     private Stage stage;
@@ -29,6 +38,8 @@ public class LabelPicker {
     private void showLabelPicker(TurboIssue issue) {
         // get all labels from issue's repo
         List<TurboLabel> allLabels = ui.logic.getRepo(issue.getRepoId()).getLabels();
+        // get original labels for undo
+        List<String> originalLabels = issue.getLabels();
         // create new LabelPickerDialog
         LabelPickerDialog labelPickerDialog = new LabelPickerDialog(issue, allLabels, stage);
         // show LabelPickerDialog and wait for result
@@ -36,33 +47,49 @@ public class LabelPicker {
         stage.show(); // ensures stage is showing after label picker is closed (mostly for tests)
         // if result is present (user did not cancel) then replace issue labels with result
         if (result.isPresent()) {
-            ui.logic.replaceIssueLabels(issue, result.get())
-                    .thenApply(success -> postReplaceLabelActions(success, issue));
+            ui.logic.replaceIssueLabels(issue, result.get().stream().sorted().collect(Collectors.toList()))
+                    .thenApply(success -> postReplaceLabelActions(success, issue, originalLabels));
         }
     }
 
-    public boolean postReplaceLabelActions(Boolean success, TurboIssue issue) {
+    public boolean postReplaceLabelActions(Boolean success, TurboIssue issue, List<String> originalLabels) {
         if (success) {
-            // if label replacement is successful, force refresh issue page only if already on that issue page
-            if (ui.getBrowserComponent().getCurrentUrl().startsWith(
-                    GitHubURL.getPathForPullRequest(issue.getRepoId(), issue.getId())) ||
-                    ui.getBrowserComponent().getCurrentUrl().startsWith(
-                            GitHubURL.getPathForIssue(issue.getRepoId(), issue.getId()))) {
-                ui.getBrowserComponent().showIssue(issue.getRepoId(), issue.getId(), issue.isPullRequest(), true);
-            }
+            refreshIssuePage(issue);
+            ui.showNotificationPane(createInfoOcticon(),
+                    "Undo label change(s) for #" + issue.getId() + ": " + issue.getTitle(),
+                    new Action("Undo", actionEvent ->
+                            ui.logic.replaceIssueLabels(issue, originalLabels)
+                                    .thenRun(() -> {
+                                        refreshIssuePage(issue);
+                                        Platform.runLater(ui::hideNotificationPane);
+                                    })));
         } else {
             // if not, show error dialog
             Platform.runLater(() -> DialogMessage.showErrorDialog(
-                "GitHub Write Error",
-                String.format(
-                    "An error occurred while attempting to apply labels to:\n\n%s\n\n"
-                            + "Please check if you have write permissions to %s.",
-                    issue,
-                    issue.getRepoId()
-                )
+                    "GitHub Write Error",
+                    String.format(
+                            "An error occurred while attempting to apply labels to:\n\n%s\n\n"
+                                    + "Please check if you have write permissions to %s.",
+                            issue,
+                            issue.getRepoId()
+                    )
             ));
         }
         return success;
+    }
+
+    private void refreshIssuePage(TurboIssue issue) {
+        // if label replacement is successful, force refresh issue page only if already on that issue page
+        if (GitHubURL.isOnSpecificIssuePage(issue, ui.getBrowserComponent().getCurrentUrl())) {
+            ui.getBrowserComponent().showIssue(issue.getRepoId(), issue.getId(), issue.isPullRequest(), true);
+        }
+    }
+
+    private Label createInfoOcticon() {
+        Label label = new Label(OCTICON_INFO);
+        label.setPadding(new Insets(0, 0, 5, 0));
+        label.getStyleClass().addAll("octicon");
+        return label;
     }
 
 }

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -258,6 +258,9 @@ public class ListPanel extends FilterPanel {
             if (KeyboardShortcuts.SWITCH_DEFAULT_REPO.match(event)) {
                 ui.switchDefaultRepo();
             }
+            if (KeyboardShortcuts.UNDO_LABEL_CHANGES.match(event)) {
+                ui.triggerNotificationPaneAction();
+            }
         });
     }
 

--- a/src/main/java/util/GitHubURL.java
+++ b/src/main/java/util/GitHubURL.java
@@ -1,5 +1,7 @@
 package util;
 
+import backend.resource.TurboIssue;
+
 public class GitHubURL {
 
     public static final String LOGIN_PAGE = "https://github.com/login";
@@ -51,4 +53,10 @@ public class GitHubURL {
     public static boolean isPullRequestLoaded(String url)  {
         return (url.endsWith("/commits") || url.endsWith("/files"));
     }
+
+    public static boolean isOnSpecificIssuePage(TurboIssue issue, String url) {
+        return url.startsWith(getPathForPullRequest(issue.getRepoId(), issue.getId())) ||
+                url.startsWith(getPathForIssue(issue.getRepoId(), issue.getId()));
+    }
+
 }

--- a/src/test/java/guitests/LabelPickerTests.java
+++ b/src/test/java/guitests/LabelPickerTests.java
@@ -13,8 +13,7 @@ import static org.junit.Assert.assertEquals;
 
 public class LabelPickerTests extends UITest {
 
-    private static final int DIALOG_DELAY = 1500;
-    public static final int EVENT_DELAY = 1000;
+    private static final int EVENT_DELAY = 1000;
 
     @Test
     public void showLabelPickerTest() {
@@ -30,7 +29,7 @@ public class LabelPickerTests extends UITest {
 
         Platform.runLater(stage::hide);
         UI.events.triggerEvent(new ShowLabelPickerEvent(listPanelCell.getIssue()));
-        sleep(DIALOG_DELAY);
+        sleep(EVENT_DELAY);
 
         TextField labelPickerTextField = find("#labelPickerTextField");
         click(labelPickerTextField);
@@ -48,8 +47,10 @@ public class LabelPickerTests extends UITest {
 
         Platform.runLater(stage::hide);
         UI.events.triggerEvent(new ShowLabelPickerEvent(listPanelCell.getIssue()));
-        sleep(DIALOG_DELAY);
+        sleep(EVENT_DELAY);
 
+        TextField labelPickerTextField = find("#labelPickerTextField");
+        click(labelPickerTextField);
         type("2 ");
         push(KeyCode.ENTER);
         sleep(EVENT_DELAY);
@@ -57,10 +58,49 @@ public class LabelPickerTests extends UITest {
 
         Platform.runLater(stage::hide);
         UI.events.triggerEvent(new ShowLabelPickerEvent(listPanelCell.getIssue()));
-        sleep(DIALOG_DELAY);
+        sleep(EVENT_DELAY);
 
+        labelPickerTextField = find("#labelPickerTextField");
+        click(labelPickerTextField);
         type("2 ");
         push(KeyCode.ENTER);
+        sleep(EVENT_DELAY);
+        assertEquals(1, listPanelCell.getIssueLabels().size());
+    }
+
+    @Test
+    public void undoLabelChangeTest() {
+        ListPanelCell listPanelCell = find("#dummy/dummy_col0_9");
+        assertEquals(1, listPanelCell.getIssueLabels().size());
+
+        Platform.runLater(stage::hide);
+        UI.events.triggerEvent(new ShowLabelPickerEvent(listPanelCell.getIssue()));
+        sleep(EVENT_DELAY);
+
+        TextField labelPickerTextField = find("#labelPickerTextField");
+        click(labelPickerTextField);
+        type("2 ");
+        push(KeyCode.ENTER);
+        sleep(EVENT_DELAY);
+        assertEquals(0, listPanelCell.getIssueLabels().size());
+
+        click("Undo");
+        sleep(EVENT_DELAY);
+        assertEquals(1, listPanelCell.getIssueLabels().size());
+
+        Platform.runLater(stage::hide);
+        UI.events.triggerEvent(new ShowLabelPickerEvent(listPanelCell.getIssue()));
+        sleep(EVENT_DELAY);
+
+        labelPickerTextField = find("#labelPickerTextField");
+        click(labelPickerTextField);
+        type("2 ");
+        push(KeyCode.ENTER);
+        sleep(EVENT_DELAY);
+        assertEquals(0, listPanelCell.getIssueLabels().size());
+
+        click("#dummy/dummy_col0_9");
+        press(KeyCode.CONTROL).press(KeyCode.Z).release(KeyCode.Z).release(KeyCode.CONTROL);
         sleep(EVENT_DELAY);
         assertEquals(1, listPanelCell.getIssueLabels().size());
     }


### PR DESCRIPTION
Fixes #870

![undo](https://cloud.githubusercontent.com/assets/1589121/9494009/24ce72ae-4c36-11e5-9e25-20dd788a7f6b.gif)

Changes are pushed to GitHub immediately, notification pane auto-hides after 5 seconds, undo-ing changes pushes the original labels to GitHub. 