### PR TITLE
Unread updates appearing as read #939

### DIFF
--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -72,7 +72,6 @@ public class MultiModel implements IModel {
     }
 
     public synchronized MultiModel replace(List<Model> newModels) {
-        preprocessUpdatedIssues(newModels);
         this.models.clear();
         newModels.forEach(this::add);
         return this;
@@ -200,29 +199,6 @@ public class MultiModel implements IModel {
         for (TurboIssue issue : model.getIssues()) {
             Optional<LocalDateTime> time = prefs.getMarkedReadAt(model.getRepoId(), issue.getId());
             issue.setMarkedReadAt(time);
-        }
-    }
-
-    /**
-     * Called on existing models that are updated.
-     * Mutates TurboIssues with meta-information.
-     * @param newModels
-     */
-    private void preprocessUpdatedIssues(List<Model> newModels) {
-        // Updates preferences with the results of issues that have been updated after a refresh.
-        // This makes read issues show up again.
-        for (Model model : newModels) {
-            assert models.containsKey(model.getRepoId());
-            Model existingModel = models.get(model.getRepoId());
-            if (!existingModel.getIssues().equals(model.getIssues())) {
-                // Find issues that have changed and update preferences with them
-                for (int i = 1; i <= model.getIssues().size(); i++) {
-                    // TODO O(n^2), optimise by preprocessing into a map or sorting
-                    if (!existingModel.getIssueById(i).equals(model.getIssueById(i))) {
-                        assert model.getIssueById(i).isPresent();
-                    }
-                }
-            }
         }
     }
 

--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -200,7 +200,6 @@ public class MultiModel implements IModel {
         for (TurboIssue issue : model.getIssues()) {
             Optional<LocalDateTime> time = prefs.getMarkedReadAt(model.getRepoId(), issue.getId());
             issue.setMarkedReadAt(time);
-            issue.setIsCurrentlyRead(time.isPresent());
         }
     }
 
@@ -221,9 +220,6 @@ public class MultiModel implements IModel {
                     // TODO O(n^2), optimise by preprocessing into a map or sorting
                     if (!existingModel.getIssueById(i).equals(model.getIssueById(i))) {
                         assert model.getIssueById(i).isPresent();
-                        // It's no longer currently read, but it retains its updated time.
-                        // No changes to preferences.
-                        model.getIssueById(i).get().setIsCurrentlyRead(false);
                     }
                 }
             }

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -4,6 +4,7 @@ import backend.IssueMetadata;
 import backend.resource.serialization.SerializableIssue;
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Label;
+import prefs.Preferences;
 import util.Utility;
 
 import java.time.LocalDateTime;
@@ -346,6 +347,17 @@ public class TurboIssue {
         }
 
         return getMarkedReadAt().get().isAfter(getUpdatedAt());
