### PR TITLE
The 'updated' filter does not consider comments on the diff of PRs

### DIFF
--- a/src/main/java/backend/github/DownloadMetadataTask.java
+++ b/src/main/java/backend/github/DownloadMetadataTask.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.egit.github.core.Comment;
 import util.HTLog;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,7 @@ public class DownloadMetadataTask extends GitHubRepoTask<Map<Integer, IssueMetad
             List<TurboIssueEvent> events = changes.getLeft();
             String updatedEventsETag = changes.getRight();
 
-            List<Comment> comments = repo.getComments(repoId, id);
+            List<Comment> comments = repo.getAllComments(repoId, issue);
 
             IssueMetadata metadata = IssueMetadata.intermediate(events, comments, updatedEventsETag, currCommentsETag);
             result.put(id, metadata);

--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -8,39 +8,25 @@ import backend.resource.TurboMilestone;
 import backend.resource.TurboUser;
 import github.*;
 import github.update.*;
-
-import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.egit.github.core.Comment;
-import org.eclipse.egit.github.core.Issue;
-import org.eclipse.egit.github.core.Label;
-import org.eclipse.egit.github.core.RepositoryId;
-import org.eclipse.egit.github.core.client.GitHubRequest;
-import org.eclipse.egit.github.core.client.NoSuchPageException;
-import org.eclipse.egit.github.core.client.PageIterator;
-import org.eclipse.egit.github.core.client.PagedRequest;
-import org.eclipse.egit.github.core.client.RequestException;
+import org.eclipse.egit.github.core.*;
+import org.eclipse.egit.github.core.client.*;
 import org.eclipse.egit.github.core.service.CollaboratorService;
 import org.eclipse.egit.github.core.service.IssueService;
 import org.eclipse.egit.github.core.service.MilestoneService;
