### PR TITLE
Nondeterministic tests #952

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - TERM=dumb
 
 script:
-    - "./gradlew clean check -i --continue"
+    - "./gradlew clean check -i"
 
 after_success:
     - "./gradlew jacocoRootReport coveralls"

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -1,31 +1,46 @@
 package guitests;
 
-import backend.interfaces.RepoStore;
-import com.google.common.util.concurrent.SettableFuture;
+import static com.google.common.io.Files.getFileExtension;
 
-import javafx.scene.Node;
-import javafx.scene.Parent;
-import javafx.scene.control.ComboBoxBase;
-import javafx.stage.Stage;
-import org.junit.Before;
-import org.loadui.testfx.GuiTest;
-import org.loadui.testfx.exceptions.NoNodesFoundException;
-import org.loadui.testfx.exceptions.NoNodesVisibleException;
-import org.loadui.testfx.utils.FXTestUtils;
-import prefs.Preferences;
-import ui.UI;
-import util.PlatformEx;
-
+import java.awt.Robot;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.io.Files.getFileExtension;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Before;
+import org.loadui.testfx.FXScreenController;
+import org.loadui.testfx.GuiTest;
+import org.loadui.testfx.exceptions.NoNodesFoundException;
+import org.loadui.testfx.exceptions.NoNodesVisibleException;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import backend.interfaces.RepoStore;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.ComboBoxBase;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.stage.Stage;
+import prefs.Preferences;
+import ui.UI;
+import util.PlatformEx;
 
 public class UITest extends GuiTest {
+
+    private static final Logger logger = LogManager.getLogger(UITest.class.getName());
 
     protected static final SettableFuture<Stage> STAGE_FUTURE = SettableFuture.create();
 
@@ -39,6 +54,15 @@ public class UITest extends GuiTest {
             super.start(primaryStage);
             STAGE_FUTURE.set(primaryStage);
         }
+    }
+
+    private final Robot robot;
+    private final FXScreenController screenController;
+
+    public UITest() {
+        super();
+        screenController = getScreenController();
+        robot = getRobot();
     }
 
     public void setupMethod() {
@@ -91,6 +115,61 @@ public class UITest extends GuiTest {
     @Override
     protected Parent getRootNode() {
         return stage.getScene().getRoot();
+    }
+
+    private FXScreenController getScreenController() {
+        try {
+            return (FXScreenController) FieldUtils.readField(this, "controller", true);
+        } catch (IllegalAccessException e) {
+            logger.error(e.getLocalizedMessage(), e);
+            return null;
+        }
+    }
+
+    private Robot getRobot() {
+        try {
+            return (Robot) FieldUtils.readField(screenController, "robot", true);
+        } catch (IllegalAccessException e) {
+            logger.error(e.getLocalizedMessage(), e);
+            return null;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void pressNoWait(KeyCode key) {
+        robot.keyPress(key.impl_getCode());
+    }
+
+    @SuppressWarnings("deprecation")
+    private void releaseNoWait(KeyCode key) {
+        robot.keyRelease(key.impl_getCode());
+    }
+
+    public void pushKeys(KeyCodeCombination combination) {
+        List<KeyCode> keys = new ArrayList<>();
+        if (combination.getAlt() == KeyCombination.ModifierValue.DOWN) {
+            keys.add(KeyCode.ALT);
+        }
+        if (combination.getShift() == KeyCombination.ModifierValue.DOWN) {
+            keys.add(KeyCode.SHIFT);
+        }
+        if (combination.getControl() == KeyCombination.ModifierValue.DOWN) {
+            keys.add(KeyCode.CONTROL);
+        }
+        keys.add(combination.getCode());
+        pushKeys(keys);
+    }
+
+    public void pushKeys(KeyCode... keys) {
+        pushKeys(Arrays.asList(keys));
+    }
+
+    private void pushKeys(List<KeyCode> keys) {
+        keys.forEach(this::pressNoWait);
+        for (int i = keys.size() - 1; i >= 0; i--) {
+            releaseNoWait(keys.get(i));
+        }
+        PlatformEx.waitOnFxThread();
     }
 
     public void waitUntilNodeAppears(Node node) {

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.logging.log4j.LogManager;
@@ -26,7 +27,6 @@ import org.loadui.testfx.utils.FXTestUtils;
 import com.google.common.util.concurrent.SettableFuture;
 
 import backend.interfaces.RepoStore;
-import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.ComboBoxBase;
@@ -189,6 +189,13 @@ public class UITest extends GuiTest {
 
     public void waitUntilNodeDisappears(String selector) {
         while (existsQuiet(selector)) {
+            PlatformEx.waitOnFxThread();
+            sleep(100);
+        }
+    }
+
+    public <T extends Node> void waitUntil(String selector, Predicate<T> condition) {
+        while (!condition.test(find(selector))) {
             PlatformEx.waitOnFxThread();
             sleep(100);
         }

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -54,6 +54,7 @@ public class UseGlobalConfigsTest extends UITest {
         // Make a new board
         click("Boards");
         click("Save as");
+
         // Somehow the text field cannot be populated by typing on the CI, use setText instead.
         // TODO find out why
         ((TextField) find("#boardnameinput")).setText("Empty Board");
@@ -63,6 +64,13 @@ public class UseGlobalConfigsTest extends UITest {
         type("Renamed panel");
         PanelNameTextField renameTextField1 = find("#dummy/dummy_col0_renameTextField");
         assertEquals("Renamed panel", renameTextField1.getText());
+        pushKeys(KeyCode.ENTER);
+
+        waitUntilNodeAppears("#dummy/dummy_col0_filterTextField");
+        click("#dummy/dummy_col0_filterTextField");
+        type("is");
+        pushKeys(KeyCode.SHIFT, KeyCode.SEMICOLON);
+        type("issue");
         pushKeys(KeyCode.ENTER);
 
         // Load dummy2/dummy2 too
@@ -81,6 +89,7 @@ public class UseGlobalConfigsTest extends UITest {
         pushKeys(KeyCode.ENTER);
 
         pushKeys(KeyboardShortcuts.CREATE_LEFT_PANEL);
+        waitUntil("#dummy/dummy_col0_filterTextField", f -> ((FilterTextField) f).getText().isEmpty());
 
         FilterTextField filterTextField3 = find("#dummy/dummy_col0_filterTextField");
         click(filterTextField3);
@@ -99,6 +108,8 @@ public class UseGlobalConfigsTest extends UITest {
         // Make a new board
         click("Boards");
         click("Save as");
+
+        // Text field cannot be populated by typing on the CI, use setText instead
         ((TextField) find("#boardnameinput")).setText("Dummy Board");
         click("OK");
 
@@ -131,7 +142,7 @@ public class UseGlobalConfigsTest extends UITest {
         List<PanelInfo> dummyBoard = boards.get("Dummy Board");
         assertEquals(3, dummyBoard.size());
         assertEquals("is:open", dummyBoard.get(0).getPanelFilter());
-        assertEquals("", dummyBoard.get(1).getPanelFilter());
+        assertEquals("is:issue", dummyBoard.get(1).getPanelFilter());
         assertEquals("repo:dummy2/dummy2", dummyBoard.get(2).getPanelFilter());
         assertEquals("Open issues", dummyBoard.get(0).getPanelName());
         assertEquals("Renamed panel", dummyBoard.get(1).getPanelName());
@@ -142,7 +153,7 @@ public class UseGlobalConfigsTest extends UITest {
         List<String> lastOpenPanelNames = testPref.getPanelNames();
         
         assertEquals("is:open", lastOpenFilters.get(0));
-        assertEquals("", lastOpenFilters.get(1));
+        assertEquals("is:issue", lastOpenFilters.get(1));
         assertEquals("repo:dummy2/dummy2", lastOpenFilters.get(2));
 
         assertEquals("Open issues", lastOpenPanelNames.get(0));

--- a/src/test/java/guitests/UseGlobalConfigsTest.java
+++ b/src/test/java/guitests/UseGlobalConfigsTest.java
@@ -18,6 +18,7 @@ import prefs.PanelInfo;
 import prefs.Preferences;
 import ui.UI;
 import ui.components.FilterTextField;
+import ui.components.KeyboardShortcuts;
 import ui.components.PanelNameTextField;
 import util.PlatformEx;
 import util.events.ShowRenamePanelEvent;
@@ -36,16 +37,19 @@ public class UseGlobalConfigsTest extends UITest {
         TextField repoOwnerField = find("#repoOwnerField");
         doubleClick(repoOwnerField);
         doubleClick(repoOwnerField);
-        type("dummy").push(KeyCode.TAB);
-        type("dummy").push(KeyCode.TAB);
-        type("test").push(KeyCode.TAB);
+        type("dummy");
+        pushKeys(KeyCode.TAB);
+        type("dummy");
+        pushKeys(KeyCode.TAB);
+        type("test");
+        pushKeys(KeyCode.TAB);
         type("test");
         click("Sign in");
         ComboBox<String> repositorySelector = findOrWaitFor("#repositorySelector");
         waitForValue(repositorySelector);
         assertEquals("dummy/dummy", repositorySelector.getValue());
         
-        press(KeyCode.CONTROL).press(KeyCode.X).release(KeyCode.X).release(KeyCode.CONTROL);
+        pushKeys(KeyboardShortcuts.MAXIMIZE_WINDOW);
 
         // Make a new board
         click("Boards");
@@ -59,40 +63,38 @@ public class UseGlobalConfigsTest extends UITest {
         type("Renamed panel");
         PanelNameTextField renameTextField1 = find("#dummy/dummy_col0_renameTextField");
         assertEquals("Renamed panel", renameTextField1.getText());
-        push(KeyCode.ENTER);
+        pushKeys(KeyCode.ENTER);
 
         // Load dummy2/dummy2 too
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
         waitUntilNodeAppears("#dummy/dummy_col1_filterTextField");
         click("#dummy/dummy_col1_filterTextField");
         type("repo");
-        press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
+        pushKeys(KeyCode.SHIFT, KeyCode.SEMICOLON);
         type("dummy2/dummy2");
-        push(KeyCode.ENTER);
+        pushKeys(KeyCode.ENTER);
 
         click("#dummy/dummy_col1_renameButton");
         type("Dummy 2 panel");
         PanelNameTextField renameTextField2 = find("#dummy/dummy_col1_renameTextField");
         assertEquals("Dummy 2 panel", renameTextField2.getText());
-        push(KeyCode.ENTER);
-        
-        // Creating panel to the left
-        press(KeyCode.SHIFT).press(KeyCode.CONTROL).press(KeyCode.P);
-        release(KeyCode.P).release(KeyCode.CONTROL).release(KeyCode.SHIFT);
-        
+        pushKeys(KeyCode.ENTER);
+
+        pushKeys(KeyboardShortcuts.CREATE_LEFT_PANEL);
+
         FilterTextField filterTextField3 = find("#dummy/dummy_col0_filterTextField");
         click(filterTextField3);
         type("is");
-        press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
+        pushKeys(KeyCode.SHIFT, KeyCode.SEMICOLON);
         type("open");
         assertEquals("is:open", filterTextField3.getText());
-        push(KeyCode.ENTER);
+        pushKeys(KeyCode.ENTER);
 
         PlatformEx.runAndWait(() -> UI.events.triggerEvent(new ShowRenamePanelEvent(0)));
         type("Open issues");
         PanelNameTextField renameTextField3 = find("#dummy/dummy_col0_renameTextField");
         assertEquals("Open issues", renameTextField3.getText());
-        push(KeyCode.ENTER);
+        pushKeys(KeyCode.ENTER);
 
         // Make a new board
         click("Boards");

--- a/src/test/java/guitests/WrongLastViewedTest.java
+++ b/src/test/java/guitests/WrongLastViewedTest.java
@@ -9,6 +9,7 @@ import prefs.GlobalConfig;
 import prefs.Preferences;
 import ui.UI;
 import ui.components.StatusUIStub;
+import util.events.EventDispatcherStub;
 
 import java.util.concurrent.ExecutionException;
 
@@ -23,7 +24,9 @@ public class WrongLastViewedTest extends UITest {
 
     @Override
     public void setupMethod() {
-        UI.status = new StatusUIStub(); // to avoid NPE
+        UI.status = new StatusUIStub();
+        UI.events = new EventDispatcherStub();
+
         // setup test json with last viewed repo "test/test"
         // but we create a repo json file for "test2/test2" instead and see if it gets loaded
         ConfigFileHandler configFileHandler =


### PR DESCRIPTION
Addresses #952 and #900. General fixes for test nondeterminism.

- Sometimes key press commands in tests get delayed, causing hundreds of key press events to be registered (happened in #925, detailed in TestFx/TestFx#43). This adds a few methods for pressing keys (and `KeyCodeCombination`s!) without delays, which seems to fix this problem. Ran `UseGlobalConfigsTest` 20 times and it failed only once (JVM crash). Method names need feedback.
- Removes `--continue` flag for CI tests, so they fail as soon as one fails
- Various test fixes