### PR TITLE
Ensure that globalConfigTest passes #920

### DIFF
--- a/src/test/java/guitests/PlatformExTest.java
+++ b/src/test/java/guitests/PlatformExTest.java
@@ -1,0 +1,66 @@
+package guitests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import javafx.application.Platform;
+import util.PlatformEx;
+
+public class PlatformExTest extends UITest {
+
+    @Override
+    public void launchApp() {
+        FXTestUtils.launchApp(TestUI.class);
+    }
+
+    /**
+     * This method is needed to sequence concurrent tests. Order matters for these
+     * as they rely on Platform.runLater, so we can't let them run in arbitrary order.
+     */
+    @Test
+    public void sequenceTests() {
+        waitOnFxThreadTest();
+        runLaterAndWaitTest();
+    }
+
+    public void waitOnFxThreadTest() {
+        AtomicInteger result = new AtomicInteger(0);
+        Platform.runLater(result::incrementAndGet);
+        assertEquals(0, result.get());
+        PlatformEx.waitOnFxThread();
+        assertEquals(1, result.get());
+    }
+
+    public void runLaterAndWaitTest() {
+        // On another thread, runLaterAndWait blocks until the operation is done
+        AtomicInteger result = new AtomicInteger(0);
+        PlatformEx.runLaterAndWait(result::incrementAndGet);
+        assertEquals(1, result.get());
+
+        // On the UI thread, the callback doesn't happen immediately
+        Platform.runLater(() -> {
+            assertEquals(1, result.get());
+            PlatformEx.runLaterAndWait(result::incrementAndGet);
+            assertEquals(1, result.get());
+        });
+    }
+
+    @Test
+    public void runAndWaitTest() {
+        // On another thread, runAndWait blocks until the operation is done
+        AtomicInteger result = new AtomicInteger(0);
+        PlatformEx.runAndWait(result::incrementAndGet);
+        assertEquals(1, result.get());
+
+        // On the UI thread, the callback is invoked immediately
+        Platform.runLater(() -> {
+            assertEquals(1, result.get());
+            PlatformEx.runAndWait(result::incrementAndGet);
+            assertEquals(2, result.get());
+        });
+    }
+}

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -2,13 +2,19 @@ package guitests;
 
 import backend.interfaces.RepoStore;
 import com.google.common.util.concurrent.SettableFuture;
+
+import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.control.ComboBoxBase;
 import javafx.stage.Stage;
 import org.junit.Before;
 import org.loadui.testfx.GuiTest;
+import org.loadui.testfx.exceptions.NoNodesFoundException;
+import org.loadui.testfx.exceptions.NoNodesVisibleException;
 import org.loadui.testfx.utils.FXTestUtils;
 import prefs.Preferences;
 import ui.UI;
+import util.PlatformEx;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,5 +90,44 @@ public class UITest extends GuiTest {
     @Override
     protected Parent getRootNode() {
         return stage.getScene().getRoot();
+    }
+
+    public void waitUntilNodeAppears(Node node) {
+        waitUntil(node, Node::isVisible);
+    }
+
+    public void waitUntilNodeDisappears(Node node) {
+        waitUntil(node, n -> !n.isVisible());
+    }
+
+    public void waitUntilNodeAppears(String selector) {
+        while (!existsQuiet(selector)) {
+            PlatformEx.waitOnFxThread();
+            sleep(100);
+        }
+    }
+
+    public void waitUntilNodeDisappears(String selector) {
+        while (existsQuiet(selector)) {
+            PlatformEx.waitOnFxThread();
+            sleep(100);
+        }
+    }
+
+    public <T extends Node> T findOrWaitFor(String selector) {
+        waitUntilNodeAppears(selector);
+        return find(selector);
+    }
+
+    private boolean existsQuiet(String selector) {
+        try {
+            return exists(selector);
+        } catch (NoNodesFoundException | NoNodesVisibleException e) {
+            return false;
+        }
+    }
+
+    public <T> void waitForValue(ComboBoxBase<T> comboBoxBase) {
+        waitUntil(comboBoxBase, c -> c.getValue() != null);
     }
 }

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -7,16 +7,15 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
-
 import org.eclipse.egit.github.core.RepositoryId;
 import org.junit.Test;
 import org.loadui.testfx.utils.FXTestUtils;
 
-import prefs.Preferences;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import prefs.PanelInfo;
+import prefs.Preferences;
 import ui.UI;
 import ui.components.FilterTextField;
 import ui.components.PanelNameTextField;
@@ -42,9 +41,9 @@ public class UseGlobalConfigsTest extends UITest {
         type("test").push(KeyCode.TAB);
         type("test");
         click("Sign in");
-        sleep(8000);
-        ComboBox<String> repositorySelector = find("#repositorySelector");
-        assertEquals(repositorySelector.getValue(), "dummy/dummy");
+        ComboBox<String> repositorySelector = findOrWaitFor("#repositorySelector");
+        waitForValue(repositorySelector);
+        assertEquals("dummy/dummy", repositorySelector.getValue());
         
         press(KeyCode.CONTROL).press(KeyCode.X).release(KeyCode.X).release(KeyCode.CONTROL);
 
@@ -64,7 +63,7 @@ public class UseGlobalConfigsTest extends UITest {
 
         // Load dummy2/dummy2 too
         press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
-        sleep(2000);
+        waitUntilNodeAppears("#dummy/dummy_col1_filterTextField");
         click("#dummy/dummy_col1_filterTextField");
         type("repo");
         press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
@@ -94,8 +93,6 @@ public class UseGlobalConfigsTest extends UITest {
         PanelNameTextField renameTextField3 = find("#dummy/dummy_col0_renameTextField");
         assertEquals("Open issues", renameTextField3.getText());
         push(KeyCode.ENTER);
-        
-        sleep(8000);
 
         // Make a new board
         click("Boards");


### PR DESCRIPTION
Fixes #920.

This needs opinions on the names of utility methods and where to put them. This is just a start; eventually we can use these new APIs in other tests.