### PR TITLE
Support ReviewComment and CommitComment #970

### DIFF
--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -46,10 +46,10 @@ public class GitHubRepo implements Repo {
 
     private static final Logger logger = HTLog.get(GitHubRepo.class);
 
-    private final GitHubClientExtended client = new GitHubClientExtended();
-    private final IssueServiceExtended issueService = new IssueServiceExtended(client);
+    private final GitHubClientEx client = new GitHubClientEx();
+    private final IssueServiceEx issueService = new IssueServiceEx(client);
     private final CollaboratorService collaboratorService = new CollaboratorService(client);
-    private final LabelServiceFixed labelService = new LabelServiceFixed(client);
+    private final LabelServiceEx labelService = new LabelServiceEx(client);
     private final MilestoneService milestoneService = new MilestoneService(client);
 
     public GitHubRepo() {
@@ -100,7 +100,7 @@ public class GitHubRepo implements Repo {
     }
 
     private <TR, R, S extends UpdateService<R>> ImmutablePair<List<TR>, String> getUpdatedResource(
-        String repoId, String eTag, BiFunction<GitHubClientExtended, String, S> constructService,
+        String repoId, String eTag, BiFunction<GitHubClientEx, String, S> constructService,
         BiFunction<String, R, TR> resourceConstructor) {
 
         S updateService = constructService.apply(client, eTag);

--- a/src/main/java/github/GitHubClientEx.java
+++ b/src/main/java/github/GitHubClientEx.java
@@ -22,8 +22,8 @@ import util.Utility;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-public class GitHubClientExtended extends GitHubClient {
-    private static final Logger logger = HTLog.get(GitHubClientExtended.class);
+public class GitHubClientEx extends GitHubClient {
+    private static final Logger logger = HTLog.get(GitHubClientEx.class);
 
     public static final int NO_UPDATE_RESPONSE_CODE = 304;
     protected static final int CONNECTION_TIMEOUT = 30000;
@@ -31,7 +31,7 @@ public class GitHubClientExtended extends GitHubClient {
     // Request method for HEAD API call
     protected static final String METHOD_HEAD = "HEAD";
 
-    public GitHubClientExtended() {
+    public GitHubClientEx() {
     }
 
     /**

--- a/src/main/java/github/IssueServiceEx.java
+++ b/src/main/java/github/IssueServiceEx.java
@@ -12,13 +12,13 @@ import java.util.Map;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
 
-public class IssueServiceExtended extends IssueService{
-    private GitHubClientExtended ghClient;
+public class IssueServiceEx extends IssueService{
+    private GitHubClientEx ghClient;
 
     public static final String ISSUE_DATE = "date";
     public static final String ISSUE_CONTENTS = "issue";
 
-    public IssueServiceExtended(GitHubClientExtended client){
+    public IssueServiceEx(GitHubClientEx client){
         super(client);
         this.ghClient = client;
     }

--- a/src/main/java/github/LabelServiceEx.java
+++ b/src/main/java/github/LabelServiceEx.java
@@ -12,13 +12,13 @@ import java.util.List;
 import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
 
 
-public class LabelServiceFixed extends LabelService {
+public class LabelServiceEx extends LabelService {
 
-    public LabelServiceFixed() {
+    public LabelServiceEx() {
         super();
     }
 
-    public LabelServiceFixed(GitHubClient client) {
+    public LabelServiceEx(GitHubClient client) {
         super(client);
     }
 

--- a/src/main/java/github/PullRequestServiceEx.java
+++ b/src/main/java/github/PullRequestServiceEx.java
@@ -1,9 +1,11 @@
 package github;
 
 import com.google.gson.reflect.TypeToken;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.client.PagedRequest;
 import org.eclipse.egit.github.core.service.PullRequestService;
+import util.HTLog;
 
 import java.io.IOException;
 import java.util.List;
@@ -11,6 +13,8 @@ import java.util.List;
 import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
 
 public class PullRequestServiceEx extends PullRequestService {
+    private static final Logger logger = HTLog.get(PullRequestServiceEx.class);
+
     /**
      * Gets a pull request's review comments
      *
@@ -48,6 +52,13 @@ public class PullRequestServiceEx extends PullRequestService {
      */
     private List<ReviewComment> getReviewComments(String repoId, String pullRequestNumber)
             throws IOException {
+        if (pullRequestNumber == null)
+            throw new IllegalArgumentException("Pull request number cannot be null");
+        if (pullRequestNumber.length() == 0)
+            throw new IllegalArgumentException("Pull request number cannot be empty");
+
+        logger.info("Getting review comments for PR" + pullRequestNumber + " " + repoId);
+
         StringBuilder uri = new StringBuilder(SEGMENT_REPOS);
         uri.append('/').append(repoId);
         uri.append(SEGMENT_PULLS);
@@ -58,8 +69,6 @@ public class PullRequestServiceEx extends PullRequestService {
         request.setUri(uri);
         request.setType(new TypeToken<List<ReviewComment>>() {
         }.getType());
-
-        System.out.println(request.getUri());
 
         return getAll(request);
     }

--- a/src/main/java/github/PullRequestServiceEx.java
+++ b/src/main/java/github/PullRequestServiceEx.java
@@ -1,0 +1,7 @@
+package github;
+
+/**
+ * Created by ndt on 9/14/15.
+ */
+public class PullRequestServiceEx {
+}

--- a/src/main/java/github/PullRequestServiceEx.java
+++ b/src/main/java/github/PullRequestServiceEx.java
@@ -1,7 +1,66 @@
 package github;
 
-/**
- * Created by ndt on 9/14/15.
- */
-public class PullRequestServiceEx {
+import com.google.gson.reflect.TypeToken;
+import org.eclipse.egit.github.core.IRepositoryIdProvider;
+import org.eclipse.egit.github.core.client.PagedRequest;
+import org.eclipse.egit.github.core.service.PullRequestService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
+
+public class PullRequestServiceEx extends PullRequestService {
+    /**
+     * Gets a pull request's review comments
+     *
+     * @param repository
+     * @param pullRequestNumber
+     * @return list of review comments
+     * @throws IOException
+     */
+    public List<ReviewComment> getReviewComments(IRepositoryIdProvider repository,
+                                                 int pullRequestNumber) throws IOException {
+        return getReviewComments(repository, Integer.toString(pullRequestNumber));
+    }
+
+    /**
+     * Gets a pull request's review comments
+     *
+     * @param repository
+     * @param pullRequestNumber
+     * @return list of review comments
+     * @throws IOException
+     */
+    public List<ReviewComment> getReviewComments(IRepositoryIdProvider repository,
+                                                 String pullRequestNumber) throws IOException {
+        String repoId = getId(repository);
+        return getReviewComments(repoId, pullRequestNumber);
+    }
+
+    /**
+     * Gets a pull request's review comments
+     *
+     * @param repoId
+     * @param pullRequestNumber
+     * @return list of review comments
+     * @throws IOException
+     */
+    private List<ReviewComment> getReviewComments(String repoId, String pullRequestNumber)
+            throws IOException {
+        StringBuilder uri = new StringBuilder(SEGMENT_REPOS);
+        uri.append('/').append(repoId);
+        uri.append(SEGMENT_PULLS);
+        uri.append('/').append(pullRequestNumber);
+        uri.append(SEGMENT_COMMENTS);
+
+        PagedRequest<ReviewComment> request = createPagedRequest();
+        request.setUri(uri);
+        request.setType(new TypeToken<List<ReviewComment>>() {
+        }.getType());
+
+        System.out.println(request.getUri());
+
+        return getAll(request);
+    }
 }

--- a/src/main/java/github/PullRequestServiceEx.java
+++ b/src/main/java/github/PullRequestServiceEx.java
@@ -52,10 +52,12 @@ public class PullRequestServiceEx extends PullRequestService {
      */
     private List<ReviewComment> getReviewComments(String repoId, String pullRequestNumber)
             throws IOException {
-        if (pullRequestNumber == null)
+        if (pullRequestNumber == null) {
             throw new IllegalArgumentException("Pull request number cannot be null");
-        if (pullRequestNumber.length() == 0)
+        }
+        if (pullRequestNumber.length() == 0) {
             throw new IllegalArgumentException("Pull request number cannot be empty");
+        }
 
         logger.info("Getting review comments for PR" + pullRequestNumber + " " + repoId);
 

--- a/src/main/java/github/RepositoryServiceEx.java
+++ b/src/main/java/github/RepositoryServiceEx.java
@@ -13,13 +13,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class RepositoryServiceExtended extends RepositoryService{
-    private static final Logger logger = LogManager.getLogger(RepositoryServiceExtended.class.getName());
+public class RepositoryServiceEx extends RepositoryService{
+    private static final Logger logger = LogManager.getLogger(RepositoryServiceEx.class.getName());
 
-    private GitHubClientExtended ghClient;
+    private GitHubClientEx ghClient;
     private OrganizationService orgService;
 
-    public RepositoryServiceExtended(GitHubClientExtended ghClient){
+    public RepositoryServiceEx(GitHubClientEx ghClient){
         this.ghClient = ghClient;
         orgService = new OrganizationService(this.ghClient);
     }

--- a/src/main/java/github/ReviewComment.java
+++ b/src/main/java/github/ReviewComment.java
@@ -1,0 +1,78 @@
+package github;
+
+import org.eclipse.egit.github.core.Comment;
+
+public class ReviewComment extends Comment {
+
+    private static final long serialVersionUID = -5563518235470110428L;
+
+    private String diffHunk;
+
+    private String path;
+
+    private int position;
+
+    private int originalPosition;
+
+    private String commitId;
+
+    private String originalCommitId;
+
+    private String pullRequestUrl;
+
+    public String getDiffHunk() {
+        return diffHunk;
+    }
+
+    public void setDiffHunk(String diffHunk) {
+        this.diffHunk = diffHunk;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int getOriginalPosition() {
+        return originalPosition;
+    }
+
+    public void setOriginalPosition(int originalPosition) {
+        this.originalPosition = originalPosition;
+    }
+
+    public String getCommitId() {
+        return commitId;
+    }
+
+    public void setCommitId(String commitId) {
+        this.commitId = commitId;
+    }
+
+    public String getOriginalCommitId() {
+        return originalCommitId;
+    }
+
+    public void setOriginalCommitId(String originalCommitId) {
+        this.originalCommitId = originalCommitId;
+    }
+
+    public String getPullRequestUrl() {
+        return pullRequestUrl;
+    }
+
+    public void setPullRequestUrl(String pullRequestUrl) {
+        this.pullRequestUrl = pullRequestUrl;
+    }
+}

--- a/src/main/java/github/update/IssueUpdateService.java
+++ b/src/main/java/github/update/IssueUpdateService.java
@@ -1,7 +1,7 @@
 package github.update;
 
 import com.google.gson.reflect.TypeToken;
-import github.GitHubClientExtended;
+import github.GitHubClientEx;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.client.PagedRequest;
@@ -14,11 +14,11 @@ import java.util.Map;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_ISSUES;
 
-public class IssueUpdateService extends UpdateService<Issue>{
+public class IssueUpdateService extends UpdateService<Issue> {
 
     private final Date lastIssueCheckTime;
 
-    public IssueUpdateService(GitHubClientExtended client, String issuesETag, Date lastIssueCheckTime){
+    public IssueUpdateService(GitHubClientEx client, String issuesETag, Date lastIssueCheckTime){
         super(client, SEGMENT_ISSUES, issuesETag);
         this.lastIssueCheckTime = new Date(lastIssueCheckTime.getTime());
     }

--- a/src/main/java/github/update/LabelUpdateService.java
+++ b/src/main/java/github/update/LabelUpdateService.java
@@ -1,7 +1,7 @@
 package github.update;
 
 import com.google.gson.reflect.TypeToken;
-import github.GitHubClientExtended;
+import github.GitHubClientEx;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.client.PagedRequest;
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_LABELS;
 
 public class LabelUpdateService extends UpdateService<Label> {
-    public LabelUpdateService(GitHubClientExtended client, String labelsETag){
+    public LabelUpdateService(GitHubClientEx client, String labelsETag){
         super(client, SEGMENT_LABELS, labelsETag);
     }
     @Override

--- a/src/main/java/github/update/MilestoneUpdateService.java
+++ b/src/main/java/github/update/MilestoneUpdateService.java
@@ -1,7 +1,7 @@
 package github.update;
 
 import com.google.gson.reflect.TypeToken;
-import github.GitHubClientExtended;
+import github.GitHubClientEx;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.Milestone;
 import org.eclipse.egit.github.core.client.PagedRequest;
@@ -12,10 +12,10 @@ import java.util.Map;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_MILESTONES;
 
-public class MilestoneUpdateService extends UpdateService<Milestone>{
+public class MilestoneUpdateService extends UpdateService<Milestone> {
 
 
-    public MilestoneUpdateService(GitHubClientExtended client, String milestonesETag){
+    public MilestoneUpdateService(GitHubClientEx client, String milestonesETag){
         super(client, SEGMENT_MILESTONES, milestonesETag);
     }
 

--- a/src/main/java/github/update/PageHeaderIterator.java
+++ b/src/main/java/github/update/PageHeaderIterator.java
@@ -1,7 +1,8 @@
 package github.update;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.PARAM_PAGE;
-import github.GitHubClientExtended;
+
+import github.GitHubClientEx;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -29,14 +30,14 @@ public class PageHeaderIterator implements Iterable<String>, Iterator<String> {
     private static final Logger logger = HTLog.get(PageHeaderIterator.class);
 
     private final GitHubRequest request;
-    private final GitHubClientExtended client;
+    private final GitHubClientEx client;
     private final String headerField;
 
     private int nextPage; // Current page number
     private String next; // Next uri to be fetched
     private HttpURLConnection lastConnection;
 
-    public PageHeaderIterator(GitHubRequest request, GitHubClientExtended client,
+    public PageHeaderIterator(GitHubRequest request, GitHubClientEx client,
                               String headerField) {
         this.request = request;
         this.client = client;

--- a/src/main/java/github/update/UpdateService.java
+++ b/src/main/java/github/update/UpdateService.java
@@ -2,7 +2,8 @@ package github.update;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_JSON;
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
-import github.GitHubClientExtended;
+
+import github.GitHubClientEx;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -34,7 +35,7 @@ import util.Utility;
 public class UpdateService<T> extends GitHubService {
     private static final Logger logger = LogManager.getLogger(UpdateService.class.getName());
 
-    private final GitHubClientExtended client;
+    private final GitHubClientEx client;
     private final String apiSuffix;
     private final String lastETags;
 
@@ -50,7 +51,7 @@ public class UpdateService<T> extends GitHubService {
      * @param apiSuffix the API URI for the type of item; defined by subclasses
      * @param lastETag the last-known ETag for these items; may be null
      */
-    public UpdateService(GitHubClientExtended client, String apiSuffix, String lastETags){
+    public UpdateService(GitHubClientEx client, String apiSuffix, String lastETags){
         assert client != null;
         assert apiSuffix != null && !apiSuffix.isEmpty();
 
@@ -142,7 +143,7 @@ public class UpdateService<T> extends GitHubService {
      *         corresponding HTTP connection or an empty Optional if an error occurs
      */
     private Optional<ImmutablePair<List<String>, HttpURLConnection>> getPagedEtags(
-            GitHubRequest request, GitHubClientExtended client) {
+            GitHubRequest request, GitHubClientEx client) {
 
         PageHeaderIterator iter = new PageHeaderIterator(request, client, "ETag");
         List<String> etags = new ArrayList<>();

--- a/src/main/java/github/update/UserUpdateService.java
+++ b/src/main/java/github/update/UserUpdateService.java
@@ -2,7 +2,7 @@ package github.update;
 
 
 import com.google.gson.reflect.TypeToken;
-import github.GitHubClientExtended;
+import github.GitHubClientEx;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.client.PagedRequest;
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_COLLABORATORS;
 
-public class UserUpdateService extends UpdateService<User>{
+public class UserUpdateService extends UpdateService<User> {
 
-    public UserUpdateService(GitHubClientExtended client, String collabsETag){
+    public UserUpdateService(GitHubClientEx client, String collabsETag){
         super(client, SEGMENT_COLLABORATORS, collabsETag);
     }
 

--- a/src/test/java/tests/PullRequestTests.java
+++ b/src/test/java/tests/PullRequestTests.java
@@ -1,0 +1,65 @@
+package tests;
+
+import github.PullRequestServiceEx;
+import github.ReviewComment;
+import org.eclipse.egit.github.core.RepositoryId;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PullRequestTests {
+    /**
+     * Tests ReviewComment class setters/getters
+     */
+    @Test
+    public void testReviewComment() {
+        ReviewComment reviewComment = new ReviewComment();
+
+        reviewComment.setCommitId("eb123bfe");
+        assertEquals("eb123bfe", reviewComment.getCommitId());
+
+        reviewComment.setDiffHunk("@@ -1,9 +1,10 @@");
+        assertEquals("@@ -1,9 +1,10 @@", reviewComment.getDiffHunk());
+
+        reviewComment.setOriginalCommitId("543ab123ef");
+        assertEquals("543ab123ef", reviewComment.getOriginalCommitId());
+
+        reviewComment.setOriginalPosition(17);
+        assertEquals(17, reviewComment.getOriginalPosition());
+
+        reviewComment.setPath("src/file.txt");
+        assertEquals("src/file.txt", reviewComment.getPath());
+
+        reviewComment.setPosition(42);
+        assertEquals(42, reviewComment.getPosition());
+
+        reviewComment.setPullRequestUrl("http://api.github.com/repos/owner/repo/pulls/1");
+        assertEquals("http://api.github.com/repos/owner/repo/pulls/1", reviewComment.getPullRequestUrl());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidArgumentsToGetReviewComments1() throws IOException {
+        PullRequestServiceEx service = new PullRequestServiceEx();
+        service.getReviewComments(null, 12);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidArgumentsToGetReviewComments2() throws IOException {
+        PullRequestServiceEx service = new PullRequestServiceEx();
+        service.getReviewComments(RepositoryId.createFromId("testrepo/testrepo"), null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidArgumentsToGetReviewComments3() throws IOException {
+        PullRequestServiceEx service = new PullRequestServiceEx();
+        service.getReviewComments(RepositoryId.createFromId("testrepo/testrepo"), "");
+    }
+
+    @Test(expected = IOException.class)
+    public void testInvalidRepositoryInGetReviewComments() throws IOException {
+        PullRequestServiceEx service = new PullRequestServiceEx();
+        service.getReviewComments(RepositoryId.createFromId("fakeowner/bogusrepo"), 1);
+    }
+}

--- a/src/test/java/tests/UpdateServiceTests.java
+++ b/src/test/java/tests/UpdateServiceTests.java
@@ -1,37 +1,30 @@
 package tests;
 
-import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_JSON;
-import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import github.GitHubClientEx;
 import github.update.MilestoneUpdateService;
 import github.update.PageHeaderIterator;
 import github.update.UpdateService;
+import org.eclipse.egit.github.core.Milestone;
+import org.eclipse.egit.github.core.RepositoryId;
+import org.eclipse.egit.github.core.client.PagedRequest;
+import org.junit.Test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
-import org.eclipse.egit.github.core.Milestone;
-import org.eclipse.egit.github.core.RepositoryId;
-import org.eclipse.egit.github.core.client.NoSuchPageException;
-import org.eclipse.egit.github.core.client.PagedRequest;
-import org.junit.Test;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_JSON;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UpdateServiceTests {
     /**
      * Tests that head request to nonexistent repo throws an exception
      * @throws IOException
      */
-    @Test(expected = FileNotFoundException.class)
+    @Test(expected = IOException.class)
     public void testHeadRequest() throws IOException {
         GitHubClientEx client = new GitHubClientEx();
 
@@ -47,7 +40,7 @@ public class UpdateServiceTests {
         client.head(request);
     }
 
-    @Test(expected = NoSuchPageException.class)
+    @Test(expected = Exception.class)
     public void testHeaderIterator() {
         GitHubClientEx client = new GitHubClientEx();
 

--- a/src/test/java/tests/UpdateServiceTests.java
+++ b/src/test/java/tests/UpdateServiceTests.java
@@ -4,7 +4,8 @@ import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import github.GitHubClientExtended;
+
+import github.GitHubClientEx;
 import github.update.MilestoneUpdateService;
 import github.update.PageHeaderIterator;
 import github.update.UpdateService;
@@ -32,7 +33,7 @@ public class UpdateServiceTests {
      */
     @Test(expected = FileNotFoundException.class)
     public void testHeadRequest() throws IOException {
-        GitHubClientExtended client = new GitHubClientExtended();
+        GitHubClientEx client = new GitHubClientEx();
 
         PagedRequest<Milestone> request = new PagedRequest<>();
         Map<String, String> params = new HashMap<>();
@@ -48,7 +49,7 @@ public class UpdateServiceTests {
 
     @Test(expected = NoSuchPageException.class)
     public void testHeaderIterator() {
-        GitHubClientExtended client = new GitHubClientExtended();
+        GitHubClientEx client = new GitHubClientEx();
 
         Map<String, String> params = new HashMap<>();
         params.put("state", "all");
@@ -87,7 +88,7 @@ public class UpdateServiceTests {
 
     @Test
     public void testGetUpdatedItems() {
-        GitHubClientExtended client = new GitHubClientExtended();
+        GitHubClientEx client = new GitHubClientEx();
         MilestoneUpdateService service = new MilestoneUpdateService(client, "abcd");
 
         assertTrue(service.getUpdatedItems(RepositoryId.create("name", "nonexistentrepo")).isEmpty());


### PR DESCRIPTION
Fixes #970

The support is implemented in a new class `PullRequestServiceEx` (together with a new `ReviewComment` class) instead of `GitHubClientEx` for consistency with `egit`. All classes that extend `egit` are also renamed with `Ex` suffice. This PR should not contain any apparent functional change.