+    }
+
+    public void markAsRead(Preferences prefs) {
+        LocalDateTime now = LocalDateTime.now();
+        setMarkedReadAt(Optional.of(now));
+        prefs.setMarkedReadAt(getRepoId(), getId(), getMarkedReadAt().get());
+    }
+
+    public void markAsUnread(Preferences prefs) {
+        setMarkedReadAt(Optional.empty());
+        prefs.clearMarkedReadAt(getRepoId(), getId());
     }
 
     /**

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -6,6 +6,7 @@ import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Label;
 import prefs.Preferences;
 import util.Utility;
+import static util.Utility.replaceNull;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -101,7 +102,7 @@ public class TurboIssue {
         this.isPullRequest = issue.isPullRequest;
 
         this.description = issue.description;
-        this.updatedAt = issue.updatedAt;
+        this.updatedAt = replaceNull(issue.updatedAt, this.createdAt);
         this.commentCount = issue.commentCount;
         this.isOpen = issue.isOpen;
         this.assignee = issue.assignee;
@@ -125,7 +126,7 @@ public class TurboIssue {
         this.description = issue.getBody() == null
             ? ""
             : issue.getBody();
-        this.updatedAt = Utility.dateToLocalDateTime(issue.getUpdatedAt());
+        this.updatedAt = replaceNull(Utility.dateToLocalDateTime(issue.getUpdatedAt()), this.createdAt);
         this.commentCount = issue.getComments();
         this.isOpen = issue.getState().equals(STATE_OPEN);
         this.assignee = issue.getAssignee() == null
@@ -151,7 +152,7 @@ public class TurboIssue {
 
         this.title = issue.getTitle();
         this.description = issue.getDescription();
-        this.updatedAt = issue.getUpdatedAt();
+        this.updatedAt = replaceNull(issue.getUpdatedAt(), this.createdAt);
         this.commentCount = issue.getCommentCount();
         this.isOpen = issue.isOpen();
         this.assignee = issue.getAssignee();
@@ -173,7 +174,7 @@ public class TurboIssue {
     private void mutableFieldDefaults() {
         this.title = "";
         this.description = "";
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = replaceNull(this.createdAt, LocalDateTime.now());
         this.commentCount = 0;
         this.isOpen = true;
         this.assignee = Optional.empty();
@@ -279,7 +280,7 @@ public class TurboIssue {
         return updatedAt;
     }
     public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
+        this.updatedAt = replaceNull(updatedAt, this.createdAt);
     }
     public int getCommentCount() {
         return commentCount;
@@ -341,9 +342,6 @@ public class TurboIssue {
     public boolean isCurrentlyRead() {
         if (!getMarkedReadAt().isPresent()) {
             return false;
-        }
-        if (getUpdatedAt() == null) {
-            return getMarkedReadAt().get().isAfter(getCreatedAt());
         }
 
         return getMarkedReadAt().get().isAfter(getUpdatedAt());

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -56,7 +56,6 @@ public class TurboIssue {
     private final String repoId;
     private IssueMetadata metadata;
     private Optional<LocalDateTime> markedReadAt;
-    private boolean isCurrentlyRead;
 
     private void ______CONSTRUCTORS______() {
     }
@@ -111,7 +110,6 @@ public class TurboIssue {
         this.metadata = new IssueMetadata(issue.metadata);
         this.repoId = issue.repoId;
         this.markedReadAt = issue.markedReadAt;
-        this.isCurrentlyRead = issue.isCurrentlyRead;
     }
 
     public TurboIssue(String repoId, Issue issue) {
@@ -142,7 +140,6 @@ public class TurboIssue {
         this.metadata = new IssueMetadata();
         this.repoId = repoId;
         this.markedReadAt = Optional.empty();
-        this.isCurrentlyRead = false;
     }
 
     public TurboIssue(String repoId, SerializableIssue issue) {
@@ -163,7 +160,6 @@ public class TurboIssue {
         this.metadata = new IssueMetadata();
         this.repoId = repoId;
         this.markedReadAt = Optional.empty();
-        this.isCurrentlyRead = false;
     }
 
     private void ______CONSTRUCTOR_HELPER_FUNCTIONS______() {
@@ -185,7 +181,6 @@ public class TurboIssue {
 
         this.metadata = new IssueMetadata();
         this.markedReadAt = Optional.empty();
-        this.isCurrentlyRead = false;
     }
 
     /**
@@ -198,7 +193,6 @@ public class TurboIssue {
     private void transferTransientState(TurboIssue fromIssue) {
         this.metadata = new IssueMetadata(fromIssue.metadata, false);
         this.markedReadAt = fromIssue.markedReadAt;
-        this.isCurrentlyRead = fromIssue.isCurrentlyRead;
     }
 
     /**
@@ -334,17 +328,24 @@ public class TurboIssue {
     public void setMetadata(IssueMetadata metadata) {
         this.metadata = metadata;
     }
+
     public Optional<LocalDateTime> getMarkedReadAt() {
         return markedReadAt;
     }
+
     public void setMarkedReadAt(Optional<LocalDateTime> markedReadAt) {
         this.markedReadAt = markedReadAt;
     }
+
     public boolean isCurrentlyRead() {
-        return isCurrentlyRead;
-    }
-    public void setIsCurrentlyRead(boolean isCurrentlyRead) {
-        this.isCurrentlyRead = isCurrentlyRead;
+        if (!getMarkedReadAt().isPresent()) {
+            return false;
+        }
+        if (getUpdatedAt() == null) {
+            return getMarkedReadAt().get().isAfter(getCreatedAt());
+        }
+
+        return getMarkedReadAt().get().isAfter(getUpdatedAt());
     }
 
     /**
@@ -367,8 +368,7 @@ public class TurboIssue {
                 !(milestone != null ? !milestone.equals(issue.milestone) : issue.milestone != null) &&
                 !(title != null ? !title.equals(issue.title) : issue.title != null) &&
                 !(updatedAt != null ? !updatedAt.equals(issue.updatedAt) : issue.updatedAt != null) &&
-                !(markedReadAt != null ? !markedReadAt.equals(issue.markedReadAt) : issue.markedReadAt != null) &&
-                isCurrentlyRead == issue.isCurrentlyRead;
+                !(markedReadAt != null ? !markedReadAt.equals(issue.markedReadAt) : issue.markedReadAt != null);
     }
 
     @Override
@@ -377,7 +377,6 @@ public class TurboIssue {
         result = 31 * result + (creator != null ? creator.hashCode() : 0);
         result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
         result = 31 * result + (isPullRequest ? 1 : 0);
-        result = 31 * result + (isCurrentlyRead ? 1 : 0);
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (updatedAt != null ? updatedAt.hashCode() : 0);

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -126,7 +126,8 @@ public class TurboIssue {
         this.description = issue.getBody() == null
             ? ""
             : issue.getBody();
-        this.updatedAt = replaceNull(Utility.dateToLocalDateTime(issue.getUpdatedAt()), this.createdAt);
+        this.updatedAt = issue.getUpdatedAt() != null ?
+                Utility.dateToLocalDateTime(issue.getUpdatedAt()) : this.createdAt;
         this.commentCount = issue.getComments();
         this.isOpen = issue.getState().equals(STATE_OPEN);
         this.assignee = issue.getAssignee() == null

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -379,9 +379,8 @@ public class ListPanel extends FilterPanel {
         Optional<TurboIssue> item = listView.getSelectedItem();
         if (item.isPresent()) {
             TurboIssue issue = item.get();
-            LocalDateTime now = LocalDateTime.now();
-            ui.prefs.setMarkedReadAt(issue.getRepoId(), issue.getId(), now);
-            issue.setMarkedReadAt(Optional.of(now));
+            issue.markAsRead(ui.prefs);
+
             parentPanelControl.refresh();
             listView.selectNextItem();
         }
@@ -391,8 +390,8 @@ public class ListPanel extends FilterPanel {
         Optional<TurboIssue> item = listView.getSelectedItem();
         if (item.isPresent()) {
             TurboIssue issue = item.get();
-            ui.prefs.clearMarkedReadAt(issue.getRepoId(), issue.getId());
-            issue.setMarkedReadAt(Optional.empty());
+            issue.markAsUnread(ui.prefs);
+
             parentPanelControl.refresh();
         }
     }

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -125,6 +125,8 @@ public class ListPanel extends FilterPanel {
         setupContextMenu();
 
         listView.setOnItemSelected(i -> {
+            updateContextMenu(contextMenu);
+
             TurboIssue issue = listView.getItems().get(i);
             ui.triggerEvent(
                     new IssueSelectedEvent(issue.getRepoId(), issue.getId(), panelIndex, issue.isPullRequest())
@@ -300,10 +302,7 @@ public class ListPanel extends FilterPanel {
         });
 
         contextMenu.getItems().addAll(markAsReadUnreadMenuItem, changeLabelsMenuItem);
-        contextMenu.setOnShowing(e -> {
-            updateContextMenu(contextMenu);
-        });
-
+        contextMenu.setOnShowing(e -> updateContextMenu(contextMenu));
         listView.setContextMenu(contextMenu);
 
         return contextMenu;

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -382,7 +382,6 @@ public class ListPanel extends FilterPanel {
             LocalDateTime now = LocalDateTime.now();
             ui.prefs.setMarkedReadAt(issue.getRepoId(), issue.getId(), now);
             issue.setMarkedReadAt(Optional.of(now));
-            issue.setIsCurrentlyRead(true);
             parentPanelControl.refresh();
             listView.selectNextItem();
         }
@@ -394,7 +393,6 @@ public class ListPanel extends FilterPanel {
             TurboIssue issue = item.get();
             ui.prefs.clearMarkedReadAt(issue.getRepoId(), issue.getId());
             issue.setMarkedReadAt(Optional.empty());
-            issue.setIsCurrentlyRead(false);
             parentPanelControl.refresh();
         }
     }

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -411,12 +411,14 @@ public class FilterEvalTests {
         assertEquals(true, matches("is:unread", issue));
         assertEquals(false, matches("is:read", issue));
 
-        issue.setMarkedReadAt(Optional.of(LocalDateTime.now()));
+        issue.setUpdatedAt(LocalDateTime.of(2015, 2, 17, 2, 10));
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
 
         assertEquals(true, matches("is:unread", issue));
         assertEquals(false, matches("is:read", issue));
 
-        issue.setIsCurrentlyRead(true);
+        issue.setUpdatedAt(LocalDateTime.of(2015, 1, 1, 1, 1));
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
 
         assertEquals(false, matches("is:unread", issue));
         assertEquals(true, matches("is:read", issue));

--- a/src/test/java/tests/TurboIssueTest.java
+++ b/src/test/java/tests/TurboIssueTest.java
@@ -6,12 +6,17 @@ import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.User;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TurboIssueTest {
+    private static String REPO = "testrepo/testrepo";
 
     @Test
     public void turboIssueTest() {
@@ -29,6 +34,33 @@ public class TurboIssueTest {
         assertEquals("test_user", turboIssue.getCreator());
         assertEquals(true, turboIssue.isOpen());
         assertEquals("test label", turboIssue.getLabels().get(0));
+    }
+
+    /**
+     * Tests TurboIssue's isCurrentRead method
+     */
+    @Test
+    public void testReadState() {
+        TurboIssue issue = new TurboIssue(REPO, 1, "", "",
+                LocalDateTime.of(2011, 1, 1, 1, 1, 1), false);
+
+        // An issue is not read if it doesn't record any markedReadAt time
+        assertFalse(issue.isCurrentlyRead());
+
+        // An issue is read if it has no updatedAt time
+        // and its markedAsRead time is after its createdAt time
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
+        issue.setUpdatedAt(null);
+        assertTrue(issue.isCurrentlyRead());
+
+        // An issue is not read if its markedAsRead time is before its updatedAt time
+        issue.setUpdatedAt(LocalDateTime.of(2015, 2, 17, 2, 10));
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
+        assertFalse(issue.isCurrentlyRead());
+
+        // An issue is marked as read if its markedAsRead time is after its updated Time
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 3, 6, 12, 15)));
+        assertTrue(issue.isCurrentlyRead());
     }
 
 }

