### PR TITLE
 Add keyboard shortcut for changing the board #919 

### DIFF
--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -25,6 +25,7 @@
         <Or>
             <Field name="events" />
             <Field name="status" />
+            <Field name="prefs" />
         </Or>
         <Bug pattern="MS_CANNOT_BE_FINAL" />
     </Match>

--- a/src/main/java/prefs/GlobalConfig.java
+++ b/src/main/java/prefs/GlobalConfig.java
@@ -30,7 +30,7 @@ public class GlobalConfig {
     private String lastLoginUsername = "";
     private byte[] lastLoginPassword = new byte[0];
     private Optional<String> lastOpenBoard = Optional.empty();
-    private Map<String, List<PanelInfo>> savedBoards = new HashMap<>();
+    private Map<String, List<PanelInfo>> savedBoards = new LinkedHashMap<>();
     private Map<String, Map<Integer, LocalDateTime>> markedReadTimes = new HashMap<>();
     private Map<String, String> keyboardShortcuts = new HashMap<>();
 

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -3,6 +3,7 @@ package prefs;
 import org.eclipse.egit.github.core.RepositoryId;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -93,6 +94,18 @@ public class Preferences {
     
     public Optional<String> getLastOpenBoard() {
         return global.getLastOpenBoard();
+    }
+    
+    public Optional<String> switchBoard() {
+        if (getLastOpenBoard().isPresent() && getAllBoards().size() > 1) {
+            List<String> boardNames = new ArrayList<>(getAllBoards().keySet());
+            int lastBoard = boardNames.indexOf(getLastOpenBoard().get());
+            int index = (lastBoard + 1) % boardNames.size();
+            
+            setLastOpenBoard(boardNames.get(index));
+        }
+        
+        return getLastOpenBoard();
     }
     
     public void clearLastOpenBoard() {

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -17,6 +17,7 @@ import ui.issuepanel.FilterPanel;
 import ui.issuepanel.PanelControl;
 import util.events.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -270,6 +271,20 @@ public class MenuControl extends MenuBar {
                 return Stream.of();
             }
         }).collect(Collectors.toList());
+    }
+    
+    public void switchBoard() {
+        if (prefs.getLastOpenBoard().isPresent()) {
+            List<String> boardNames = new ArrayList<>(prefs.getAllBoards().keySet());
+            int index = boardNames.indexOf(prefs.getLastOpenBoard().get());
+            if (index == boardNames.size()-1) {
+                index = 0;
+            } else {
+                index++;
+            }
+            
+            onBoardOpen(boardNames.get(index), prefs.getBoardPanels(boardNames.get(index)));
+        }
     }
 
     private MenuItem createDocumentationMenuItem() {

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -17,7 +17,6 @@ import ui.issuepanel.FilterPanel;
 import ui.issuepanel.PanelControl;
 import util.events.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -274,12 +273,9 @@ public class MenuControl extends MenuBar {
     }
     
     public void switchBoard() {
-        if (prefs.getLastOpenBoard().isPresent() && prefs.getAllBoards().size() > 1) {
-            List<String> boardNames = new ArrayList<>(prefs.getAllBoards().keySet());
-            int lastBoard = boardNames.indexOf(prefs.getLastOpenBoard().get());
-            int index = (lastBoard + 1) % boardNames.size();
-            
-            onBoardOpen(boardNames.get(index), prefs.getBoardPanels(boardNames.get(index)));
+        Optional<String> name = prefs.switchBoard();
+        if (name.isPresent()) {
+            onBoardOpen(name.get(), prefs.getBoardPanels(name.get()));
         }
     }
 

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -274,10 +274,10 @@ public class MenuControl extends MenuBar {
     }
     
     public void switchBoard() {
-        if (prefs.getLastOpenBoard().isPresent()) {
+        if (prefs.getLastOpenBoard().isPresent() && prefs.getAllBoards().size() > 1) {
             List<String> boardNames = new ArrayList<>(prefs.getAllBoards().keySet());
             int index = boardNames.indexOf(prefs.getLastOpenBoard().get());
-            if (index == boardNames.size()-1) {
+            if (index == boardNames.size() - 1) {
                 index = 0;
             } else {
                 index++;

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -276,12 +276,8 @@ public class MenuControl extends MenuBar {
     public void switchBoard() {
         if (prefs.getLastOpenBoard().isPresent() && prefs.getAllBoards().size() > 1) {
             List<String> boardNames = new ArrayList<>(prefs.getAllBoards().keySet());
-            int index = boardNames.indexOf(prefs.getLastOpenBoard().get());
-            if (index == boardNames.size() - 1) {
-                index = 0;
-            } else {
-                index++;
-            }
+            int lastBoard = boardNames.indexOf(prefs.getLastOpenBoard().get());
+            int index = (lastBoard + 1) % boardNames.size();
             
             onBoardOpen(boardNames.get(index), prefs.getBoardPanels(boardNames.get(index)));
         }

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -68,7 +68,7 @@ public class UI extends Application implements EventDispatcher {
 
     public UIManager uiManager;
     public Logic logic;
-    public Preferences prefs;
+    public static Preferences prefs;
     public static StatusUI status;
     public static EventDispatcher events;
     public EventBus eventBus;

--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -65,6 +65,8 @@ public class KeyboardShortcuts {
             new KeyCodeCombination(KeyCode.D, KeyCombination.CONTROL_DOWN);
     public static final KeyCodeCombination SWITCH_DEFAULT_REPO =
             new KeyCodeCombination(KeyCode.R, KeyCombination.CONTROL_DOWN);
+    public static final KeyCodeCombination SWITCH_BOARD = 
+            new KeyCodeCombination(KeyCode.B, KeyCombination.CONTROL_DOWN);
     public static final KeyCombination UNDO_LABEL_CHANGES =
                 new KeyCodeCombination(KeyCode.Z, KeyCombination.CONTROL_DOWN);
 

--- a/src/main/java/ui/issuepanel/PanelControl.java
+++ b/src/main/java/ui/issuepanel/PanelControl.java
@@ -273,4 +273,8 @@ public class PanelControl extends HBox {
     public int getNumberOfSavedBoards() {
         return prefs.getAllBoards().size();
     }
+    
+    public Preferences getPreferences() {
+        return prefs;
+    }
 }

--- a/src/main/java/ui/issuepanel/PanelControl.java
+++ b/src/main/java/ui/issuepanel/PanelControl.java
@@ -273,8 +273,4 @@ public class PanelControl extends HBox {
     public int getNumberOfSavedBoards() {
         return prefs.getAllBoards().size();
     }
-    
-    public Preferences getPreferences() {
-        return prefs;
-    }
 }

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -263,6 +263,9 @@ public class ListPanel extends FilterPanel {
             if (KeyboardShortcuts.DEFAULT_SIZE_WINDOW.match(event)) {
                 ui.setDefaultWidth();
             }
+            if (KeyboardShortcuts.SWITCH_BOARD.match(event)) {
+                ui.getMenuControl().switchBoard();
+            }
             if (KeyboardShortcuts.SWITCH_DEFAULT_REPO.match(event)) {
                 ui.switchDefaultRepo();
             }

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -167,6 +167,9 @@ public class ListPanel extends FilterPanel {
             if (KeyboardShortcuts.SWITCH_DEFAULT_REPO.match(event)) {
                 ui.switchDefaultRepo();
             }
+            if (KeyboardShortcuts.SWITCH_BOARD.match(event)) {
+                ui.getMenuControl().switchBoard();
+            }
         });
 
         addEventHandler(KeyEvent.KEY_RELEASED, event -> {

--- a/src/test/java/guitests/MenuControlTest.java
+++ b/src/test/java/guitests/MenuControlTest.java
@@ -9,6 +9,7 @@ import ui.UI;
 import ui.components.KeyboardShortcuts;
 import ui.issuepanel.PanelControl;
 import prefs.Preferences;
+import util.PlatformEx;
 import util.events.ModelUpdatedEventHandler;
 import static org.junit.Assert.assertEquals;
 
@@ -22,7 +23,7 @@ public class MenuControlTest extends UITest {
         modelUpdatedEventTriggered = false;
         UI.events.registerEvent((ModelUpdatedEventHandler) e -> modelUpdatedEventTriggered = true);
         PanelControl panelControl = (PanelControl) find("#dummy/dummy_col0").getParent();
-        Preferences testPref = panelControl.getPreferences();
+        Preferences testPref = UI.prefs;
         
         press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
         assertEquals(0, panelControl.getNumberOfPanels());
@@ -53,7 +54,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 1");
         push(KeyCode.ESCAPE);
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(0, panelControl.getNumberOfSavedBoards());
         
         // Testing board open keyboard shortcut when no board is saved
@@ -66,7 +67,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 1");
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(1, panelControl.getNumberOfSavedBoards());
         assertEquals(2, panelControl.getNumberOfPanels());
         
@@ -83,7 +84,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 2");
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
         
         // Testing invalid board names
@@ -91,14 +92,14 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("");
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
 
         click("Boards");
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("   ");
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
 
         press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
@@ -111,7 +112,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
         push(KeyCode.RIGHT);
         push(KeyCode.ENTER); // Opening Board "2"
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(3, panelControl.getNumberOfPanels());
         
         // Testing board open keyboard shortcut
@@ -124,7 +125,7 @@ public class MenuControlTest extends UITest {
         click("Boards");
         push(KeyCode.DOWN);
         push(KeyCode.ENTER);
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
         
         // Testing board delete
@@ -134,7 +135,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN);
         push(KeyCode.ENTER); // Deleting current board (Board 1): no board is set as open
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(1, panelControl.getNumberOfSavedBoards());
         
         // Testing board open keyboard shortcut when there are saved boards but none is open
@@ -148,7 +149,7 @@ public class MenuControlTest extends UITest {
         push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 1");
         click("OK");
-        sleep(1000);
+        PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
         
         click("View");

--- a/src/test/java/guitests/MenuControlTest.java
+++ b/src/test/java/guitests/MenuControlTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import ui.UI;
 import ui.components.KeyboardShortcuts;
 import ui.issuepanel.PanelControl;
+import prefs.Preferences;
 import util.events.ModelUpdatedEventHandler;
 import static org.junit.Assert.assertEquals;
 
@@ -21,6 +22,8 @@ public class MenuControlTest extends UITest {
         modelUpdatedEventTriggered = false;
         UI.events.registerEvent((ModelUpdatedEventHandler) e -> modelUpdatedEventTriggered = true);
         PanelControl panelControl = (PanelControl) find("#dummy/dummy_col0").getParent();
+        Preferences testPref = panelControl.getPreferences();
+        
         press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
         assertEquals(0, panelControl.getNumberOfPanels());
         press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
@@ -53,6 +56,11 @@ public class MenuControlTest extends UITest {
         sleep(1000);
         assertEquals(0, panelControl.getNumberOfSavedBoards());
         
+        // Testing board open keyboard shortcut when no board is saved
+        // Expected: nothing happens
+        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        assertEquals(false, testPref.getLastOpenBoard().isPresent());
+        
         // Testing board save as
         click("Boards");
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
@@ -61,6 +69,12 @@ public class MenuControlTest extends UITest {
         sleep(1000);
         assertEquals(1, panelControl.getNumberOfSavedBoards());
         assertEquals(2, panelControl.getNumberOfPanels());
+        
+        // Testing board open keyboard shortcut when there is only one saved board
+        // Expected: nothing happens
+        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        assertEquals(true, testPref.getLastOpenBoard().isPresent());
+        assertEquals("Board 1", testPref.getLastOpenBoard().get());
 
         press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
         assertEquals(3, panelControl.getNumberOfPanels());
@@ -96,10 +110,14 @@ public class MenuControlTest extends UITest {
         click("Boards");
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
         push(KeyCode.RIGHT);
-        push(KeyCode.DOWN);
-        push(KeyCode.ENTER); // Opening Board "1"
+        push(KeyCode.ENTER); // Opening Board "2"
         sleep(1000);
-        assertEquals(2, panelControl.getNumberOfPanels());
+        assertEquals(3, panelControl.getNumberOfPanels());
+        
+        // Testing board open keyboard shortcut
+        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        assertEquals(true, testPref.getLastOpenBoard().isPresent());
+        assertEquals("Board 1", testPref.getLastOpenBoard().get());
         
         // Testing board save
         press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
@@ -118,6 +136,11 @@ public class MenuControlTest extends UITest {
         click("OK");
         sleep(1000);
         assertEquals(1, panelControl.getNumberOfSavedBoards());
+        
+        // Testing board open keyboard shortcut when there are saved boards but none is open
+        // Expected: nothing happens
+        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        assertEquals(false, testPref.getLastOpenBoard().isPresent());
         
         // Testing board save when no board is open because current board was closed
         // Expected: prompts user to save as new board

--- a/src/test/java/tests/BoardSwitchTest.java
+++ b/src/test/java/tests/BoardSwitchTest.java
@@ -1,0 +1,104 @@
+package tests;
+
+import static org.junit.Assert.*;
+import prefs.PanelInfo;
+import prefs.Preferences;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+public class BoardSwitchTest {
+    
+    Preferences testPrefs;
+
+    @Test
+    public void boardsSwitchTest() {
+        testPrefs = new Preferences(true);
+        
+        List<PanelInfo> board1 = new ArrayList<PanelInfo>();
+        board1.add(new PanelInfo("Panel 1", ""));
+        List<PanelInfo> board2 = new ArrayList<PanelInfo>();
+        board2.add(new PanelInfo("Panel 1", ""));
+        board2.add(new PanelInfo("Panel 2", ""));
+        List<PanelInfo> board3 = new ArrayList<PanelInfo>();
+        board3.add(new PanelInfo("Panel 1", ""));
+        board3.add(new PanelInfo("Panel 2", ""));
+        board3.add(new PanelInfo("Panel 3", ""));
+        
+        testPrefs.addBoard("Board 1", board1);
+        testPrefs.addBoard("Board 2", board2);
+        testPrefs.addBoard("Board 3", board3);
+        
+        testPrefs.setLastOpenBoard("Board 1");
+        
+        switchBoard();
+        assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
+        
+        switchBoard();
+        assertEquals("Board 2", testPrefs.getLastOpenBoard().get());
+        
+        switchBoard();
+        assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
+        
+        switchBoard();
+        assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
+        
+    }
+    
+    @Test
+    public void noBoardSwitchTest() {
+        testPrefs = new Preferences(true);
+        
+        switchBoard();
+        assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
+    }
+    
+    @Test
+    public void noBoardOpenSwitchTest() {
+        testPrefs = new Preferences(true);
+        
+        List<PanelInfo> board1 = new ArrayList<PanelInfo>();
+        board1.add(new PanelInfo("Panel 1", ""));
+        List<PanelInfo> board2 = new ArrayList<PanelInfo>();
+        board2.add(new PanelInfo("Panel 1", ""));
+        board2.add(new PanelInfo("Panel 2", ""));
+        List<PanelInfo> board3 = new ArrayList<PanelInfo>();
+        board3.add(new PanelInfo("Panel 1", ""));
+        board3.add(new PanelInfo("Panel 2", ""));
+        board3.add(new PanelInfo("Panel 3", ""));
+        
+        testPrefs.addBoard("Board 1", board1);
+        testPrefs.addBoard("Board 2", board2);
+        testPrefs.addBoard("Board 3", board3);
+        
+        switchBoard();
+        assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
+    }
+    
+    @Test
+    public void oneBoardSwitchTest() {
+        testPrefs = new Preferences(true);
+        
+        List<PanelInfo> board1 = new ArrayList<PanelInfo>();
+        board1.add(new PanelInfo("Panel 1", ""));
+        testPrefs.addBoard("Board 1", board1);
+        testPrefs.setLastOpenBoard("Board 1");
+        
+        switchBoard();
+        assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
+        
+    }
+    
+    public void switchBoard() {
+        if (testPrefs.getLastOpenBoard().isPresent() && testPrefs.getAllBoards().size() > 1) {
+            List<String> boardNames = new ArrayList<>(testPrefs.getAllBoards().keySet());
+            int lastBoard = boardNames.indexOf(testPrefs.getLastOpenBoard().get());
+            int index = (lastBoard + 1) % boardNames.size();
+            
+            testPrefs.setLastOpenBoard(boardNames.get(index));
+        }
+    }
+
+}

--- a/src/test/java/tests/BoardSwitchTest.java
+++ b/src/test/java/tests/BoardSwitchTest.java
@@ -18,14 +18,8 @@ public class BoardSwitchTest {
         testPrefs = new Preferences(true);
         
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
-        board1.add(new PanelInfo("Panel 1", ""));
         List<PanelInfo> board2 = new ArrayList<PanelInfo>();
-        board2.add(new PanelInfo("Panel 1", ""));
-        board2.add(new PanelInfo("Panel 2", ""));
         List<PanelInfo> board3 = new ArrayList<PanelInfo>();
-        board3.add(new PanelInfo("Panel 1", ""));
-        board3.add(new PanelInfo("Panel 2", ""));
-        board3.add(new PanelInfo("Panel 3", ""));
         
         testPrefs.addBoard("Board 1", board1);
         testPrefs.addBoard("Board 2", board2);
@@ -33,16 +27,16 @@ public class BoardSwitchTest {
         
         testPrefs.setLastOpenBoard("Board 1");
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals("Board 2", testPrefs.getLastOpenBoard().get());
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
         
     }
@@ -51,7 +45,7 @@ public class BoardSwitchTest {
     public void noBoardSwitchTest() {
         testPrefs = new Preferences(true);
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
     }
     
@@ -60,20 +54,14 @@ public class BoardSwitchTest {
         testPrefs = new Preferences(true);
         
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
-        board1.add(new PanelInfo("Panel 1", ""));
         List<PanelInfo> board2 = new ArrayList<PanelInfo>();
-        board2.add(new PanelInfo("Panel 1", ""));
-        board2.add(new PanelInfo("Panel 2", ""));
         List<PanelInfo> board3 = new ArrayList<PanelInfo>();
-        board3.add(new PanelInfo("Panel 1", ""));
-        board3.add(new PanelInfo("Panel 2", ""));
-        board3.add(new PanelInfo("Panel 3", ""));
         
         testPrefs.addBoard("Board 1", board1);
         testPrefs.addBoard("Board 2", board2);
         testPrefs.addBoard("Board 3", board3);
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
     }
     
@@ -82,23 +70,11 @@ public class BoardSwitchTest {
         testPrefs = new Preferences(true);
         
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
-        board1.add(new PanelInfo("Panel 1", ""));
         testPrefs.addBoard("Board 1", board1);
         testPrefs.setLastOpenBoard("Board 1");
         
-        switchBoard();
+        testPrefs.switchBoard();
         assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
-        
-    }
-    
-    public void switchBoard() {
-        if (testPrefs.getLastOpenBoard().isPresent() && testPrefs.getAllBoards().size() > 1) {
-            List<String> boardNames = new ArrayList<>(testPrefs.getAllBoards().keySet());
-            int lastBoard = boardNames.indexOf(testPrefs.getLastOpenBoard().get());
-            int index = (lastBoard + 1) % boardNames.size();
-            
-            testPrefs.setLastOpenBoard(boardNames.get(index));
-        }
     }
 
 }


### PR DESCRIPTION
Fixes #919 

Changes board when Ctrl+B is pushed.
Only happens if 1) there are at least 2 boards saved, 2) one of them is currently open

2 might be debatable. I chose that because I wanted to prevent changing the board and losing the current board panels. I'll modify if there are other opinions.