-
 import ui.UI;
 import util.HTLog;
 import util.events.UpdateProgressEvent;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
 
 public class GitHubRepo implements Repo {
 
@@ -48,6 +34,7 @@ public class GitHubRepo implements Repo {
 
     private final GitHubClientEx client = new GitHubClientEx();
     private final IssueServiceEx issueService = new IssueServiceEx(client);
+    private final PullRequestServiceEx pullRequestService = new PullRequestServiceEx();
     private final CollaboratorService collaboratorService = new CollaboratorService(client);
     private final LabelServiceEx labelService = new LabelServiceEx(client);
     private final MilestoneService milestoneService = new MilestoneService(client);
@@ -222,6 +209,26 @@ public class GitHubRepo implements Repo {
     public List<Comment> getComments(String repoId, int issueId) {
         try {
             return issueService.getComments(RepositoryId.createFromId(repoId), issueId);
+        } catch (IOException e) {
+            HTLog.error(logger, e);
+            return new ArrayList<>();
+        }
+    }
+
+    public List<ReviewComment> getReviewComments(String repoId, int pullRequestId) {
+        try {
+            return pullRequestService.getReviewComments(RepositoryId.createFromId(repoId),
+                                                        pullRequestId);
+        } catch (IOException e) {
+            HTLog.error(logger, e);
+            return new ArrayList<>();
+        }
+    }
+
+    public List<CommitComment> getCommitComments(String repoId, int pullRequestId) {
+        try {
+            return pullRequestService.getComments(RepositoryId.createFromId(repoId),
+                                                  pullRequestId);
         } catch (IOException e) {
             HTLog.error(logger, e);
             return new ArrayList<>();

--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -215,6 +215,7 @@ public class GitHubRepo implements Repo {
         }
     }
 
+    @Override
     public List<ReviewComment> getReviewComments(String repoId, int pullRequestId) {
         try {
             return pullRequestService.getReviewComments(RepositoryId.createFromId(repoId),
@@ -225,6 +226,7 @@ public class GitHubRepo implements Repo {
         }
     }
 
+    @Override
     public List<CommitComment> getCommitComments(String repoId, int pullRequestId) {
         try {
             return pullRequestService.getComments(RepositoryId.createFromId(repoId),
@@ -233,6 +235,26 @@ public class GitHubRepo implements Repo {
             HTLog.error(logger, e);
             return new ArrayList<>();
         }
+    }
+
+    /**
+     * Get all types of comments for an issue. Review comments and commit comments
+     * are only relevant if the issue is a also pull request
+     * @param repoId
+     * @param issue
+     * @return list of comments for an issue
+     */
+    @Override
+    public List<Comment> getAllComments(String repoId, TurboIssue issue) {
+        List<Comment> result = new ArrayList<>();
+
+        result.addAll(getComments(repoId, issue.getId()));
+        if (issue.isPullRequest()) {
+            result.addAll(getReviewComments(repoId, issue.getId()));
+            result.addAll(getCommitComments(repoId, issue.getId()));
+        }
+
+        return result;
     }
 
     @Override

--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -232,17 +232,6 @@ public class GitHubRepo implements Repo {
         }
     }
 
-    @Override
-    public List<CommitComment> getCommitComments(String repoId, int pullRequestId) {
-        try {
-            return pullRequestService.getComments(RepositoryId.createFromId(repoId),
-                                                  pullRequestId);
-        } catch (IOException e) {
-            HTLog.error(logger, e);
-            return new ArrayList<>();
-        }
-    }
-
     /**
      * Get all types of comments for an issue. Review comments and commit comments
      * are only relevant if the issue is a also pull request
@@ -257,7 +246,6 @@ public class GitHubRepo implements Repo {
         result.addAll(getComments(repoId, issue.getId()));
         if (issue.isPullRequest()) {
             result.addAll(getReviewComments(repoId, issue.getId()));
-            result.addAll(getCommitComments(repoId, issue.getId()));
         }
 
         return result;

--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -72,6 +72,12 @@ public class GitHubRepo implements Repo {
     }
 
     @Override
+    public List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime) {
+        PullRequestUpdateService updateService = new PullRequestUpdateService(client, eTag, lastCheckTime);
+        return updateService.getUpdatedItems(RepositoryId.createFromId(repoId));
+    }
+
+    @Override
     public ImmutablePair<List<TurboLabel>, String> getUpdatedLabels(String repoId, String eTag) {
         return getUpdatedResource(repoId, eTag, LabelUpdateService::new, TurboLabel::new);
     }

--- a/src/main/java/backend/github/GitHubRepo.java
+++ b/src/main/java/backend/github/GitHubRepo.java
@@ -72,8 +72,8 @@ public class GitHubRepo implements Repo {
     }
 
     @Override
-    public List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime) {
-        PullRequestUpdateService updateService = new PullRequestUpdateService(client, eTag, lastCheckTime);
+    public List<PullRequest> getUpdatedPullRequests(String repoId, Date lastCheckTime) {
+        PullRequestUpdateService updateService = new PullRequestUpdateService(client, lastCheckTime);
         return updateService.getUpdatedItems(RepositoryId.createFromId(repoId));
     }
 

--- a/src/main/java/backend/github/UpdateIssuesTask.java
+++ b/src/main/java/backend/github/UpdateIssuesTask.java
@@ -28,7 +28,7 @@ public class UpdateIssuesTask extends GitHubRepoTask<GitHubRepoTask.Result<Turbo
         ImmutableTriple<List<TurboIssue>, String, Date> changes = repo.getUpdatedIssues(model.getRepoId(),
             model.getUpdateSignature().issuesETag, model.getUpdateSignature().lastCheckTime);
         List<PullRequest> updatedPullRequests = repo.getUpdatedPullRequests(
-                model.getRepoId(), "", model.getUpdateSignature().lastCheckTime);
+                model.getRepoId(), model.getUpdateSignature().lastCheckTime);
 
         List<TurboIssue> existing = model.getIssues();
         List<TurboIssue> updatedIssues = changes.left;

--- a/src/main/java/backend/github/UpdateIssuesTask.java
+++ b/src/main/java/backend/github/UpdateIssuesTask.java
@@ -6,6 +6,7 @@ import backend.resource.Model;
 import backend.resource.TurboIssue;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.egit.github.core.PullRequest;
 import util.HTLog;
 
 import java.util.Date;
@@ -26,16 +27,20 @@ public class UpdateIssuesTask extends GitHubRepoTask<GitHubRepoTask.Result<Turbo
     public void run() {
         ImmutableTriple<List<TurboIssue>, String, Date> changes = repo.getUpdatedIssues(model.getRepoId(),
             model.getUpdateSignature().issuesETag, model.getUpdateSignature().lastCheckTime);
+        List<PullRequest> updatedPullRequests = repo.getUpdatedPullRequests(
+                model.getRepoId(), "", model.getUpdateSignature().lastCheckTime);
 
         List<TurboIssue> existing = model.getIssues();
-        List<TurboIssue> changed = changes.left;
+        List<TurboIssue> updatedIssues = changes.left;
 
         logger.info(HTLog.format(model.getRepoId(), "%s issue(s)) changed%s",
-            changed.size(), changed.isEmpty() ? "" : ": " + changed));
+                updatedIssues.size(), updatedIssues.isEmpty() ? "" : ": " + updatedIssues));
+        logger.info(HTLog.format(model.getRepoId(), "%s pr(s)) changed%s",
+                updatedPullRequests.size(), updatedPullRequests.isEmpty() ? "" : ": " + updatedPullRequests));
 
-        List<TurboIssue> updated = changed.isEmpty()
+        List<TurboIssue> updated = updatedIssues.isEmpty()
             ? existing
-            : TurboIssue.reconcile(model.getRepoId(), existing, changed);
+            : TurboIssue.reconcile(model.getRepoId(), existing, updatedIssues);
 
         response.complete(new Result<>(updated, changes.middle, changes.right));
     }

--- a/src/main/java/backend/github/UpdateIssuesTask.java
+++ b/src/main/java/backend/github/UpdateIssuesTask.java
@@ -41,6 +41,7 @@ public class UpdateIssuesTask extends GitHubRepoTask<GitHubRepoTask.Result<Turbo
         List<TurboIssue> updated = updatedIssues.isEmpty()
             ? existing
             : TurboIssue.reconcile(model.getRepoId(), existing, updatedIssues);
+        updated = TurboIssue.combineWithPullRequests(updated, updatedPullRequests);
 
         response.complete(new Result<>(updated, changes.middle, changes.right));
     }

--- a/src/main/java/backend/interfaces/Repo.java
+++ b/src/main/java/backend/interfaces/Repo.java
@@ -10,7 +10,6 @@ import github.TurboIssueEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
-import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.PullRequest;
 
@@ -38,7 +37,6 @@ public interface Repo {
     ImmutablePair<List<TurboIssueEvent>, String> getUpdatedEvents(String repoId, int issueId, String eTag);
     List<Comment> getComments(String repoId, int issueId);
     List<ReviewComment> getReviewComments(String repoId, int pullRequestId);
-    List<CommitComment> getCommitComments(String repoId, int pullRequestId);
     List<Comment> getAllComments(String repoId, TurboIssue issue);
 
     boolean isRepositoryValid(String repoId);

--- a/src/main/java/backend/interfaces/Repo.java
+++ b/src/main/java/backend/interfaces/Repo.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
 import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
+import org.eclipse.egit.github.core.PullRequest;
 
 import java.io.IOException;
 import java.util.Date;
@@ -29,6 +30,7 @@ public interface Repo {
     // Returns tuples in order to be maximally generic
     ImmutableTriple<List<TurboIssue>, String, Date>
         getUpdatedIssues(String repoId, String eTag, Date lastCheckTime);
+    List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime);
     ImmutablePair<List<TurboLabel>, String> getUpdatedLabels(String repoId, String eTag);
     ImmutablePair<List<TurboMilestone>, String> getUpdatedMilestones(String repoId, String eTag);
     ImmutablePair<List<TurboUser>, String> getUpdatedCollaborators(String repoId, String eTag);

--- a/src/main/java/backend/interfaces/Repo.java
+++ b/src/main/java/backend/interfaces/Repo.java
@@ -5,10 +5,12 @@ import backend.resource.TurboIssue;
 import backend.resource.TurboLabel;
 import backend.resource.TurboMilestone;
 import backend.resource.TurboUser;
+import github.ReviewComment;
 import github.TurboIssueEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
+import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
 
 import java.io.IOException;
@@ -33,6 +35,9 @@ public interface Repo {
 
     ImmutablePair<List<TurboIssueEvent>, String> getUpdatedEvents(String repoId, int issueId, String eTag);
     List<Comment> getComments(String repoId, int issueId);
+    List<ReviewComment> getReviewComments(String repoId, int pullRequestId);
+    List<CommitComment> getCommitComments(String repoId, int pullRequestId);
+    List<Comment> getAllComments(String repoId, TurboIssue issue);
 
     boolean isRepositoryValid(String repoId);
     List<Label> setLabels(String repoId, int issueId, List<String> labels) throws IOException;

--- a/src/main/java/backend/interfaces/Repo.java
+++ b/src/main/java/backend/interfaces/Repo.java
@@ -29,7 +29,7 @@ public interface Repo {
     // Returns tuples in order to be maximally generic
     ImmutableTriple<List<TurboIssue>, String, Date>
         getUpdatedIssues(String repoId, String eTag, Date lastCheckTime);
-    List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime);
+    List<PullRequest> getUpdatedPullRequests(String repoId, Date lastCheckTime);
     ImmutablePair<List<TurboLabel>, String> getUpdatedLabels(String repoId, String eTag);
     ImmutablePair<List<TurboMilestone>, String> getUpdatedMilestones(String repoId, String eTag);
     ImmutablePair<List<TurboUser>, String> getUpdatedCollaborators(String repoId, String eTag);

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -2,11 +2,13 @@ package backend.resource;
 
 import backend.IssueMetadata;
 import backend.resource.serialization.SerializableIssue;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Label;
+import org.eclipse.egit.github.core.PullRequest;
 import prefs.Preferences;
+import util.HTLog;
 import util.Utility;
-import static util.Utility.replaceNull;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,11 +16,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static util.Utility.replaceNull;
+
 /**
  * The guidelines in this class apply to all TurboResources.
  */
 @SuppressWarnings("unused")
 public class TurboIssue {
+    private static final Logger logger = HTLog.get(TurboIssue.class);
 
     public static final String STATE_CLOSED = "closed";
     public static final String STATE_OPEN = "open";
@@ -234,6 +239,50 @@ public class TurboIssue {
             }
         }
         return existing;
+    }
+
+    /**
+     * Updates data for issues with corresponding pull requests. Original list of
+     * issues and original issue instances are not mutated
+     * @param issues
+     * @param pullRequests
+     * @return a new list of issues
+     */
+    public static List<TurboIssue> combineWithPullRequests(List<TurboIssue> issues,
+                                                           List<PullRequest> pullRequests) {
+        issues = new ArrayList<>(issues);
+
+        for (PullRequest pullRequest : pullRequests) {
+            int id = pullRequest.getNumber();
+
+            Optional<Integer> corresponding = findIssueWithId(issues, id);
+            if (corresponding.isPresent()) {
+                TurboIssue issue = issues.get(corresponding.get());
+                issues.set(corresponding.get(), issue.combineWithPullRequest(pullRequest));
+            } else {
+                String errorMsg = "No corresponding issue for pull request " + pullRequest;
+                logger.error(errorMsg);
+            }
+        }
+
+        return issues;
+    }
+
+    /**
+     * Combines data from a corresponding pull request with data in this issue
+     * This method returns a new combined issue and does not mutate this issue
+     * @param pullRequest
+     * @return new new combined issue
+     */
+    public TurboIssue combineWithPullRequest(PullRequest pullRequest) {
+        TurboIssue newIssue = new TurboIssue(this);
+
+        if (pullRequest.getUpdatedAt() == null) {
+            return newIssue;
+        }
+
+        newIssue.setUpdatedAt(Utility.dateToLocalDateTime(pullRequest.getUpdatedAt()));
+        return newIssue;
     }
 
     private static Optional<Integer> findIssueWithId(List<TurboIssue> existing, int id) {

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -281,13 +281,18 @@ public class TurboIssue {
             return newIssue;
         }
 
-        newIssue.setUpdatedAt(Utility.dateToLocalDateTime(pullRequest.getUpdatedAt()));
+        LocalDateTime pullRequestUpdatedAt = Utility.dateToLocalDateTime(pullRequest.getUpdatedAt());
+        if (pullRequestUpdatedAt.isBefore(newIssue.getUpdatedAt())) {
+            return newIssue;
+        }
+
+        newIssue.setUpdatedAt(pullRequestUpdatedAt);
         return newIssue;
     }
 
-    private static Optional<Integer> findIssueWithId(List<TurboIssue> existing, int id) {
+    public static Optional<Integer> findIssueWithId(List<TurboIssue> issues, int id) {
         int i = 0;
-        for (TurboIssue issue : existing) {
+        for (TurboIssue issue : issues) {
             if (issue.getId() == id) {
                 return Optional.of(i);
             }

--- a/src/main/java/backend/stub/DummyRepo.java
+++ b/src/main/java/backend/stub/DummyRepo.java
@@ -108,7 +108,7 @@ public class DummyRepo implements Repo {
     }
 
     @Override
-    public List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime) {
+    public List<PullRequest> getUpdatedPullRequests(String repoId, Date lastCheckTime) {
         return new ArrayList<>();
     }
 

--- a/src/main/java/backend/stub/DummyRepo.java
+++ b/src/main/java/backend/stub/DummyRepo.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
 import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
+import org.eclipse.egit.github.core.PullRequest;
 import ui.UI;
 import util.events.testevents.ClearLogicModelEvent;
 import util.events.testevents.UpdateDummyRepoEventHandler;
@@ -105,6 +106,11 @@ public class DummyRepo implements Repo {
     public ImmutableTriple<List<TurboIssue>, String, Date>
         getUpdatedIssues(String repoId, String eTag, Date lastCheckTime) {
         return getRepoState(repoId).getUpdatedIssues(eTag, lastCheckTime);
+    }
+
+    @Override
+    public List<PullRequest> getUpdatedPullRequests(String repoId, String eTag, Date lastCheckTime) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/backend/stub/DummyRepo.java
+++ b/src/main/java/backend/stub/DummyRepo.java
@@ -6,15 +6,18 @@ import backend.resource.TurboIssue;
 import backend.resource.TurboLabel;
 import backend.resource.TurboMilestone;
 import backend.resource.TurboUser;
+import github.ReviewComment;
 import github.TurboIssueEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
+import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
 import ui.UI;
 import util.events.testevents.ClearLogicModelEvent;
 import util.events.testevents.UpdateDummyRepoEventHandler;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -153,6 +156,21 @@ public class DummyRepo implements Repo {
     public List<Comment> getComments(String repoId, int issueId) {
         apiQuota--;
         return getRepoState(repoId).getComments(issueId);
+    }
+
+    @Override
+    public List<Comment> getAllComments(String repoId, TurboIssue issue) {
+        return getComments(repoId, issue.getId());
+    }
+
+    @Override
+    public List<ReviewComment> getReviewComments(String repoId, int pullRequestId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<CommitComment> getCommitComments(String repoId, int pullRequestId) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/backend/stub/DummyRepo.java
+++ b/src/main/java/backend/stub/DummyRepo.java
@@ -166,7 +166,10 @@ public class DummyRepo implements Repo {
 
     @Override
     public List<Comment> getAllComments(String repoId, TurboIssue issue) {
-        return getComments(repoId, issue.getId());
+        List<Comment> result = getComments(repoId, issue.getId());
+        result.addAll(getReviewComments(repoId, issue.getId()));
+        result.addAll(getCommitComments(repoId, issue.getId()));
+        return result;
     }
 
     @Override

--- a/src/main/java/backend/stub/DummyRepo.java
+++ b/src/main/java/backend/stub/DummyRepo.java
@@ -11,7 +11,6 @@ import github.TurboIssueEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.eclipse.egit.github.core.Comment;
-import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.PullRequest;
 import ui.UI;
@@ -168,17 +167,11 @@ public class DummyRepo implements Repo {
     public List<Comment> getAllComments(String repoId, TurboIssue issue) {
         List<Comment> result = getComments(repoId, issue.getId());
         result.addAll(getReviewComments(repoId, issue.getId()));
-        result.addAll(getCommitComments(repoId, issue.getId()));
         return result;
     }
 
     @Override
     public List<ReviewComment> getReviewComments(String repoId, int pullRequestId) {
-        return new ArrayList<>();
-    }
-
-    @Override
-    public List<CommitComment> getCommitComments(String repoId, int pullRequestId) {
         return new ArrayList<>();
     }
 

--- a/src/main/java/github/update/PullRequestUpdateService.java
+++ b/src/main/java/github/update/PullRequestUpdateService.java
@@ -5,26 +5,20 @@ import github.GitHubClientEx;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.PullRequest;
 import org.eclipse.egit.github.core.client.PagedRequest;
-import util.Utility;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_PULLS;
 
 public class PullRequestUpdateService extends UpdateService<PullRequest> {
-    private final Date lastIssueCheckTime;
-
-    public PullRequestUpdateService(GitHubClientEx client, String pullRequestsETags, Date lastIssueCheckTime) {
+    public PullRequestUpdateService(GitHubClientEx client, String pullRequestsETags) {
         super(client, SEGMENT_PULLS, pullRequestsETags);
-        this.lastIssueCheckTime = new Date(lastIssueCheckTime.getTime());
     }
 
     private Map<String, String> createUpdatedPullRequestsParams(){
         Map<String, String> params = new HashMap<>();
-        params.put("since", Utility.formatDateISO8601(lastIssueCheckTime));
         params.put("state", "all");
         return params;
     }

--- a/src/main/java/github/update/PullRequestUpdateService.java
+++ b/src/main/java/github/update/PullRequestUpdateService.java
@@ -2,33 +2,134 @@ package github.update;
 
 import com.google.gson.reflect.TypeToken;
 import github.GitHubClientEx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.PullRequest;
+import org.eclipse.egit.github.core.client.NoSuchPageException;
+import org.eclipse.egit.github.core.client.PageIterator;
 import org.eclipse.egit.github.core.client.PagedRequest;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
+import java.util.*;
 
-import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_PULLS;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
 
 public class PullRequestUpdateService extends UpdateService<PullRequest> {
-    public PullRequestUpdateService(GitHubClientEx client, String pullRequestsETags) {
-        super(client, SEGMENT_PULLS, pullRequestsETags);
+    private static final Logger logger = LogManager.getLogger(PullRequestUpdateService.class.getName());
+
+    private final Date lastIssueCheckTime;
+
+    public PullRequestUpdateService(GitHubClientEx client, String etags, Date lastIssueCheckTime) {
+        super(client, SEGMENT_PULLS, etags);
+        this.lastIssueCheckTime = new Date(lastIssueCheckTime.getTime());
     }
 
-    private Map<String, String> createUpdatedPullRequestsParams(){
+    private Map<String, String> createUpdatedPullRequestsParams() {
         Map<String, String> params = new HashMap<>();
         params.put("state", "all");
+        params.put("sort", "updated");
+        params.put("direction", "desc");
         return params;
     }
 
+    /**
+     * Overrides parent's method to change the number of items per page. This allow the update process
+     * to stop earlier once it encounters the first item whose updatedAt time is before lastIssueCheckTime
+     * @param repoId the repository to make the request for
+     * @return a list of pull requests
+     */
     @Override
-    protected PagedRequest<PullRequest> createUpdatedRequest(IRepositoryIdProvider repoId){
-        PagedRequest<PullRequest> request = super.createUpdatedRequest(repoId);
+    protected PagedRequest<PullRequest> createUpdatedRequest(IRepositoryIdProvider repoId) {
+        PagedRequest<PullRequest> request = new PagedRequest<>(1, 30);
+
+        String path = SEGMENT_REPOS + "/" + repoId.generateId() + apiSuffix;
+        request.setUri(path);
+        request.setResponseContentType(CONTENT_TYPE_JSON);
+
         request.setParams(createUpdatedPullRequestsParams());
-        request.setType(new TypeToken<PullRequest>(){}.getType());
-        request.setArrayType(new TypeToken<ArrayList<PullRequest>>(){}.getType());
+        request.setType(new TypeToken<PullRequest>() { }.getType());
+        request.setArrayType(new TypeToken<ArrayList<PullRequest>>() { }.getType());
         return request;
+    }
+
+    /**
+     * Overrides the parent's method to remove ETags checking step and use the specialized
+     * method get
+     * @param repoId the repository to get the items from
+     * @return
+     */
+    @Override
+    public ArrayList<PullRequest> getUpdatedItems(IRepositoryIdProvider repoId) {
+        if (updatedItems != null)  {
+            return updatedItems;
+        }
+
+        ArrayList<PullRequest> result = new ArrayList<>();
+        String resourceDesc = repoId.generateId() + apiSuffix;
+        logger.info(String.format("Updating %s", resourceDesc));
+
+        try {
+            PagedRequest<PullRequest> request = createUpdatedRequest(repoId);
+            result = new ArrayList<>(getPagedItems(resourceDesc, new PageIterator<>(request, client)));
+        } catch (IOException e) {
+            logger.error(e.getLocalizedMessage(), e);
+            return result;
+        }
+
+        updatedItems = result;
+        return result;
+    }
+
+    /**
+     * Overrides parent's method to stop getting items if some items in a page has
+     * updatedAt time before the lastIssueCheckTime
+     * @param resourceDesc
+     * @param iterator the paged request to iterate through
+     * @return
+     * @throws IOException
+     */
+    @Override
+    protected List<PullRequest> getPagedItems(String resourceDesc, PageIterator<PullRequest> iterator)
+            throws IOException {
+        List<PullRequest> elements = new ArrayList<>();
+        int page = 0;
+
+        try {
+            while (iterator.hasNext()) {
+                Collection<PullRequest> newPullRequests = iterator.next();
+                int numAddedItems = addItemsUpdatedSince(elements, newPullRequests, lastIssueCheckTime);
+
+                logger.info(resourceDesc + " | page " + (page++) + ": " + numAddedItems + " items");
+
+                if (numAddedItems < newPullRequests.size()) {
+                    break;
+                }
+            }
+        } catch (NoSuchPageException pageException) {
+            throw pageException.getCause();
+        }
+
+        return elements;
+    }
+
+    /**
+     * Add all pull requests in {@code src} to {@code dest} of which updated time is after {@code since}
+     * @param dest current list of pull requests
+     * @param src new pull quests to be added
+     * @param since
+     * @return number of pull requests added to {@code dest}
+     */
+    private int addItemsUpdatedSince(List<PullRequest> dest, Collection<PullRequest> src, Date since) {
+        int numPullRequestsAdded = 0;
+
+        for (PullRequest pr : src) {
+            if (pr.getUpdatedAt().after(since)) {
+                dest.add(pr);
+                numPullRequestsAdded++;
+            }
+        }
+
+        return numPullRequestsAdded;
     }
 }

--- a/src/main/java/github/update/PullRequestUpdateService.java
+++ b/src/main/java/github/update/PullRequestUpdateService.java
@@ -1,0 +1,40 @@
+package github.update;
+
+import com.google.gson.reflect.TypeToken;
+import github.GitHubClientEx;
+import org.eclipse.egit.github.core.IRepositoryIdProvider;
+import org.eclipse.egit.github.core.PullRequest;
+import org.eclipse.egit.github.core.client.PagedRequest;
+import util.Utility;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_PULLS;
+
+public class PullRequestUpdateService extends UpdateService<PullRequest> {
+    private final Date lastIssueCheckTime;
+
+    public PullRequestUpdateService(GitHubClientEx client, String pullRequestsETags, Date lastIssueCheckTime) {
+        super(client, SEGMENT_PULLS, pullRequestsETags);
+        this.lastIssueCheckTime = new Date(lastIssueCheckTime.getTime());
+    }
+
+    private Map<String, String> createUpdatedPullRequestsParams(){
+        Map<String, String> params = new HashMap<>();
+        params.put("since", Utility.formatDateISO8601(lastIssueCheckTime));
+        params.put("state", "all");
+        return params;
+    }
+
+    @Override
+    protected PagedRequest<PullRequest> createUpdatedRequest(IRepositoryIdProvider repoId){
+        PagedRequest<PullRequest> request = super.createUpdatedRequest(repoId);
+        request.setParams(createUpdatedPullRequestsParams());
+        request.setType(new TypeToken<PullRequest>(){}.getType());
+        request.setArrayType(new TypeToken<ArrayList<PullRequest>>(){}.getType());
+        return request;
+    }
+}

--- a/src/main/java/github/update/PullRequestUpdateService.java
+++ b/src/main/java/github/update/PullRequestUpdateService.java
@@ -20,8 +20,8 @@ public class PullRequestUpdateService extends UpdateService<PullRequest> {
 
     private final Date lastIssueCheckTime;
 
-    public PullRequestUpdateService(GitHubClientEx client, String etags, Date lastIssueCheckTime) {
-        super(client, SEGMENT_PULLS, etags);
+    public PullRequestUpdateService(GitHubClientEx client, Date lastIssueCheckTime) {
+        super(client, SEGMENT_PULLS, "");
         this.lastIssueCheckTime = new Date(lastIssueCheckTime.getTime());
     }
 

--- a/src/main/java/github/update/UpdateService.java
+++ b/src/main/java/github/update/UpdateService.java
@@ -33,16 +33,16 @@ import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS
 public class UpdateService<T> extends GitHubService {
     private static final Logger logger = LogManager.getLogger(UpdateService.class.getName());
 
-    private final GitHubClientEx client;
-    private final String apiSuffix;
-    private final String lastETags;
+    protected final GitHubClientEx client;
+    protected final String apiSuffix;
+    protected final String lastETags;
 
     // Auxillary results of calling getUpdatedItems
-    private Optional<String> updatedETags = Optional.empty();
-    private Date updatedCheckTime = new Date();
+    protected Optional<String> updatedETags = Optional.empty();
+    protected Date updatedCheckTime = new Date();
 
     // Cached results of calling getUpdatedItems
-    private ArrayList<T> updatedItems = null;
+    protected ArrayList<T> updatedItems = null;
 
     /**
      * @param client an authenticated GitHubClient
@@ -75,11 +75,11 @@ public class UpdateService<T> extends GitHubService {
     }
 
     /**
-     * Retrieves the requested items from GitHub. Sets the auxillary fields.
+     * Retrieves the requested items from GitHub
      * @param repoId the repository to get the items from
      * @return a list of requested items
      */
-    public ArrayList<T> getUpdatedItems(IRepositoryIdProvider repoId){
+    public ArrayList<T> getUpdatedItems(IRepositoryIdProvider repoId) {
 
         // Return cached results if available
         if (updatedItems != null)  {
@@ -96,10 +96,9 @@ public class UpdateService<T> extends GitHubService {
             Optional<ImmutablePair<List<String>, HttpURLConnection>> etags = getPagedEtags(request, client);
 
             if (!etags.isPresent()) {
+                /* Respond as if we succeeded and there were no updates.
+                   The assumption is that updates are cheap and we can do them as frequently as needed. */
                 logger.warn(String.format("%s: error getting updated items", getClass().getSimpleName()));
-
-                // Respond as if we succeeded and there were no updates.
-                // The assumption is that updates are cheap and we can do them as frequently as needed.
             } else {
                 updatedETags = combineETags(etags.get().getLeft());
                 if (!updatedETags.isPresent() || updatedETags.get().equals(lastETags)){
@@ -168,7 +167,7 @@ public class UpdateService<T> extends GitHubService {
      * @return a list of items
      * @throws IOException
      */
-    private List<T> getPagedItems(String resourceDesc, PageIterator<T> iterator) throws IOException {
+    protected List<T> getPagedItems(String resourceDesc, PageIterator<T> iterator) throws IOException {
         List<T> elements = new ArrayList<>();
         int length = 0;
         int page = 0;

--- a/src/main/java/github/update/UpdateService.java
+++ b/src/main/java/github/update/UpdateService.java
@@ -1,17 +1,6 @@
 package github.update;
 
-import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_JSON;
-import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
-
 import github.GitHubClientEx;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,8 +10,17 @@ import org.eclipse.egit.github.core.client.NoSuchPageException;
 import org.eclipse.egit.github.core.client.PageIterator;
 import org.eclipse.egit.github.core.client.PagedRequest;
 import org.eclipse.egit.github.core.service.GitHubService;
-
 import util.Utility;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.eclipse.egit.github.core.client.IGitHubConstants.CONTENT_TYPE_JSON;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
 
 /**
  * Given a type of item and the current ETag, fetches a list of updated items.
@@ -49,7 +47,7 @@ public class UpdateService<T> extends GitHubService {
     /**
      * @param client an authenticated GitHubClient
      * @param apiSuffix the API URI for the type of item; defined by subclasses
-     * @param lastETag the last-known ETag for these items; may be null
+     * @param lastETags the last-known ETag for these items; may be null
      */
     public UpdateService(GitHubClientEx client, String apiSuffix, String lastETags){
         assert client != null;

--- a/src/test/java/tests/GitHubRepoTests.java
+++ b/src/test/java/tests/GitHubRepoTests.java
@@ -1,0 +1,43 @@
+package tests;
+
+import backend.github.GitHubRepo;
+import backend.resource.TurboIssue;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitHubRepoTests {
+    /**
+     * GitHubRepo.getReviewComments should return an empty list if the requested repository is invalid
+     */
+    @Test
+    public void testGetReviewCommentsForInvalidRepo() {
+        GitHubRepo repo = new GitHubRepo();
+        assertEquals(new ArrayList<>(), repo.getReviewComments("owner/nonexistentrepo", 1));
+    }
+
+    /**
+     * GitHubRepo.getCommitComments should return an empty list if the requested repository is invalid
+     */
+    @Test
+    public void testGetCommitCommentsForInvalidRepo() {
+        GitHubRepo repo = new GitHubRepo();
+        assertEquals(new ArrayList<>(), repo.getCommitComments("owner/nonexistentrepo", 1));
+    }
+
+    /**
+     * GitHubRepo.getAllComments should return an empty list if the requested repository is invalid
+     */
+    @Test
+    public void testGetAllCommentsForInvalidRepo() {
+        GitHubRepo repo = new GitHubRepo();
+        TurboIssue issue = new TurboIssue("repo", 1, "title", "owner", LocalDateTime.now(), false);
+        TurboIssue pullRequest = new TurboIssue("repo", 1, "title", "owner", LocalDateTime.now(), false);
+
+        assertEquals(new ArrayList<>(), repo.getAllComments("owner/nonexistentrepo", issue));
+        assertEquals(new ArrayList<>(), repo.getAllComments("owner/nonexistentrepo", pullRequest));
+    }
+}

--- a/src/test/java/tests/GitHubRepoTests.java
+++ b/src/test/java/tests/GitHubRepoTests.java
@@ -20,15 +20,6 @@ public class GitHubRepoTests {
     }
 
     /**
-     * GitHubRepo.getCommitComments should return an empty list if the requested repository is invalid
-     */
-    @Test
-    public void testGetCommitCommentsForInvalidRepo() {
-        GitHubRepo repo = new GitHubRepo();
-        assertEquals(new ArrayList<>(), repo.getCommitComments("owner/nonexistentrepo", 1));
-    }
-
-    /**
      * GitHubRepo.getAllComments should return an empty list if the requested repository is invalid
      */
     @Test

--- a/src/test/java/tests/TurboIssueTest.java
+++ b/src/test/java/tests/TurboIssueTest.java
@@ -3,21 +3,36 @@ package tests;
 import backend.resource.TurboIssue;
 import org.eclipse.egit.github.core.Issue;
 import org.eclipse.egit.github.core.Label;
+import org.eclipse.egit.github.core.PullRequest;
 import org.eclipse.egit.github.core.User;
 import org.junit.Test;
+import util.Utility;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class TurboIssueTest {
 
     private static final String REPO = "testrepo/testrepo";
+
+    private TurboIssue createIssueWithUpdatedAt(int number, LocalDateTime updatedAt) {
+        TurboIssue issue = new TurboIssue(REPO, number, "", "", null, false);
+        issue.setUpdatedAt(updatedAt);
+
+        return issue;
+    }
+
+    private PullRequest createPullRequestWithUpdatedAt(int number, LocalDateTime updatedAt) {
+        Date date = Utility.localDateTimeToDate(updatedAt);
+
+        PullRequest pullRequest = new PullRequest();
+        pullRequest.setNumber(number);
+        pullRequest.setUpdatedAt(date);
+
+        return pullRequest;
+    }
 
     @Test
     public void turboIssueTest() {
@@ -58,4 +73,39 @@ public class TurboIssueTest {
         assertTrue(issue.isCurrentlyRead());
     }
 
+    @Test
+    public void testCombinePullRequest() {
+        TurboIssue issue1 = createIssueWithUpdatedAt(1, LocalDateTime.of(2015, 2, 17, 2, 10));
+        TurboIssue issue2 = createIssueWithUpdatedAt(2, LocalDateTime.of(2015, 2, 18, 2, 10));
+        TurboIssue issue3 = createIssueWithUpdatedAt(3, LocalDateTime.of(2015, 2, 19, 2, 10));
+        TurboIssue issue4 = createIssueWithUpdatedAt(4, LocalDateTime.of(2015, 2, 20, 2, 10));
+
+        List<TurboIssue> issues = new ArrayList<>();
+        issues.add(issue1);
+        issues.add(issue2);
+        issues.add(issue3);
+        issues.add(issue4);
+        Collections.shuffle(issues);
+
+        PullRequest pr1 = createPullRequestWithUpdatedAt(1, LocalDateTime.of(2015, 7, 7, 1, 21));
+        PullRequest pr2 = createPullRequestWithUpdatedAt(2, LocalDateTime.of(2015, 2, 18, 2, 9));
+        PullRequest pr3 = new PullRequest();
+        pr3.setNumber(3);
+
+        List<PullRequest> pullRequests = new ArrayList<>();
+        pullRequests.add(pr1);
+        pullRequests.add(pr2);
+        pullRequests.add(pr3);
+        Collections.shuffle(pullRequests);
+
+        List<TurboIssue> newIssues = TurboIssue.combineWithPullRequests(issues, pullRequests);
+        TurboIssue newIssue1 = newIssues.get(TurboIssue.findIssueWithId(newIssues, 1).get());
+        TurboIssue newIssue2 = newIssues.get(TurboIssue.findIssueWithId(newIssues, 2).get());
+        TurboIssue newIssue3 = newIssues.get(TurboIssue.findIssueWithId(newIssues, 3).get());
+        TurboIssue newIssue4 = newIssues.get(TurboIssue.findIssueWithId(newIssues, 4).get());
+        assertEquals(LocalDateTime.of(2015, 7, 7, 1, 21), newIssue1.getUpdatedAt());
+        assertEquals(issue2.getUpdatedAt(), newIssue2.getUpdatedAt());
+        assertEquals(issue3.getUpdatedAt(), newIssue3.getUpdatedAt());
+        assertEquals(issue4.getUpdatedAt(), newIssue4.getUpdatedAt());
+    }
 }

--- a/src/test/java/tests/TurboIssueTest.java
+++ b/src/test/java/tests/TurboIssueTest.java
@@ -91,11 +91,14 @@ public class TurboIssueTest {
         PullRequest pr2 = createPullRequestWithUpdatedAt(2, LocalDateTime.of(2015, 2, 18, 2, 9));
         PullRequest pr3 = new PullRequest();
         pr3.setNumber(3);
+        PullRequest pr5 = new PullRequest();
+        pr5.setNumber(5);
 
         List<PullRequest> pullRequests = new ArrayList<>();
         pullRequests.add(pr1);
         pullRequests.add(pr2);
         pullRequests.add(pr3);
+        pullRequests.add(pr5);
         Collections.shuffle(pullRequests);
 
         List<TurboIssue> newIssues = TurboIssue.combineWithPullRequests(issues, pullRequests);

--- a/src/test/java/tests/UpdateServiceTests.java
+++ b/src/test/java/tests/UpdateServiceTests.java
@@ -3,6 +3,7 @@ package tests;
 import github.GitHubClientEx;
 import github.update.MilestoneUpdateService;
 import github.update.PageHeaderIterator;
+import github.update.PullRequestUpdateService;
 import github.update.UpdateService;
 import org.eclipse.egit.github.core.Milestone;
 import org.eclipse.egit.github.core.RepositoryId;
@@ -40,8 +41,8 @@ public class UpdateServiceTests {
         client.head(request);
     }
 
-    @Test(expected = Exception.class)
-    public void testHeaderIterator() {
+    @Test(expected = NoSuchElementException.class)
+    public void testHeaderIterator() throws NoSuchElementException {
         GitHubClientEx client = new GitHubClientEx();
 
         Map<String, String> params = new HashMap<>();
@@ -84,6 +85,16 @@ public class UpdateServiceTests {
         GitHubClientEx client = new GitHubClientEx();
         MilestoneUpdateService service = new MilestoneUpdateService(client, "abcd");
 
+        assertTrue(service.getUpdatedItems(RepositoryId.create("name", "nonexistentrepo")).isEmpty());
+    }
+
+    /**
+     * Tests if PullRequestUpdateService returns an empty list if the repo is invalid
+     */
+    @Test
+    public void testGetUpdatedPullRequests() {
+        GitHubClientEx client = new GitHubClientEx();
+        PullRequestUpdateService service = new PullRequestUpdateService(client, "", new Date());
         assertTrue(service.getUpdatedItems(RepositoryId.create("name", "nonexistentrepo")).isEmpty());
     }
 }

--- a/src/test/java/tests/UpdateServiceTests.java
+++ b/src/test/java/tests/UpdateServiceTests.java
@@ -94,7 +94,7 @@ public class UpdateServiceTests {
     @Test
     public void testGetUpdatedPullRequests() {
         GitHubClientEx client = new GitHubClientEx();
-        PullRequestUpdateService service = new PullRequestUpdateService(client, "", new Date());
+        PullRequestUpdateService service = new PullRequestUpdateService(client, new Date());
         assertTrue(service.getUpdatedItems(RepositoryId.create("name", "nonexistentrepo")).isEmpty());
     }
 }


### PR DESCRIPTION
Fix #654 

Depending on how large a user's `updated` filter window is, the correctness of this fix may take some times to stabilize since only PRs updated after the fix will be combined with the existing Issues.

Another issue is with commit comments. Commenting on a commit does not affect the `updatedAt` time of both PR and Issue. So we need to retrieve a list of commits for a PR and inject their latest `updatedAt` into the PR. This has potential implementation difficulties due to API usage, comments and PRs being retrieved on 2 separate update cycles and also is not as critical to be in this PR since we don't comment on commit that often. So I will open a separate issue for this.