--- a/src/test/java/tests/TurboIssueTest.java
+++ b/src/test/java/tests/TurboIssueTest.java
@@ -41,17 +41,10 @@ public class TurboIssueTest {
      */
     @Test
     public void testReadState() {
-        TurboIssue issue = new TurboIssue(REPO, 1, "", "",
-                LocalDateTime.of(2011, 1, 1, 1, 1, 1), false);
+        TurboIssue issue = new TurboIssue(REPO, 1, "", "", null, false);
 
         // An issue is not read if it doesn't record any markedReadAt time
         assertFalse(issue.isCurrentlyRead());
-
-        // An issue is read if it has no updatedAt time
-        // and its markedAsRead time is after its createdAt time
-        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
-        issue.setUpdatedAt(null);
-        assertTrue(issue.isCurrentlyRead());
 
         // An issue is not read if its markedAsRead time is before its updatedAt time
         issue.setUpdatedAt(LocalDateTime.of(2015, 2, 17, 2, 10));
@@ -59,7 +52,8 @@ public class TurboIssueTest {
         assertFalse(issue.isCurrentlyRead());
 
         // An issue is marked as read if its markedAsRead time is after its updated Time
-        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 3, 6, 12, 15)));
+        issue.setUpdatedAt(LocalDateTime.of(2015, 1, 1, 1, 1));
+        issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
         assertTrue(issue.isCurrentlyRead());
     }
 


### PR DESCRIPTION
Fix #939 

This PR also helps with the same problem as in #944, so @rd1992 might want to take a look.

Also, I think the logic of fixes or extensions to read/unread state should be kept within TurboIssue and expose through a unifying interface such as `TurboIssue.isCurrentlyRead`, since they are inherently tied to an issue. For example, #953 should be ideally done by extending `isCurrentlyRead` and no complex logic is necessary in the Model level (like what's being done in `MultiModel.preprocessUpdatedIssues`)