### PR TITLE
updated-others missing issues #997

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -108,8 +108,6 @@ This will not work for ambiguous expressions (containing OR or NOT operators) an
 - [`is`](#is)
 - [`created`](#created)
 - [`updated`](#updated)
-- [`updated-others`](#updated-others)
-- [`updated-self`](#updated-self)
 - [`repo`](#repo)
 - [`sort`](#sort)
 
@@ -223,18 +221,6 @@ Matches issues which were created on a given date, or within a given date range.
 *Expects a number or  number range*
 
 Matches issues which were updated in the given number of hours. For example, `updated:<24` would match issues updated in the last day. If a number `n` is given, it is implicitly translated to `<n`. Number ranges are written using a relational operator (.e.g `>5`, `<=10`).
-
-### updated-others
-
-*Expects a number or  number range*
-
-Like [`updated`](#updated), but considers only issues updated by others (not the logged in user).
-
-### updated-self
-
-*Expects a number or  number range*
-
-Like [`updated`](#updated), but considers only issues updated by the logged in user.
 
 ### repo
 

--- a/src/main/java/backend/IssueMetadata.java
+++ b/src/main/java/backend/IssueMetadata.java
@@ -24,144 +24,147 @@ public class IssueMetadata {
     // Properties computed from events and comments on instantiation, so we
     // don't have to recompute on querying.
 
+    private final String user;
     private final LocalDateTime nonSelfUpdatedAt;
     private final int nonSelfCommentCount;
 
     private final String eventsETag; // Only modified in the DownloadMetadataTask constructor
     private final String commentsETag;
 
-    // Constructor for default use when initializing TurboIssue
-    public IssueMetadata() {
-        events = new ArrayList<>();
-        comments = new ArrayList<>();
-
-        nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0));
-        nonSelfCommentCount = 0;
-
-        eventsETag = "";
-        commentsETag = "";
-        isLatest = false;
+    /**
+     * Factory method for the empty metadata instance. This is used as the default for
+     * new issues.
+     */
+    public static IssueMetadata empty() {
+        return new IssueMetadata(new ArrayList<>(), new ArrayList<>(), false, "", "");
     }
 
-    // Copy constructor used in TurboIssue
-    public IssueMetadata(IssueMetadata other) {
-        this.events = new ArrayList<>(other.events);
-        this.comments = new ArrayList<>(other.comments);
-
-        this.nonSelfUpdatedAt = other.nonSelfUpdatedAt;
-        this.nonSelfCommentCount  = other.nonSelfCommentCount;
-
-        this.eventsETag = other.eventsETag;
-        this.commentsETag = other.commentsETag;
-        this.isLatest = other.isLatest;
+    /**
+     * Invalidates a metadata instance. This occurs after issue updates are reconciled; in
+     * that case we assume the metadata is no longer the latest.
+     */
+    public IssueMetadata invalidate() {
+        return new IssueMetadata(events, comments, false, eventsETag, commentsETag, user);
     }
 
-    // Copy constructor used in reconciliation
-    public IssueMetadata(IssueMetadata other, boolean isLatest) {
-        this.events = new ArrayList<>(other.events);
-        this.comments = new ArrayList<>(other.comments);
-
-        this.nonSelfUpdatedAt = other.nonSelfUpdatedAt;
-        this.nonSelfCommentCount  = other.nonSelfCommentCount;
-
-        this.eventsETag = other.eventsETag;
-        this.commentsETag = other.commentsETag;
-        this.isLatest = isLatest;
+    /**
+     * Constructs an intermediate metadata instance. Intermediate metadata does not have
+     * computed properties filled in; the name of the current user is required for that.
+     * Intermediate instances are constructed immediately upon download. The current user
+     * is filled in later.
+     */
+    public static IssueMetadata intermediate(List<TurboIssueEvent> events, List<Comment> comments,
+                                             String eventsETag, String commentsETag) {
+        return new IssueMetadata(events, comments, false, eventsETag, commentsETag);
     }
 
-    // Constructor used in DownloadMetadataTask
-    public IssueMetadata(List<TurboIssueEvent> events, List<Comment> comments,
-                         String eventsETag, String commentsETag) {
+    /**
+     * Fills in the current user for an intermediate metadata instance, computing properties
+     * and turning it into a full metadata instance.
+     * May also be used to change the perspective of a full metadata instance, but that's
+     * not very interesting.
+     */
+    public IssueMetadata full(String currentUser) {
+        return new IssueMetadata(events, comments, true, eventsETag, commentsETag, currentUser);
+    }
+
+    /**
+     * Reconciles a newly-updated metadata instance against older data.
+     */
+    public IssueMetadata reconcile(LocalDateTime nonSelfUpdatedAt,
+                                   List<TurboIssueEvent> existingEvents, String existingETag) {
+        List<TurboIssueEvent> newEvents;
+        if (existingETag.equals(eventsETag)) {
+            newEvents = new ArrayList<>(existingEvents);
+        } else {
+            newEvents = new ArrayList<>(events);
+        }
+        return new IssueMetadata(newEvents, comments, isLatest, eventsETag, commentsETag, nonSelfUpdatedAt, user);
+    }
+
+    /**
+     * Intermediate metadata constructor (no user provided, empty computed properties)
+     */
+    private IssueMetadata(List<TurboIssueEvent> events, List<Comment> comments,
+                          boolean isLatest, String eventsETag, String commentsETag) {
         this.events = new ArrayList<>(events);
         this.comments = new ArrayList<>(comments);
-
-        this.nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)); // Not calculated yet
-        this.nonSelfCommentCount = 0; // Not calculated yet
-
+        this.isLatest = isLatest;
         this.eventsETag = eventsETag;
         this.commentsETag = commentsETag;
-        this.isLatest = false;
+
+        this.user = "";
+        this.nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0));
+        this.nonSelfCommentCount = 0;
     }
 
-    // Constructor used in Logic
-    public IssueMetadata(IssueMetadata existingMetadata, String currentUser) {
-        Date lastNonSelfUpdate = new Date(0);
-        Date lastSelfUpdate = new Date(0);
-        for (TurboIssueEvent event : existingMetadata.getEvents()) {
-            if (isNewEventByOther(currentUser, event, lastNonSelfUpdate)) {
-                lastNonSelfUpdate = event.getDate();
-            }
-            if (isNewEventBySelf(currentUser, event, lastSelfUpdate)){
-                lastSelfUpdate = event.getDate();
+    /**
+     * Full metadata constructor (user provided, computed properties present)
+     */
+    private IssueMetadata(List<TurboIssueEvent> events, List<Comment> comments,
+                          boolean isLatest, String eventsETag, String commentsETag,
+                          String user) {
+        this(events, comments, isLatest, eventsETag, commentsETag,
+            computeNonSelfUpdatedAt(events, comments, user), user);
+    }
+
+    /**
+     * Full metadata constructor with nonSelfUpdateTime left out
+     */
+    private IssueMetadata(List<TurboIssueEvent> events, List<Comment> comments,
+                          boolean isLatest, String eventsETag, String commentsETag,
+                          LocalDateTime nonSelfUpdatedAt, String user) {
+        this.events = new ArrayList<>(events);
+        this.comments = new ArrayList<>(comments);
+        this.isLatest = isLatest;
+        this.eventsETag = eventsETag;
+        this.commentsETag = commentsETag;
+
+        this.user = user;
+        this.nonSelfUpdatedAt = nonSelfUpdatedAt;
+        this.nonSelfCommentCount = countCommentsByOthers(comments, user);
+    }
+
+    private static LocalDateTime computeNonSelfUpdatedAt(List<TurboIssueEvent> events, List<Comment> comments,
+                                                         String user) {
+        Date result = new Date(0);
+        for (TurboIssueEvent event : events) {
+            if (isEventByOthers(event, user) && event.getDate().after(result)) {
+                result = event.getDate();
             }
         }
-        for (Comment comment : existingMetadata.getComments()) {
-            if (isNewCommentByOther(currentUser, comment, lastNonSelfUpdate)) {
-                lastNonSelfUpdate = comment.getCreatedAt();
-            }
-            if (isNewCommentBySelf(currentUser, comment, lastSelfUpdate)){
-                lastSelfUpdate = comment.getCreatedAt();
+        for (Comment comment : comments) {
+            if (isCommentByOthers(comment, user) && comment.getCreatedAt().after(result)) {
+                result = comment.getCreatedAt();
             }
         }
-
-        this.events = new ArrayList<>(existingMetadata.events);
-        this.comments = new ArrayList<>(existingMetadata.comments);
-        this.nonSelfUpdatedAt = Utility.dateToLocalDateTime(lastNonSelfUpdate);
-        this.nonSelfCommentCount = countCommentsByOthers(existingMetadata.getComments(), currentUser);
-
-        this.eventsETag = existingMetadata.eventsETag;
-        this.commentsETag = existingMetadata.commentsETag;
-        this.isLatest = true;
+        return Utility.dateToLocalDateTime(result);
     }
 
-    private static boolean isNewCommentByOther(String currentUser, Comment comment, Date lastNonSelfUpdate){
-        return !comment.getUser().getLogin().equalsIgnoreCase(currentUser)
-                && comment.getCreatedAt().after(lastNonSelfUpdate);
+    private static boolean isCommentBySelf(Comment comment, String user) {
+        return comment.getUser().getLogin().equalsIgnoreCase(user);
     }
 
-    private static boolean isNewCommentBySelf(String currentUser, Comment comment, Date lastSelfUpdate){
-        return comment.getUser().getLogin().equalsIgnoreCase(currentUser)
-                && comment.getCreatedAt().after(lastSelfUpdate);
+    private static boolean isCommentByOthers(Comment comment, String user) {
+        return !isCommentBySelf(comment, user);
     }
 
-    private static boolean isNewEventBySelf(String currentUser, TurboIssueEvent event, Date lastSelfUpdate){
-        return event.getActor().getLogin().equalsIgnoreCase(currentUser)
-                && event.getDate().after(lastSelfUpdate);
+    private static int countCommentsBySelf(List<Comment> comments, String user) {
+        return Utility.safeLongToInt((comments.stream()
+            .filter(c -> isCommentBySelf(c, user))
+            .count()));
     }
 
-    private static boolean isNewEventByOther(String currentUser, TurboIssueEvent event, Date lastNonSelfUpdate){
-        return !event.getActor().getLogin().equalsIgnoreCase(currentUser)
-                && event.getDate().after(lastNonSelfUpdate);
+    private static boolean isEventBySelf(TurboIssueEvent event, String user) {
+        return event.getActor().getLogin().equalsIgnoreCase(user);
+    }
+
+    private static boolean isEventByOthers(TurboIssueEvent event, String user) {
+        return !isEventBySelf(event, user);
     }
 
     private static int countCommentsByOthers(List<Comment> comments, String user) {
         return comments.size() - countCommentsBySelf(comments, user);
-    }
-
-    private static int countCommentsBySelf(List<Comment> comments, String user) {
-        return Utility.safeLongToInt((comments.stream().filter(c -> isCommentBySelf(user, c)).count()));
-    }
-
-    private static boolean isCommentBySelf(String currentUser, Comment comment){
-        return comment.getUser().getLogin().equalsIgnoreCase(currentUser);
-    }
-
-    // Constructor used in MultiModel
-    public IssueMetadata(IssueMetadata other, LocalDateTime nonSelfUpdatedAt,
-                         List<TurboIssueEvent> currEvents, String currEventsETag) {
-        if (currEventsETag.equals(other.eventsETag)) {
-            events = new ArrayList<>(currEvents);
-        } else {
-            events = new ArrayList<>(other.events);
-        }
-        this.comments = new ArrayList<>(other.comments);
-
-        this.nonSelfUpdatedAt = nonSelfUpdatedAt; // After creation date reconciliation
-        this.nonSelfCommentCount  = other.nonSelfCommentCount;
-
-        this.eventsETag = currEventsETag;
-        this.commentsETag = other.commentsETag;
-        this.isLatest = other.isLatest;
     }
 
     public String summarise() {

--- a/src/main/java/backend/IssueMetadata.java
+++ b/src/main/java/backend/IssueMetadata.java
@@ -72,8 +72,8 @@ public class IssueMetadata {
     // Constructor used in DownloadMetadataTask
     public IssueMetadata(List<TurboIssueEvent> events, List<Comment> comments,
                          String eventsETag, String commentsETag) {
-        this.events = events;
-        this.comments = comments;
+        this.events = new ArrayList<>(events);
+        this.comments = new ArrayList<>(comments);
 
         this.nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)); // Not calculated yet
         this.nonSelfCommentCount = 0; // Not calculated yet
@@ -159,7 +159,7 @@ public class IssueMetadata {
         this.nonSelfUpdatedAt = nonSelfUpdatedAt; // After creation date reconciliation
         this.nonSelfCommentCount  = other.nonSelfCommentCount;
 
-        this.eventsETag = other.eventsETag;
+        this.eventsETag = currEventsETag;
         this.commentsETag = other.commentsETag;
         this.isLatest = other.isLatest;
     }

--- a/src/main/java/backend/IssueMetadata.java
+++ b/src/main/java/backend/IssueMetadata.java
@@ -25,15 +25,7 @@ public class IssueMetadata {
     // don't have to recompute on querying.
 
     private final LocalDateTime nonSelfUpdatedAt;
-    private final LocalDateTime selfUpdatedAt;
     private final int nonSelfCommentCount;
-    private final int selfCommentCount;
-    private final boolean isUpdatedBySelf;
-    private final boolean isUpdatedByOthers;
-
-    private enum UpdatedKind {
-        UPDATED_BY_SELF, UPDATED_BY_OTHER
-    }
 
     private final String eventsETag; // Only modified in the DownloadMetadataTask constructor
     private final String commentsETag;
@@ -44,11 +36,7 @@ public class IssueMetadata {
         comments = new ArrayList<>();
 
         nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0));
-        selfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0));
         nonSelfCommentCount = 0;
-        selfCommentCount = 0;
-        isUpdatedByOthers = false;
-        isUpdatedBySelf = false;
 
         eventsETag = "";
         commentsETag = "";
@@ -61,11 +49,7 @@ public class IssueMetadata {
         this.comments = new ArrayList<>(other.comments);
 
         this.nonSelfUpdatedAt = other.nonSelfUpdatedAt;
-        this.selfUpdatedAt = other.selfUpdatedAt;
         this.nonSelfCommentCount  = other.nonSelfCommentCount;
-        this.selfCommentCount = other.selfCommentCount;
-        this.isUpdatedByOthers = other.isUpdatedByOthers;
-        this.isUpdatedBySelf = other.isUpdatedBySelf;
 
         this.eventsETag = other.eventsETag;
         this.commentsETag = other.commentsETag;
@@ -78,11 +62,7 @@ public class IssueMetadata {
         this.comments = new ArrayList<>(other.comments);
 
         this.nonSelfUpdatedAt = other.nonSelfUpdatedAt;
-        this.selfUpdatedAt = other.selfUpdatedAt;
         this.nonSelfCommentCount  = other.nonSelfCommentCount;
-        this.selfCommentCount  = other.selfCommentCount;
-        this.isUpdatedByOthers = other.isUpdatedByOthers;
-        this.isUpdatedBySelf = other.isUpdatedBySelf;
 
         this.eventsETag = other.eventsETag;
         this.commentsETag = other.commentsETag;
@@ -96,11 +76,7 @@ public class IssueMetadata {
         this.comments = comments;
 
         this.nonSelfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)); // Not calculated yet
-        this.selfUpdatedAt = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)); // Not calculated yet
         this.nonSelfCommentCount = 0; // Not calculated yet
-        this.selfCommentCount = 0; // Not calculated yet
-        this.isUpdatedByOthers = false;
-        this.isUpdatedBySelf = false;
 
         this.eventsETag = eventsETag;
         this.commentsETag = commentsETag;
@@ -111,39 +87,27 @@ public class IssueMetadata {
     public IssueMetadata(IssueMetadata existingMetadata, String currentUser) {
         Date lastNonSelfUpdate = new Date(0);
         Date lastSelfUpdate = new Date(0);
-        boolean isUpdatedByOthers = false;
-        boolean isUpdatedBySelf = false;
         for (TurboIssueEvent event : existingMetadata.getEvents()) {
             if (isNewEventByOther(currentUser, event, lastNonSelfUpdate)) {
                 lastNonSelfUpdate = event.getDate();
-                isUpdatedByOthers = true;
             }
             if (isNewEventBySelf(currentUser, event, lastSelfUpdate)){
                 lastSelfUpdate = event.getDate();
-                isUpdatedBySelf = true;
             }
         }
         for (Comment comment : existingMetadata.getComments()) {
             if (isNewCommentByOther(currentUser, comment, lastNonSelfUpdate)) {
                 lastNonSelfUpdate = comment.getCreatedAt();
-                isUpdatedByOthers = true;
             }
             if (isNewCommentBySelf(currentUser, comment, lastSelfUpdate)){
                 lastSelfUpdate = comment.getCreatedAt();
-                isUpdatedBySelf = true;
             }
         }
 
         this.events = new ArrayList<>(existingMetadata.events);
         this.comments = new ArrayList<>(existingMetadata.comments);
         this.nonSelfUpdatedAt = Utility.dateToLocalDateTime(lastNonSelfUpdate);
-        this.selfUpdatedAt = Utility.dateToLocalDateTime(lastSelfUpdate);
-        this.nonSelfCommentCount = calculateCommentCount(existingMetadata.getComments(), currentUser,
-                UpdatedKind.UPDATED_BY_OTHER);
-        this.selfCommentCount = calculateCommentCount(existingMetadata.getComments(), currentUser,
-                UpdatedKind.UPDATED_BY_SELF);
-        this.isUpdatedByOthers = isUpdatedByOthers;
-        this.isUpdatedBySelf = isUpdatedBySelf;
+        this.nonSelfCommentCount = countCommentsByOthers(existingMetadata.getComments(), currentUser);
 
         this.eventsETag = existingMetadata.eventsETag;
         this.commentsETag = existingMetadata.commentsETag;
@@ -170,14 +134,12 @@ public class IssueMetadata {
                 && event.getDate().after(lastNonSelfUpdate);
     }
 
-    private static int calculateCommentCount(List<Comment> comments, String currentUser, UpdatedKind updatedKind) {
-        int result = 0;
-        if (updatedKind == UpdatedKind.UPDATED_BY_OTHER) {
-            return Utility.safeLongToInt((comments.stream().filter(c -> !isCommentBySelf(currentUser, c)).count()));
-        } else if (updatedKind == UpdatedKind.UPDATED_BY_SELF){
-            return Utility.safeLongToInt((comments.stream().filter(c -> isCommentBySelf(currentUser, c)).count()));
-        }
-        return result;
+    private static int countCommentsByOthers(List<Comment> comments, String user) {
+        return comments.size() - countCommentsBySelf(comments, user);
+    }
+
+    private static int countCommentsBySelf(List<Comment> comments, String user) {
+        return Utility.safeLongToInt((comments.stream().filter(c -> isCommentBySelf(user, c)).count()));
     }
 
     private static boolean isCommentBySelf(String currentUser, Comment comment){
@@ -195,35 +157,11 @@ public class IssueMetadata {
         this.comments = new ArrayList<>(other.comments);
 
         this.nonSelfUpdatedAt = nonSelfUpdatedAt; // After creation date reconciliation
-        this.selfUpdatedAt = other.selfUpdatedAt;
         this.nonSelfCommentCount  = other.nonSelfCommentCount;
-        this.selfCommentCount = other.selfCommentCount;
-        this.isUpdatedBySelf = other.isUpdatedBySelf;
-        this.isUpdatedByOthers = other.isUpdatedByOthers;
 
         this.eventsETag = other.eventsETag;
         this.commentsETag = other.commentsETag;
         this.isLatest = other.isLatest;
-    }
-
-    //Constructor used in FilterEvalTests
-    public IssueMetadata(IssueMetadata other, LocalDateTime nonSelfUpdatedAt, LocalDateTime selfUpdatedAt,
-                         int nonSelfCommentCount, int selfCommentCount,
-                         boolean isUpdatedByOthers, boolean isUpdatedBySelf,
-                         boolean isLatest) {
-        this.events = new ArrayList<>(other.events);
-        this.comments = new ArrayList<>(other.comments);
-
-        this.nonSelfUpdatedAt = nonSelfUpdatedAt; // Calculated just prior to calling this constructor
-        this.selfUpdatedAt = selfUpdatedAt;
-        this.nonSelfCommentCount = nonSelfCommentCount;
-        this.selfCommentCount = selfCommentCount;
-        this.isUpdatedBySelf = isUpdatedBySelf;
-        this.isUpdatedByOthers = isUpdatedByOthers;
-
-        this.eventsETag = "";
-        this.commentsETag = "";
-        this.isLatest = isLatest;
     }
 
     public String summarise() {
@@ -246,24 +184,8 @@ public class IssueMetadata {
         return nonSelfUpdatedAt;
     }
 
-    public LocalDateTime getSelfUpdatedAt() {
-        return selfUpdatedAt;
-    }
-
     public int getNonSelfCommentCount() {
         return nonSelfCommentCount;
-    }
-
-    public int getSelfCommentCount() {
-        return selfCommentCount;
-    }
-
-    public boolean isUpdatedByOthers() {
-        return isUpdatedByOthers;
-    }
-
-    public boolean isUpdatedBySelf() {
-        return isUpdatedBySelf;
     }
 
     public String getEventsETag() {

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -153,7 +153,7 @@ public class Logic {
         for (Map.Entry<Integer, IssueMetadata> entry : metadata.entrySet()) {
             IssueMetadata currentMetadata = entry.getValue();
 
-            entry.setValue(new IssueMetadata(currentMetadata, currentUser));
+            entry.setValue(currentMetadata.full(currentUser));
         }
         return metadata;
     }

--- a/src/main/java/backend/github/DownloadMetadataTask.java
+++ b/src/main/java/backend/github/DownloadMetadataTask.java
@@ -46,7 +46,7 @@ public class DownloadMetadataTask extends GitHubRepoTask<Map<Integer, IssueMetad
 
             List<Comment> comments = repo.getComments(repoId, id);
 
-            IssueMetadata metadata = new IssueMetadata(events, comments, updatedEventsETag, currCommentsETag);
+            IssueMetadata metadata = IssueMetadata.intermediate(events, comments, updatedEventsETag, currCommentsETag);
             result.put(id, metadata);
         });
 

--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -87,8 +87,8 @@ public class MultiModel implements IModel {
                 // TODO move ETag comparison here when comments ETag implementation is complete.
                 LocalDateTime nonSelfUpdatedAt = reconcileCreationDate(toBeInserted.getNonSelfUpdatedAt(),
                         issue.getCreatedAt(), currentUser, issue.getCreator());
-                issue.setMetadata(new IssueMetadata(toBeInserted, nonSelfUpdatedAt,
-                        issue.getMetadata().getEvents(), issue.getMetadata().getEventsETag()));
+                issue.setMetadata(toBeInserted.reconcile(nonSelfUpdatedAt,
+                    issue.getMetadata().getEvents(), issue.getMetadata().getEventsETag()));
             }
         });
     }

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -109,7 +109,7 @@ public class TurboIssue {
         this.labels = new ArrayList<>(issue.labels);
         this.milestone = issue.milestone;
 
-        this.metadata = new IssueMetadata(issue.metadata);
+        this.metadata = issue.metadata;
         this.repoId = issue.repoId;
         this.markedReadAt = issue.markedReadAt;
     }
@@ -140,7 +140,7 @@ public class TurboIssue {
             ? Optional.empty()
             : Optional.of(issue.getMilestone().getNumber());
 
-        this.metadata = new IssueMetadata();
+        this.metadata = IssueMetadata.empty();
         this.repoId = repoId;
         this.markedReadAt = Optional.empty();
     }
@@ -160,7 +160,7 @@ public class TurboIssue {
         this.labels = issue.getLabels();
         this.milestone = issue.getMilestone();
 
-        this.metadata = new IssueMetadata();
+        this.metadata = IssueMetadata.empty();
         this.repoId = repoId;
         this.markedReadAt = Optional.empty();
     }
@@ -182,7 +182,7 @@ public class TurboIssue {
         this.labels = new ArrayList<>();
         this.milestone = Optional.empty();
 
-        this.metadata = new IssueMetadata();
+        this.metadata = IssueMetadata.empty();
         this.markedReadAt = Optional.empty();
     }
 
@@ -194,7 +194,7 @@ public class TurboIssue {
      * @param fromIssue
      */
     private void transferTransientState(TurboIssue fromIssue) {
-        this.metadata = new IssueMetadata(fromIssue.metadata, false);
+        this.metadata = fromIssue.metadata.invalidate();
         this.markedReadAt = fromIssue.markedReadAt;
     }
 

--- a/src/main/java/backend/stub/DummyRepoState.java
+++ b/src/main/java/backend/stub/DummyRepoState.java
@@ -104,7 +104,7 @@ public class DummyRepoState {
         Comment[] ownComments = { ownComment };
         issues.get(9).setCommentCount(1);
         issues.get(9).setUpdatedAt(LocalDateTime.now());
-        issueMetadata.put(9, new IssueMetadata(
+        issueMetadata.put(9, IssueMetadata.intermediate(
                 new ArrayList<>(),
                 new ArrayList<>(Arrays.asList(ownComments)),
                 "", ""
@@ -124,7 +124,7 @@ public class DummyRepoState {
         Comment[] dummyComments = { dummyComment1, dummyComment2, dummyComment3 };
         issues.get(10).setCommentCount(3);
         issues.get(10).setUpdatedAt(LocalDateTime.now());
-        issueMetadata.put(10, new IssueMetadata(
+        issueMetadata.put(10, IssueMetadata.intermediate(
                 new ArrayList<>(),
                 new ArrayList<>(Arrays.asList(dummyComments)),
                 "", ""
@@ -290,7 +290,7 @@ public class DummyRepoState {
         toRename.setUpdatedAt(LocalDateTime.now());
 
         // Replace originals with copies, and queue them up to be retrieved
-        markUpdatedEvents(toRename, new IssueMetadata(eventsOfIssue, metadataOfIssue.getComments(), "", ""));
+        markUpdatedEvents(toRename, IssueMetadata.intermediate(eventsOfIssue, metadataOfIssue.getComments(), "", ""));
 
         return toRename;
     }
@@ -359,7 +359,7 @@ public class DummyRepoState {
         toSet.setUpdatedAt(LocalDateTime.now());
 
         // Replace originals with copies, and queue them up to be retrieved
-        markUpdatedEvents(toSet, new IssueMetadata(eventsOfIssue, metadataOfIssue.getComments(), "", ""));
+        markUpdatedEvents(toSet, IssueMetadata.intermediate(eventsOfIssue, metadataOfIssue.getComments(), "", ""));
 
         return labels.stream().map(new Label()::setName).collect(Collectors.toList());
     }
@@ -381,7 +381,8 @@ public class DummyRepoState {
         toComment.setCommentCount(toComment.getCommentCount() + 1);
 
         // Replace originals with copies, and queue them up to be retrieved
-        markUpdatedComments(toComment, new IssueMetadata(metadataOfIssue.getEvents(), commentsOfIssue, "", ""));
+        markUpdatedComments(toComment,
+            IssueMetadata.intermediate(metadataOfIssue.getEvents(), commentsOfIssue, "", ""));
 
         return toComment;
     }
@@ -404,7 +405,7 @@ public class DummyRepoState {
                 metadataOfIssue.getComments() :
                 new ArrayList<>();
 
-        return new ImmutablePair<>(toMutate, new IssueMetadata(eventsOfIssue, commentsOfIssue, "", ""));
+        return new ImmutablePair<>(toMutate, IssueMetadata.intermediate(eventsOfIssue, commentsOfIssue, "", ""));
     }
 
     /**

--- a/src/test/java/guitests/MetadataUpdateTest.java
+++ b/src/test/java/guitests/MetadataUpdateTest.java
@@ -13,6 +13,7 @@ import util.events.testevents.UpdateDummyRepoEvent;
 
 public class MetadataUpdateTest extends UITest {
 
+    @Test
     public void testUpdatedTriggersMetadata() {
         resetRepo();
 
@@ -23,40 +24,6 @@ public class MetadataUpdateTest extends UITest {
         TestUtils.awaitCondition(() ->
             findQuiet("1 comments since, involving test.").isPresent());
         assertTrue(findQuiet("2 comments since, involving User 1, User 2.").isPresent());
-    }
-
-    @Test
-    public void testUpdatedOthersTriggersMetadata() {
-
-        // updated-others doesn't work without metadata, so do everything we did in updated first
-        testUpdatedTriggersMetadata();
-
-        // Put a non-self comment on issue 10
-        UI.events.triggerEvent(UpdateDummyRepoEvent.addComment("dummy/dummy", 10, "Test comment", "test-nonself"));
-
-        updated24("updated-others");
-        ensureMetadataDownloadIsTriggered();
-        ensureMetadataIsReceived();
-
-        TestUtils.awaitCondition(() ->
-            findQuiet("3 comments since, involving User 1, User 2, test-nonself.").isPresent());
-    }
-
-    @Test
-    public void testUpdatedSelfTriggersMetadata() {
-
-        // updated-self doesn't work without metadata, so do everything we did in updated first
-        testUpdatedTriggersMetadata();
-
-        // Put a self comment on issue 9
-        UI.events.triggerEvent(UpdateDummyRepoEvent.addComment("dummy/dummy", 9, "Test comment", "test"));
-
-        updated24("updated-self");
-        ensureMetadataDownloadIsTriggered();
-        ensureMetadataIsReceived();
-
-        TestUtils.awaitCondition(() ->
-            findQuiet("2 comments since, involving test.").isPresent());
     }
 
     private void ensureMetadataDownloadIsTriggered() {

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 
-import backend.IssueMetadata;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -436,44 +435,6 @@ public class FilterEvalTests {
     }
 
     @Test
-    public void updatedBySelfAndOther(){
-        LocalDateTime now = LocalDateTime.now();
-        Qualifier.setCurrentTime(now);
-        TurboIssue issueUpdated = new TurboIssue(REPO, 1, "");
-        IssueMetadata updatedByOtherMetadata = new IssueMetadata(issueUpdated.getMetadata(), now.minusHours(4),
-                now.minusHours(4), 2, 2, true, false); //UpdatedByOther true with updated time 4 hours ago.
-        issueUpdated.setMetadata(updatedByOtherMetadata);
-        assertEquals(false, matches("updated-others:<2", issueUpdated));
-        assertEquals(false, matches("updated-self:<2", issueUpdated));
-        assertEquals(true, matches("updated-others:<=4", issueUpdated));
-        assertEquals(false, matches("updated-self:<=4", issueUpdated));
-
-        IssueMetadata updatedBySelfAndOtherMetadata = new IssueMetadata(issueUpdated.getMetadata(), now.minusHours(4),
-                now.minusHours(4), 2, 2, true, true); //UpdatedByOther and UpdatedBySelf true with updated time 4 hours.
-        issueUpdated.setMetadata(updatedBySelfAndOtherMetadata);
-        assertEquals(false, matches("updated-others:<2", issueUpdated));
-        assertEquals(false, matches("updated-self:<2", issueUpdated));
-        assertEquals(true, matches("updated-others:<=4", issueUpdated));
-        assertEquals(true, matches("updated-self:<=4", issueUpdated));
-
-        IssueMetadata updatedBySelfMetadata = new IssueMetadata(issueUpdated.getMetadata(), now.minusHours(4),
-                now.minusHours(4), 2, 2, false, true); //UpdatedBySelf true with updated time 4 hours ago.
-        issueUpdated.setMetadata(updatedBySelfMetadata);
-        assertEquals(false, matches("updated-others:<2", issueUpdated));
-        assertEquals(false, matches("updated-self:<2", issueUpdated));
-        assertEquals(false, matches("updated-others:<=4", issueUpdated));
-        assertEquals(true, matches("updated-self:<=4", issueUpdated));
-
-        IssueMetadata updatedByNoneMetadata = new IssueMetadata(issueUpdated.getMetadata(), now.minusHours(4),
-                now.minusHours(4), 2, 2, false, false); //UpdatedBySelf and UpdatedByOthers both false.
-        issueUpdated.setMetadata(updatedByNoneMetadata);
-        assertEquals(false, matches("updated-others:<2", issueUpdated));
-        assertEquals(false, matches("updated-self:<2", issueUpdated));
-        assertEquals(false, matches("updated-others:<=4", issueUpdated));
-        assertEquals(false, matches("updated-self:<=4", issueUpdated));
-    }
-
-    @Test
     public void updated() {
         LocalDateTime now = LocalDateTime.now();
         Qualifier.setCurrentTime(now);
@@ -484,7 +445,6 @@ public class FilterEvalTests {
         assertEquals(false, matches("updated:<24", issue));
         assertEquals(matches("updated:<24", issue),
             matches("updated:24", issue));
-        System.out.println(issue.getUpdatedAt());
         assertEquals(true, matches("updated:>24", issue));
         assertEquals(false, matches("updated:nondate", issue));
 

--- a/src/test/java/tests/FilterParserTests.java
+++ b/src/test/java/tests/FilterParserTests.java
@@ -358,11 +358,6 @@ public class FilterParserTests {
             "updated:<24",
             "updated:<=24",
             "updated:24",
-            "updatedByOthers:>24", // Number ranges
-            "updatedByOthers:>=24",
-            "updatedByOthers:<24",
-            "updatedByOthers:<=24",
-            "updatedByOthers:24",
             "created:<=2014-12-4", // Date operators
             "created:>=2014-12-4",
             "created:<2014-12-4",

--- a/src/test/java/tests/IssueMetadataTests.java
+++ b/src/test/java/tests/IssueMetadataTests.java
@@ -1,0 +1,164 @@
+package tests;
+
+import static junit.framework.Assert.assertEquals;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.eclipse.egit.github.core.Comment;
+import org.eclipse.egit.github.core.User;
+import org.junit.Test;
+
+import backend.IssueMetadata;
+import github.IssueEventType;
+import github.TurboIssueEvent;
+import util.Utility;
+
+public class IssueMetadataTests {
+
+    @Test
+    public void immutability() {
+        List<TurboIssueEvent> events = stubEvents();
+        List<Comment> comments = stubComments();
+
+        IssueMetadata metadata = new IssueMetadata(events, comments, "", "");
+        assertEquals(3, metadata.getEvents().size());
+        assertEquals(3, metadata.getComments().size());
+
+        events.addAll(stubEvents());
+        comments.addAll(stubComments());
+
+        assertEquals(3, metadata.getEvents().size());
+        assertEquals(3, metadata.getComments().size());
+
+        metadata.getEvents().addAll(stubEvents());
+        metadata.getComments().addAll(stubComments());
+
+        assertEquals(3, metadata.getEvents().size());
+        assertEquals(3, metadata.getComments().size());
+    }
+
+    @Test
+    public void empty() {
+        IssueMetadata empty = new IssueMetadata();
+        assertEquals(new ArrayList<TurboIssueEvent>(), empty.getEvents());
+        assertEquals(new ArrayList<Comment>(), empty.getComments());
+        assertEquals(LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)), empty.getNonSelfUpdatedAt());
+        assertEquals(0, empty.getNonSelfCommentCount());
+        assertEquals("", empty.getEventsETag());
+        assertEquals("", empty.getCommentsETag());
+        assertEquals(false, empty.isLatest());
+    }
+
+    @Test
+    public void invalidation() {
+        IssueMetadata empty = new IssueMetadata();
+        IssueMetadata trueMetadata = new IssueMetadata(empty, true);
+        assertEquals(true, trueMetadata.isLatest());
+    }
+
+    @Test
+    public void intermediate() {
+        IssueMetadata metadata = new IssueMetadata(stubEvents(), stubComments(), "events", "comments");
+        assertEquals(3, metadata.getEvents().size());
+        assertEquals(3, metadata.getComments().size());
+        assertEquals("events", metadata.getEventsETag());
+        assertEquals("comments", metadata.getCommentsETag());
+
+        // Computed properties are empty
+        assertEquals(LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)), metadata.getNonSelfUpdatedAt());
+        assertEquals(0, metadata.getNonSelfCommentCount());
+    }
+
+    @Test
+    public void computed() {
+        IssueMetadata original = new IssueMetadata(stubEvents(), stubComments(), "events", "comments");
+
+        // Computed properties are empty
+        assertEquals(LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.ofHours(0)), original.getNonSelfUpdatedAt());
+        assertEquals(0, original.getNonSelfCommentCount());
+
+        // They are no longer empty
+        IssueMetadata computed = new IssueMetadata(original, "test");
+        assertEquals(Utility.dateToLocalDateTime(now), computed.getNonSelfUpdatedAt());
+        assertEquals(2, computed.getNonSelfCommentCount());
+    }
+
+    @Test
+    public void update() {
+//        public IssueMetadata(IssueMetadata other, LocalDateTime nonSelfUpdatedAt,
+//            List<TurboIssueEvent> currEvents, String currEventsETag) {
+
+        List<TurboIssueEvent> originalEvents = stubEvents();
+        List<Comment> originalComments = stubComments();
+
+        IssueMetadata original = new IssueMetadata(originalEvents, originalComments, "events", "comments");
+        IssueMetadata derived = new IssueMetadata(original, "test");
+
+        assertEquals(originalEvents, derived.getEvents());
+        assertEquals(originalComments, derived.getComments());
+        assertEquals("events", derived.getEventsETag());
+        assertEquals("comments", derived.getCommentsETag());
+
+        // Computed properties are non-empty
+        assertEquals(Utility.dateToLocalDateTime(now), derived.getNonSelfUpdatedAt());
+        assertEquals(2, derived.getNonSelfCommentCount());
+
+        LocalDateTime rightNow = LocalDateTime.now();
+
+        // Failed update
+        List<TurboIssueEvent> newEvents = stubEvents();
+        IssueMetadata updated = new IssueMetadata(derived, rightNow, newEvents, "events2");
+
+        assertEquals(originalEvents, updated.getEvents());
+        assertEquals(originalComments, updated.getComments());
+        assertEquals("events2", updated.getEventsETag());
+        assertEquals("comments", updated.getCommentsETag());
+
+        // Successful update
+        updated = new IssueMetadata(derived, rightNow, newEvents, "events");
+
+        assertEquals(newEvents, updated.getEvents());
+        assertEquals(originalComments, updated.getComments());
+        assertEquals("events", updated.getEventsETag());
+        assertEquals("comments", updated.getCommentsETag());
+    }
+
+    private static final Date now = new Date();
+
+    private static List<TurboIssueEvent> stubEvents() {
+        List<TurboIssueEvent> events = new ArrayList<>();
+        events.add(new TurboIssueEvent(new User().setLogin("test"), IssueEventType.Closed, now));
+        events.add(new TurboIssueEvent(new User().setLogin("test-nonself"), IssueEventType.Closed, now));
+        events.add(new TurboIssueEvent(new User().setLogin("test-nonself"), IssueEventType.Assigned, now));
+        return events;
+    }
+
+    private static List<Comment> stubComments() {
+        List<Comment> comments = new ArrayList<>();
+
+        Comment comment = new Comment();
+        comment.setBody("hello");
+        comment.setUser(new User().setLogin("test"));
+        comment.setCreatedAt(now);
+        comments.add(comment);
+
+        comment = new Comment();
+        comment.setBody("not by me");
+        comment.setUser(new User().setLogin("test-nonself"));
+        comment.setCreatedAt(now);
+        comments.add(comment);
+
+        comment = new Comment();
+        comment.setBody("not by me 2");
+        comment.setUser(new User().setLogin("test-nonself"));
+        comment.setCreatedAt(now);
+        comments.add(comment);
+
+        return comments;
+    }
+
+}


### PR DESCRIPTION
Fixes #997. Disables the new qualifiers.

I'm reverting #924 and #993 here, but keeping the useful parts. This should bring us back to before both were implemented. We can then focus on redesigning how `updated` is done, then selectively revert parts of *this* PR and put the functionality back in.

Also taking the chance to redesign IssueMetadata while things aren't so messy.