### PR TITLE
Make Keyboard Shortcuts work in Mac #957

### DIFF
--- a/docs/keyboardShortcuts.md
+++ b/docs/keyboardShortcuts.md
@@ -2,12 +2,11 @@
 
 ## Go to page ...
 
-These key sequences (one key followed by the other) are used to load (in the browser view)
- various pages of the default repository
+These key sequences (one key followed by the other) are used to load various pages of the default repository in the browser view.
 
-| **Page to go**| **Shortcut**|**Explanation**|
+| **Page to go to**| **Shortcut**|**Explanation**|
 | ------------- |:-------------:| ------------|
-| **G**o to **I**ssues page|<kbd>G</kbd> then <kbd>I</kbd>|Loads the *issues* page in the browser view|
+| **G**o to **I**ssues page|<kbd>G</kbd> <kbd>I</kbd>|Loads the *issues* page in the browser view|
 | **L**abels page|<kbd>G</kbd> <kbd>L</kbd>|Loads the *labels* page |
 | **M**ilestones page|<kbd>G</kbd> <kbd>M</kbd>|Loads the *milestones* page |
 | **P**ull requests page|<kbd>G</kbd> <kbd>P</kbd>|Loads the *pull requests* page |
@@ -20,11 +19,13 @@ These key sequences (one key followed by the other) are used to load (in the bro
 
 ## Create new ...
 
+On OS X, <kbd>⌘</kbd> replaces <kbd>Ctrl</kbd>.
+
 | **Item to create**| **Shortcut**|**Explanation**|
 | ------------- |:-------------:| --------- |
-| Issue|<kbd>Ctrl</kbd> + <kbd>I</kbd>|Loads the 'New Issue' page in the browser view|
-| Label|<kbd>Ctrl</kbd> + <kbd>L</kbd>|Loads the 'Labels' page in the browser view|
-| Milestone|<kbd>Ctrl</kbd> + <kbd>M</kbd>|Loads the 'New Milestone' page in the browser view|
+| Issue|<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>|Loads the 'New Issue' page in the browser view|
+| Label|<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>|Loads the 'Labels' page in the browser view|
+| Milestone|<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd>|Loads the 'New Milestone' page in the browser view|
 | Panel (on right)|<kbd>Ctrl</kbd> + <kbd>P</kbd>| Create a new panel to the right of current panel|
 | Panel (on left)|<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>|Create a new panel to the left of current panel|
 
@@ -38,8 +39,8 @@ These key sequences (one key followed by the other) are used to load (in the bro
 | Issue list|<kbd>Ctrl</kbd> + <kbd>Enter</kbd>|Focus moves to issue list of the selected panel|
 | Out of filter box (while editing filter)|<kbd>ESC</kbd> then <kbd>ESC</kbd>|First <kbd>ESC</kbd> restores previous filter and selects the filter text. The second <kbd>ESC</kbd> moves focus out of filter box|
 |n<sup>th</sup> issue (from *1* to *9*)| <kbd>Ctrl</kbd> + <kbd>1</kbd> to <kbd>9</kbd> | If the focus is already on the issue list, jumps to n<sup>th</sup> issue, where n is the issue number ranging from 1 (at the top of the list) to 9|
-| n<sup>th</sup> issue *to* first issue|<kbd>Home</kbd>|If the focus is already in the issue list, jumps to the first issue of that list|
-| n<sup>th</sup> issue *to* last issue|<kbd>End</kbd>|If the focus is already in the issue list, jumps to the last issue of that list|
+| First issue|<kbd>Home</kbd>|If the focus is already in the issue list, jumps to the first issue of that list|
+| Last issue|<kbd>End</kbd>|If the focus is already in the issue list, jumps to the last issue of that list|
 | Previous issue |<kbd>T</kbd> / <kbd>↑</kbd>|Go to the previous in the panel and loads it in browser view|
 | Previous issue (without loading) |<kbd>Shift</kbd> + <kbd>T</kbd> / <kbd>Shift</kbd> + <kbd>↑</kbd>|Go to the previous in the panel but does not load it in the browser view|
 | Next issue |<kbd>V</kbd> / <kbd>↓</kbd>|Go to the next in the panel and loads it in browser view|
@@ -59,13 +60,13 @@ These shortcuts can be used when the focus is on an issue card in a panel.
 | Mark as R**e**ad|<kbd>E</kbd>|Mark an issue as read. Read issues will be shown in a different color and can be filtered. After marking an issue as *read*, it will remain in *read* state until the issue is updated.|
 | Mark as **U**nread|<kbd>U</kbd>|Reverts an issue's *read* status|
 
-## Control the panel view Window ...
+## Control the panel view window ...
 
 | **Action on the browser view**| **Shortcut**|**Explanation**|
 | ------------- |:-------------:| -----------|
 | Close|<kbd>Ctrl</kbd> + <kbd>W</kbd>| Closes the panel in focus|
 | Ma**x**imize|<kbd>Ctrl</kbd> + <kbd>X</kbd>||
-| Mi**n**imize|<kbd>Ctrl</kbd> + <kbd>N</kbd>||
+| Mi**n**imize|<kbd>Ctrl</kbd> + <kbd>M</kbd>||
 | Mi**d**-sized window|<kbd>Ctrl</kbd> + <kbd>D</kbd>||
 | Refresh|<kbd>F5</kbd>|Causes HubTurbo to check for updates to the repo's issues|
 | Force Refresh|<kbd>Ctrl</kbd> + <kbd>F5</kbd>|Clears HubTurbo's cache and re-downloads all issues from the repo|

--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -97,22 +97,24 @@ public class KeyboardShortcuts {
             new KeyCodeCombination(KeyCode.K);
     public static final KeyCodeCombination SHOW_CONTRIBUTORS =
             new KeyCodeCombination(KeyCode.D);
+
     public static final Map<Integer, KeyCodeCombination> JUMP_TO_NTH_ISSUE_KEYS = populateJumpToNthIssueMap();
+
     public static final KeyCodeCombination PR_FILES_CHANGED =
             new KeyCodeCombination(KeyCode.F);
     public static final KeyCodeCombination PR_COMMITS =
             new KeyCodeCombination(KeyCode.C);
-
-    // TODO decouple manage/show labels/milestones?
     public static final KeyCodeCombination NEW_COMMENT =
             new KeyCodeCombination(KeyCode.R);
+
+    // TODO decouple manage/show labels/milestones?
     public static final KeyCodeCombination MANAGE_LABELS =
-            new KeyCodeCombination(KeyCode.L);
+        new KeyCodeCombination(KeyCode.L);
     public static final KeyCodeCombination MANAGE_ASSIGNEES =
-            new KeyCodeCombination(KeyCode.A);
+        new KeyCodeCombination(KeyCode.A);
     public static final KeyCodeCombination MANAGE_MILESTONE =
-            new KeyCodeCombination(KeyCode.M);
-    
+        new KeyCodeCombination(KeyCode.M);
+
     //ui.RepositorySelector
     public static final KeyCodeCombination REMOVE_FOCUS =
             new KeyCodeCombination(KeyCode.ESCAPE);
@@ -162,11 +164,11 @@ public class KeyboardShortcuts {
     }
 
     private static void addNonCustomizableShortcutKeys() {
-        assignedKeys.add(new KeyCodeCombination(KeyCode.F5)); //REFRESH
-        assignedKeys.add(new KeyCodeCombination(KeyCode.F1)); //SHOW_DOCS
-        assignedKeys.add(new KeyCodeCombination(KeyCode.G)); //GOTO_MODIFIER
-        assignedKeys.add(new KeyCodeCombination(KeyCode.R)); //NEW_COMMENT
-        assignedKeys.add(new KeyCodeCombination(KeyCode.A)); //MANAGE_ASSIGNEES
+        assignedKeys.add(REFRESH);
+        assignedKeys.add(SHOW_DOCS);
+        assignedKeys.add(GOTO_MODIFIER);
+        assignedKeys.add(NEW_COMMENT);
+        assignedKeys.add(MANAGE_ASSIGNEES);
     }
 
     private static void getKeyboardShortcutsFromHashMap() {

--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -55,21 +55,21 @@ public class KeyboardShortcuts {
     // non-customizable keyboard shortcuts
     // ui.listpanel.ListPanel
     public static final KeyCodeCombination JUMP_TO_FIRST_ISSUE =
-            new KeyCodeCombination(KeyCode.ENTER, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.ENTER, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination JUMP_TO_FILTER_BOX =
-            new KeyCodeCombination(KeyCode.F, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination MAXIMIZE_WINDOW =
-            new KeyCodeCombination(KeyCode.X, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination MINIMIZE_WINDOW =
-            new KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.N, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination DEFAULT_SIZE_WINDOW =
-            new KeyCodeCombination(KeyCode.D, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.D, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination SWITCH_DEFAULT_REPO =
-            new KeyCodeCombination(KeyCode.R, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.R, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination SWITCH_BOARD = 
-            new KeyCodeCombination(KeyCode.B, KeyCombination.CONTROL_DOWN);
-    public static final KeyCombination UNDO_LABEL_CHANGES =
-                new KeyCodeCombination(KeyCode.Z, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.B, KeyCombination.SHORTCUT_DOWN);
+    public static final KeyCodeCombination UNDO_LABEL_CHANGES =
+            new KeyCodeCombination(KeyCode.Z, KeyCombination.SHORTCUT_DOWN);
 
     public static final KeyCodeCombination FIRST_ISSUE =
             new KeyCodeCombination(KeyCode.HOME);
@@ -119,30 +119,30 @@ public class KeyboardShortcuts {
 
     // ui.MenuControl
     public static final KeyCodeCombination NEW_ISSUE =
-            new KeyCodeCombination(KeyCode.I, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.I, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination NEW_LABEL =
-            new KeyCodeCombination(KeyCode.L, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.L, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination NEW_MILESTONE =
-            new KeyCodeCombination(KeyCode.M, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.M, KeyCombination.SHORTCUT_DOWN);
 
     public static final KeyCodeCombination CREATE_LEFT_PANEL =
-            new KeyCodeCombination(KeyCode.P, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN);
+            new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
     public static final KeyCodeCombination CREATE_RIGHT_PANEL =
-            new KeyCodeCombination(KeyCode.P, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination CLOSE_PANEL =
-            new KeyCodeCombination(KeyCode.W, KeyCombination.CONTROL_DOWN);
+            new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN);
     
     private static Map<Integer, KeyCodeCombination> populateJumpToNthIssueMap() {
         Map<Integer, KeyCodeCombination> result = new HashMap<>();
-        result.put(1, new KeyCodeCombination(KeyCode.DIGIT1, KeyCombination.CONTROL_DOWN));
-        result.put(2, new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.CONTROL_DOWN));
-        result.put(3, new KeyCodeCombination(KeyCode.DIGIT3, KeyCombination.CONTROL_DOWN));
-        result.put(4, new KeyCodeCombination(KeyCode.DIGIT4, KeyCombination.CONTROL_DOWN));
-        result.put(5, new KeyCodeCombination(KeyCode.DIGIT5, KeyCombination.CONTROL_DOWN));
-        result.put(6, new KeyCodeCombination(KeyCode.DIGIT6, KeyCombination.CONTROL_DOWN));
-        result.put(7, new KeyCodeCombination(KeyCode.DIGIT7, KeyCombination.CONTROL_DOWN));
-        result.put(8, new KeyCodeCombination(KeyCode.DIGIT8, KeyCombination.CONTROL_DOWN));
-        result.put(9, new KeyCodeCombination(KeyCode.DIGIT9, KeyCombination.CONTROL_DOWN));
+        result.put(1, new KeyCodeCombination(KeyCode.DIGIT1, KeyCombination.SHORTCUT_DOWN));
+        result.put(2, new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHORTCUT_DOWN));
+        result.put(3, new KeyCodeCombination(KeyCode.DIGIT3, KeyCombination.SHORTCUT_DOWN));
+        result.put(4, new KeyCodeCombination(KeyCode.DIGIT4, KeyCombination.SHORTCUT_DOWN));
+        result.put(5, new KeyCodeCombination(KeyCode.DIGIT5, KeyCombination.SHORTCUT_DOWN));
+        result.put(6, new KeyCodeCombination(KeyCode.DIGIT6, KeyCombination.SHORTCUT_DOWN));
+        result.put(7, new KeyCodeCombination(KeyCode.DIGIT7, KeyCombination.SHORTCUT_DOWN));
+        result.put(8, new KeyCodeCombination(KeyCode.DIGIT8, KeyCombination.SHORTCUT_DOWN));
+        result.put(9, new KeyCodeCombination(KeyCode.DIGIT9, KeyCombination.SHORTCUT_DOWN));
         return Collections.unmodifiableMap(result);
     }
     

--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -61,7 +61,7 @@ public class KeyboardShortcuts {
     public static final KeyCodeCombination MAXIMIZE_WINDOW =
             new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination MINIMIZE_WINDOW =
-            new KeyCodeCombination(KeyCode.N, KeyCombination.SHORTCUT_DOWN);
+            new KeyCodeCombination(KeyCode.M, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination DEFAULT_SIZE_WINDOW =
             new KeyCodeCombination(KeyCode.D, KeyCombination.SHORTCUT_DOWN);
     public static final KeyCodeCombination SWITCH_DEFAULT_REPO =
@@ -121,11 +121,11 @@ public class KeyboardShortcuts {
 
     // ui.MenuControl
     public static final KeyCodeCombination NEW_ISSUE =
-            new KeyCodeCombination(KeyCode.I, KeyCombination.SHORTCUT_DOWN);
+            new KeyCodeCombination(KeyCode.I, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
     public static final KeyCodeCombination NEW_LABEL =
-            new KeyCodeCombination(KeyCode.L, KeyCombination.SHORTCUT_DOWN);
+            new KeyCodeCombination(KeyCode.L, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
     public static final KeyCodeCombination NEW_MILESTONE =
-            new KeyCodeCombination(KeyCode.M, KeyCombination.SHORTCUT_DOWN);
+            new KeyCodeCombination(KeyCode.M, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
 
     public static final KeyCodeCombination CREATE_LEFT_PANEL =
             new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -318,8 +318,8 @@ public class ListPanel extends FilterPanel {
         return issueCount;
     }
 
-    public TurboIssue getSelectedIssue() {
-        return listView.getSelectedItem().get();
+    public Optional<TurboIssue> getSelectedIssue() {
+        return listView.getSelectedItem();
     }
 
     /* Methods that perform user's actions under the context of this ListPanel */
@@ -346,6 +346,8 @@ public class ListPanel extends FilterPanel {
     }
 
     private void changeLabels() {
-        ui.triggerEvent(new ShowLabelPickerEvent(getSelectedIssue()));
+        if (getSelectedIssue().isPresent()) {
+            ui.triggerEvent(new ShowLabelPickerEvent(getSelectedIssue().get()));
+        }
     }
 }

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -1,23 +1,6 @@
 package ui.listpanel;
 
-import static ui.components.KeyboardShortcuts.GOTO_MODIFIER;
-import static ui.components.KeyboardShortcuts.JUMP_TO_FIRST_ISSUE;
-import static ui.components.KeyboardShortcuts.JUMP_TO_NTH_ISSUE_KEYS;
-import static ui.components.KeyboardShortcuts.MANAGE_ASSIGNEES;
-import static ui.components.KeyboardShortcuts.MINIMIZE_WINDOW;
-import static ui.components.KeyboardShortcuts.NEW_COMMENT;
-import static ui.components.KeyboardShortcuts.SHOW_CONTRIBUTORS;
-import static ui.components.KeyboardShortcuts.SHOW_DOCS;
-import static ui.components.KeyboardShortcuts.SHOW_HELP;
-import static ui.components.KeyboardShortcuts.SHOW_ISSUES;
-import static ui.components.KeyboardShortcuts.SHOW_KEYBOARD_SHORTCUTS;
-import static ui.components.KeyboardShortcuts.SHOW_LABELS;
-import static ui.components.KeyboardShortcuts.SHOW_MILESTONES;
-import static ui.components.KeyboardShortcuts.SHOW_PULL_REQUESTS;
-import static ui.components.KeyboardShortcuts.UNDO_LABEL_CHANGES;
-import static ui.components.KeyboardShortcuts.PR_FILES_CHANGED;
-import static ui.components.KeyboardShortcuts.PR_COMMITS;
-
+import static ui.components.KeyboardShortcuts.*;
 import static util.GithubURLPageElements.DISCUSSION_TAB;
 import static util.GithubURLPageElements.COMMITS_TAB;
 import static util.GithubURLPageElements.FILES_TAB;
@@ -204,9 +187,7 @@ public class ListPanel extends FilterPanel {
                 ui.getBrowserComponent().scrollToTop();
             }
             if (KeyboardShortcuts.scrollToBottom.match(event)) {
-                if (!MINIMIZE_WINDOW.match(event)) {
-                    ui.getBrowserComponent().scrollToBottom();
-                }
+                ui.getBrowserComponent().scrollToBottom();
             }
             if (KeyboardShortcuts.scrollUp.match(event) || KeyboardShortcuts.scrollDown.match(event)) {
                 ui.getBrowserComponent().scrollPage(KeyboardShortcuts.scrollDown.match(event));

--- a/src/test/java/guitests/IssuePanelTests.java
+++ b/src/test/java/guitests/IssuePanelTests.java
@@ -1,6 +1,8 @@
 package guitests;
 
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.JUMP_TO_FIRST_ISSUE;
+
 import github.IssueEventType;
 import github.TurboIssueEvent;
 
@@ -43,7 +45,7 @@ public class IssuePanelTests extends UITest {
         press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
         type("date");
         push(KeyCode.ENTER);
-        press(KeyCode.CONTROL).press(KeyCode.ENTER).release(KeyCode.ENTER).release(KeyCode.CONTROL);
+        press(JUMP_TO_FIRST_ISSUE);
         push(KeyCode.DOWN).push(KeyCode.DOWN);
         sleep(EVENT_DELAY);
         assertEquals(3, issuePanel.getSelectedIssue().getId());

--- a/src/test/java/guitests/IssuePanelTests.java
+++ b/src/test/java/guitests/IssuePanelTests.java
@@ -48,12 +48,14 @@ public class IssuePanelTests extends UITest {
         press(JUMP_TO_FIRST_ISSUE);
         push(KeyCode.DOWN).push(KeyCode.DOWN);
         sleep(EVENT_DELAY);
-        assertEquals(3, issuePanel.getSelectedIssue().getId());
+        assertEquals(true, issuePanel.getSelectedIssue().isPresent());
+        assertEquals(3, issuePanel.getSelectedIssue().get().getId());
         sleep(EVENT_DELAY);
         UI.events.triggerEvent(UpdateDummyRepoEvent.updateIssue("dummy/dummy", 3, "updated issue"));
         UI.events.triggerEvent(new UILogicRefreshEvent());
         sleep(EVENT_DELAY);
-        assertEquals(3, issuePanel.getSelectedIssue().getId());
+        assertEquals(true, issuePanel.getSelectedIssue().isPresent());
+        assertEquals(3, issuePanel.getSelectedIssue().get().getId());
     }
 
     @Test

--- a/src/test/java/guitests/KeyboardShortcutsTest.java
+++ b/src/test/java/guitests/KeyboardShortcutsTest.java
@@ -15,6 +15,7 @@ import util.events.testevents.UIComponentFocusEvent;
 import util.events.testevents.UIComponentFocusEventHandler;
 
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.*;
 
 import static ui.components.KeyboardShortcuts.SWITCH_DEFAULT_REPO;
 
@@ -35,76 +36,77 @@ public class KeyboardShortcutsTest extends UITest {
 
         // maximize
         assertEquals(false, stage.getMinWidth() > 500);
-        press(KeyCode.CONTROL).press(KeyCode.X).release(KeyCode.X).release(KeyCode.CONTROL);
+        press(MAXIMIZE_WINDOW);
         assertEquals(true, stage.getMinWidth() > 500);
 
         // mid-sized window
-        press(KeyCode.CONTROL).press(KeyCode.D).release(KeyCode.D).release(KeyCode.CONTROL);
+        press(DEFAULT_SIZE_WINDOW);
         assertEquals(false, stage.getMinWidth() > 500);
 
         // jump from panel focus to first issue
         // - This is because on startup focus is on panel and not on filter box
-        press(KeyCode.CONTROL).press(KeyCode.ENTER).release(KeyCode.ENTER).release(KeyCode.CONTROL);
+        press(JUMP_TO_FIRST_ISSUE);
         assertEquals(10, selectedIssueId);
         clearSelectedIssueId();
 
         // jump from issue list to filter box
-        press(KeyCode.CONTROL).press(KeyCode.F).release(KeyCode.F).release(KeyCode.CONTROL);
+        press(JUMP_TO_FILTER_BOX);
         assertEquals(UIComponentFocusEvent.EventType.FILTER_BOX, uiComponentFocusEventType);
         clearUiComponentFocusEventType();
 
         // jump from filter box to first issue
         // - To ensure shortcut works from filter box, too
-        press(KeyCode.CONTROL).press(KeyCode.ENTER).release(KeyCode.ENTER).release(KeyCode.CONTROL);
+        press(JUMP_TO_FIRST_ISSUE);
+        press(JUMP_TO_FILTER_BOX);
         assertEquals(10, selectedIssueId);
         clearSelectedIssueId();
 
         // jump to first issue using number key(1) or ENTER
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT1).release(KeyCode.DIGIT1).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(1));
         PlatformEx.waitOnFxThread();
         assertEquals(10, selectedIssueId);
         clearSelectedIssueId();
-        press(KeyCode.CONTROL).press(KeyCode.F).release(KeyCode.F).release(KeyCode.CONTROL);
+        press(JUMP_TO_FILTER_BOX);
         assertEquals(UIComponentFocusEvent.EventType.FILTER_BOX, uiComponentFocusEventType);
         clearUiComponentFocusEventType();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT2).release(KeyCode.DIGIT2).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(2));
         PlatformEx.waitOnFxThread();
         assertEquals(9, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT3).release(KeyCode.DIGIT3).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(3));
         PlatformEx.waitOnFxThread();
         assertEquals(8, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT4).release(KeyCode.DIGIT4).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(4));
         PlatformEx.waitOnFxThread();
         assertEquals(7, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT5).release(KeyCode.DIGIT5).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(5));
         PlatformEx.waitOnFxThread();
         assertEquals(6, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT6).release(KeyCode.DIGIT6).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(6));
         PlatformEx.waitOnFxThread();
         assertEquals(5, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT7).release(KeyCode.DIGIT7).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(7));
         PlatformEx.waitOnFxThread();
         assertEquals(4, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT8).release(KeyCode.DIGIT8).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(8));
         PlatformEx.waitOnFxThread();
         assertEquals(3, selectedIssueId);
         clearSelectedIssueId();
         push(KeyCode.ESCAPE);
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT9).release(KeyCode.DIGIT9).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(9));
         PlatformEx.waitOnFxThread();
         assertEquals(2, selectedIssueId);
         clearSelectedIssueId();
@@ -130,8 +132,8 @@ public class KeyboardShortcutsTest extends UITest {
         assertEquals(9, selectedIssueId);
         clearSelectedIssueId();
 
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
-        press(KeyCode.CONTROL).press(KeyCode.ENTER).release(KeyCode.ENTER).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
+        press(JUMP_TO_FIRST_ISSUE);
 
         push(getKeyCode("RIGHT_PANEL"));
         assertEquals(0, panelIndex);
@@ -172,12 +174,12 @@ public class KeyboardShortcutsTest extends UITest {
         // test shortcut when focus is on panel
         PlatformEx.waitOnFxThread();
         click("#dummy/dummy_col1_1");
-        press(KeyCode.CONTROL).press(KeyCode.R).release(KeyCode.R).release(KeyCode.CONTROL);
+        press(SWITCH_DEFAULT_REPO);
         PlatformEx.waitOnFxThread();
         assertEquals(repoSelectorComboBox.getValue(), "dummy1/dummy1");
         // test shortcut when focus is on issue list
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT1).release(KeyCode.DIGIT1).release(KeyCode.CONTROL);
-        press(KeyCode.CONTROL).press(KeyCode.R).release(KeyCode.R).release(KeyCode.CONTROL);
+        press(JUMP_TO_NTH_ISSUE_KEYS.get(1));
+        press(SWITCH_DEFAULT_REPO);
         PlatformEx.waitOnFxThread();
         assertEquals(repoSelectorComboBox.getValue(), "dummy/dummy");
 
@@ -217,7 +219,7 @@ public class KeyboardShortcutsTest extends UITest {
         assertEquals(5, selectedIssueId);
         
         // minimize window
-        press(KeyCode.CONTROL).press(KeyCode.N).release(KeyCode.N).release(KeyCode.CONTROL); // run this last
+        press(MINIMIZE_WINDOW);
         assertEquals(true, stage.isIconified());
 
     }

--- a/src/test/java/guitests/KeyboardShortcutsTest.java
+++ b/src/test/java/guitests/KeyboardShortcutsTest.java
@@ -193,18 +193,21 @@ public class KeyboardShortcutsTest extends UITest {
         push(getKeyCode("MARK_AS_READ"));
         assertEquals(issueIdExpected, selectedIssueId);
         push(getKeyCode("UP_ISSUE")); // required since focus has changed to next issue
-        assertEquals(true, issuePanel.getSelectedIssue().isCurrentlyRead());
+        assertEquals(true, issuePanel.getSelectedIssue().isPresent());
+        assertEquals(true, issuePanel.getSelectedIssue().get().isCurrentlyRead());
         
         // mark as read an issue at the bottom
         push(KeyCode.END);
         push(getKeyCode("MARK_AS_READ"));
         // focus should remain at bottom issue
         assertEquals(1, selectedIssueId);
-        assertEquals(true, issuePanel.getSelectedIssue().isCurrentlyRead());
+        assertEquals(true, issuePanel.getSelectedIssue().isPresent());
+        assertEquals(true, issuePanel.getSelectedIssue().get().isCurrentlyRead());
         
         // mark as unread
         push(getKeyCode("MARK_AS_UNREAD"));
-        assertEquals(false, issuePanel.getSelectedIssue().isCurrentlyRead());
+        assertEquals(true, issuePanel.getSelectedIssue().isPresent());
+        assertEquals(false, issuePanel.getSelectedIssue().get().isCurrentlyRead());
         clearSelectedIssueId();
 
         // testing corner case for mark as read where there is only one issue displayed

--- a/src/test/java/guitests/PanelRenameTest.java
+++ b/src/test/java/guitests/PanelRenameTest.java
@@ -15,6 +15,8 @@ import util.PlatformEx;
 import util.events.ShowRenamePanelEvent;
 
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.CREATE_RIGHT_PANEL;
+import static ui.components.KeyboardShortcuts.MAXIMIZE_WINDOW;
 
 public class PanelRenameTest extends UITest {
 
@@ -33,8 +35,7 @@ public class PanelRenameTest extends UITest {
         
         // Test for saving panel name
         
-        // maximize
-        press(KeyCode.CONTROL).press(KeyCode.X).release(KeyCode.X).release(KeyCode.CONTROL);
+        press(MAXIMIZE_WINDOW);
         sleep(EVENT_DELAY);
 
         // Testing case where rename is canceled with ESC
@@ -47,7 +48,7 @@ public class PanelRenameTest extends UITest {
         assertEquals("Panel", panelNameText0.getText());
         sleep(EVENT_DELAY);
         
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         
         // Testing case where a name with whitespaces at either end is submitted
         // Expected: new name accepted with whitespaces removed
@@ -58,9 +59,9 @@ public class PanelRenameTest extends UITest {
         Text panelNameText1 = find("#dummy/dummy_col1_nameText");
         assertEquals("Renamed panel", panelNameText1.getText());
         sleep(EVENT_DELAY);
-        
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
-        
+
+        press(CREATE_RIGHT_PANEL);
+
         // Testing case where empty name is submitted
         // Expected: new name not accepted
         PlatformEx.runAndWait(() -> UI.events.triggerEvent(new ShowRenamePanelEvent(2)));
@@ -71,7 +72,7 @@ public class PanelRenameTest extends UITest {
         assertEquals("Panel", panelNameText2.getText());
         sleep(EVENT_DELAY);
         
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         
         // Testing boundary case where a name shorter than maximum allowed length is submitted
         // Expected: new name accepted
@@ -85,7 +86,7 @@ public class PanelRenameTest extends UITest {
         assertEquals(randomName3, panelNameText3.getText());
         sleep(EVENT_DELAY);
         
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         
         // Testing boundary case where a name exactly at maximum allowed length is submitted
         // Expected: new name accepted
@@ -98,9 +99,9 @@ public class PanelRenameTest extends UITest {
         Text panelNameText4 = find("#dummy/dummy_col4_nameText");
         assertEquals(randomName4, panelNameText4.getText());
         sleep(EVENT_DELAY);
-        
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
-        
+
+        press(CREATE_RIGHT_PANEL);
+
         // Testing boundary case where a name longer than maximum allowed length is submitted
         // Expected: new name not accepted
         PlatformEx.runAndWait(() -> UI.events.triggerEvent(new ShowRenamePanelEvent(5)));
@@ -113,8 +114,7 @@ public class PanelRenameTest extends UITest {
         assertEquals("Panel", panelNameText5.getText());
         sleep(EVENT_DELAY);
         
-        
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         
         // Testing typing more characters when textfield is full
         // Expected: new name accepted with additional characters not added
@@ -132,7 +132,7 @@ public class PanelRenameTest extends UITest {
         assertEquals(randomName6, panelNameText6.getText());
         sleep(EVENT_DELAY);
         
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         
         PlatformEx.runAndWait(() -> UI.events.triggerEvent(new ShowRenamePanelEvent(7)));
         sleep(EVENT_DELAY);

--- a/src/test/java/guitests/ScrollableListViewTests.java
+++ b/src/test/java/guitests/ScrollableListViewTests.java
@@ -24,12 +24,14 @@ public class ScrollableListViewTests extends UITest {
             push(KeyCode.DOWN);
         }
         sleep(1000);
-        assertEquals(9, col0.getSelectedIssue().getId());
+        assertEquals(true, col0.getSelectedIssue().isPresent());
+        assertEquals(9, col0.getSelectedIssue().get().getId());
         for (int i = 0; i < 40; i++) {
             push(KeyCode.UP);
         }
         sleep(1000);
-        assertEquals(49, col0.getSelectedIssue().getId());
+        assertEquals(true, col0.getSelectedIssue().isPresent());
+        assertEquals(49, col0.getSelectedIssue().get().getId());
     }
 
 }

--- a/src/test/java/guitests/UIEventTests.java
+++ b/src/test/java/guitests/UIEventTests.java
@@ -4,7 +4,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.input.KeyCode;
 import org.junit.Test;
 import ui.UI;
-import util.PlatformEx;
+import ui.components.KeyboardShortcuts;
 import util.events.IssueCreatedEventHandler;
 import util.events.LabelCreatedEventHandler;
 import util.events.MilestoneCreatedEventHandler;
@@ -12,9 +12,8 @@ import util.events.PanelClickedEventHandler;
 import util.events.testevents.PrimaryRepoChangedEvent;
 import util.events.testevents.PrimaryRepoChangedEventHandler;
 
-import static ui.components.KeyboardShortcuts.SWITCH_DEFAULT_REPO;
-
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.*;
 
 public class UIEventTests extends UITest {
 
@@ -41,7 +40,7 @@ public class UIEventTests extends UITest {
         click("Issue");
         assertEquals(1, eventTestCount);
         resetEventTestCount();
-        press(KeyCode.CONTROL).press(KeyCode.I).release(KeyCode.I).release(KeyCode.CONTROL);
+        press(NEW_ISSUE);
         assertEquals(1, eventTestCount);
     }
 
@@ -53,7 +52,7 @@ public class UIEventTests extends UITest {
         click("Label");
         assertEquals(1, eventTestCount);
         resetEventTestCount();
-        press(KeyCode.CONTROL).press(KeyCode.L).release(KeyCode.L).release(KeyCode.CONTROL);
+        press(NEW_LABEL);
         assertEquals(1, eventTestCount);
     }
 
@@ -65,7 +64,7 @@ public class UIEventTests extends UITest {
         click("Milestone");
         assertEquals(1, eventTestCount);
         resetEventTestCount();
-        press(KeyCode.CONTROL).press(KeyCode.M).release(KeyCode.M).release(KeyCode.CONTROL);
+        press(NEW_MILESTONE);
         assertEquals(1, eventTestCount);
     }
 
@@ -82,8 +81,7 @@ public class UIEventTests extends UITest {
         UI.events.registerEvent((PrimaryRepoChangedEventHandler) e -> UIEventTests.increaseEventTestCount());
         UI.events.registerEvent((PrimaryRepoChangedEventHandler) e -> UIEventTests.getEventRepoId(e));
         resetEventTestCount();
-        pushKeys(SWITCH_DEFAULT_REPO);
-        PlatformEx.waitOnFxThread();
+        press(KeyboardShortcuts.SWITCH_DEFAULT_REPO);
         assertEquals(1, eventTestCount);
         resetEventTestCount();
 
@@ -95,9 +93,9 @@ public class UIEventTests extends UITest {
         push(KeyCode.ENTER);
         click("#dummy/dummy_col0_filterTextField");
         resetEventTestCount();
-        press(KeyCode.CONTROL).press(KeyCode.R).release(KeyCode.R).release(KeyCode.CONTROL);
+        press(KeyboardShortcuts.SWITCH_DEFAULT_REPO);
         assertEquals(1, eventTestCount);
-        press(KeyCode.CONTROL).press(KeyCode.R).release(KeyCode.R).release(KeyCode.CONTROL);
+        press(KeyboardShortcuts.SWITCH_DEFAULT_REPO);
         assertEquals("dummy3/dummy3", defaultRepoId);
     }
 }

--- a/src/test/java/unstable/LabelPickerTests.java
+++ b/src/test/java/unstable/LabelPickerTests.java
@@ -13,6 +13,7 @@ import util.PlatformEx;
 import util.events.ShowLabelPickerEvent;
 
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.UNDO_LABEL_CHANGES;
 
 public class LabelPickerTests extends UITest {
 
@@ -111,7 +112,7 @@ public class LabelPickerTests extends UITest {
         assertEquals(0, listPanelCell.getIssueLabels().size());
 
         click("#dummy/dummy_col0_9");
-        press(KeyCode.CONTROL).press(KeyCode.Z).release(KeyCode.Z).release(KeyCode.CONTROL);
+        press(UNDO_LABEL_CHANGES);
         while (notificationPane.isShowing()) {
             PlatformEx.waitOnFxThread();
             sleep(100);

--- a/src/test/java/unstable/MenuControlTest.java
+++ b/src/test/java/unstable/MenuControlTest.java
@@ -13,6 +13,7 @@ import prefs.Preferences;
 import util.PlatformEx;
 import util.events.ModelUpdatedEventHandler;
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.*;
 
 public class MenuControlTest extends UITest {
 
@@ -26,12 +27,11 @@ public class MenuControlTest extends UITest {
         PanelControl panelControl = (PanelControl) find("#dummy/dummy_col0").getParent();
         Preferences testPref = UI.prefs;
         
-        press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
+        press(CLOSE_PANEL);
         assertEquals(0, panelControl.getNumberOfPanels());
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         assertEquals(1, panelControl.getNumberOfPanels());
-        press(KeyCode.CONTROL).press(KeyCode.SHIFT).press(KeyCode.P).release(KeyCode.P)
-            .release(KeyCode.SHIFT).release(KeyCode.CONTROL);
+        press(CREATE_LEFT_PANEL);
         assertEquals(2, panelControl.getNumberOfPanels());
 
         click("Panels");
@@ -60,7 +60,7 @@ public class MenuControlTest extends UITest {
         
         // Testing board open keyboard shortcut when no board is saved
         // Expected: nothing happens
-        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        pushKeys(SWITCH_BOARD);
         assertEquals(false, testPref.getLastOpenBoard().isPresent());
         
         // Testing board save as
@@ -74,11 +74,11 @@ public class MenuControlTest extends UITest {
         
         // Testing board open keyboard shortcut when there is only one saved board
         // Expected: nothing happens
-        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        press(SWITCH_BOARD);
         assertEquals(true, testPref.getLastOpenBoard().isPresent());
         assertEquals("Board 1", testPref.getLastOpenBoard().get());
 
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         assertEquals(3, panelControl.getNumberOfPanels());
         
         click("Boards");
@@ -103,11 +103,11 @@ public class MenuControlTest extends UITest {
         PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
 
-        press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
-        press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
-        press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
+        press(CLOSE_PANEL);
+        press(CLOSE_PANEL);
+        press(CLOSE_PANEL);
         assertEquals(0, panelControl.getNumberOfPanels());
-        
+
         // Testing board open
         click("Boards");
         push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
@@ -118,16 +118,16 @@ public class MenuControlTest extends UITest {
 
         // Testing First Panel selected
         assertEquals(0, (int) panelControl.getCurrentlySelectedPanel().get());
-        press(KeyCode.CONTROL).press(KeyCode.DIGIT1).release(KeyCode.DIGIT1).release(KeyCode.CONTROL);
+        press(KeyboardShortcuts.JUMP_TO_NTH_ISSUE_KEYS.get(1));
         assertEquals(0, (int) panelControl.getCurrentlySelectedPanel().get());
         
         // Testing board open keyboard shortcut
-        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        press(SWITCH_BOARD);
         assertEquals(true, testPref.getLastOpenBoard().isPresent());
         assertEquals("Board 1", testPref.getLastOpenBoard().get());
         
         // Testing board save
-        press(KeyCode.CONTROL).press(KeyCode.W).release(KeyCode.W).release(KeyCode.CONTROL);
+        press(CLOSE_PANEL);
         click("Boards");
         push(KeyCode.DOWN);
         push(KeyCode.ENTER);
@@ -146,7 +146,7 @@ public class MenuControlTest extends UITest {
         
         // Testing board open keyboard shortcut when there are saved boards but none is open
         // Expected: nothing happens
-        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        pushKeys(SWITCH_BOARD);
         assertEquals(false, testPref.getLastOpenBoard().isPresent());
         
         // Testing board save when no board is open because current board was closed

--- a/src/test/java/unstable/PanelFocusTest.java
+++ b/src/test/java/unstable/PanelFocusTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.*;
 
 public class PanelFocusTest extends UITest {
 
@@ -73,9 +74,9 @@ public class PanelFocusTest extends UITest {
         assertEquals(1, (int) panelControl.getCurrentlySelectedPanel().get());
 
         // More shortcut checks to ensure the focus is always correct
-        press(KeyCode.CONTROL).press(KeyCode.F).release(KeyCode.F).release(KeyCode.CONTROL);
+        press(JUMP_TO_FILTER_BOX);
         assertEquals(1, (int) panelControl.getCurrentlySelectedPanel().get());
-        press(KeyCode.CONTROL).press(KeyCode.ENTER).release(KeyCode.ENTER).release(KeyCode.CONTROL);
+        press(JUMP_TO_FIRST_ISSUE);
         assertEquals(1, (int) panelControl.getCurrentlySelectedPanel().get());
         push(KeyCode.F);
         assertEquals(2, (int) panelControl.getCurrentlySelectedPanel().get());
@@ -88,7 +89,7 @@ public class PanelFocusTest extends UITest {
         // test that upon creating panel on the right, focus is on the last panel
         // - this includes testing double space as the last panel might be
         //   colour focused but the real JavaFX focus is on first panel
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         PlatformEx.waitOnFxThread();
         assertEquals((int) panelControl.getCurrentlySelectedPanel().get(),
                 panelControl.getNumberOfPanels() - 1);
@@ -99,8 +100,7 @@ public class PanelFocusTest extends UITest {
 
         // test that upon creating panel on the left, focus is on the first panel
         // - same consideration as above
-        press(KeyCode.CONTROL).press(KeyCode.SHIFT).press(KeyCode.P).
-                release(KeyCode.P).release(KeyCode.SHIFT).release(KeyCode.CONTROL);
+        press(CREATE_LEFT_PANEL);
         PlatformEx.waitOnFxThread();
         assertEquals(0, (int) panelControl.getCurrentlySelectedPanel().get());
         type("  ");
@@ -121,12 +121,12 @@ public class PanelFocusTest extends UITest {
         PlatformEx.waitOnFxThread();
         assertEquals(1, panelControl.getNumberOfSavedBoards());
         // 2. Create a new panel so that scroll bar is on the left
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         PlatformEx.waitOnFxThread();
         assertEquals((int) panelControl.getCurrentlySelectedPanel().get(),
                 panelControl.getNumberOfPanels() - 1);
         // 3. Open board
-        press(KeyCode.CONTROL).press(KeyCode.B).release(KeyCode.B).release(KeyCode.CONTROL);
+        press(SWITCH_BOARD);
         PlatformEx.waitOnFxThread();
 
         // Check that first panel is on focus

--- a/src/test/java/unstable/PanelsTest.java
+++ b/src/test/java/unstable/PanelsTest.java
@@ -3,6 +3,8 @@ package unstable;
 import guitests.UITest;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static ui.components.KeyboardShortcuts.CREATE_RIGHT_PANEL;
+import static ui.components.KeyboardShortcuts.MAXIMIZE_WINDOW;
 
 import org.junit.Test;
 import org.loadui.testfx.exceptions.NoNodesFoundException;
@@ -28,10 +30,9 @@ public class PanelsTest extends UITest {
 
         UI.events.registerEvent((PanelClickedEventHandler) e -> eventTriggered.negate());
 
-        // maximize
-        press(KeyCode.CONTROL).press(KeyCode.X).release(KeyCode.X).release(KeyCode.CONTROL);
+        press(MAXIMIZE_WINDOW);
 
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         type("repo");
         press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
         type("dummy2/dummy2");
@@ -62,7 +63,7 @@ public class PanelsTest extends UITest {
         doubleClick();
         type("dummy2/dummy2");
         push(KeyCode.ENTER);
-        press(KeyCode.CONTROL).press(KeyCode.P).release(KeyCode.P).release(KeyCode.CONTROL);
+        press(CREATE_RIGHT_PANEL);
         // Actually a check. If #dummy2/dummy2_col1 did not exist, this would throw an exception.
         click("#dummy2/dummy2_col1");
     }

--- a/src/test/java/unstable/ValidLoginTest.java
+++ b/src/test/java/unstable/ValidLoginTest.java
@@ -26,8 +26,7 @@ public class ValidLoginTest extends UITest {
         type("test").push(KeyCode.TAB);
         type("test");
         click("Sign in");
-        sleep(2000);
-        ComboBox<String> repositorySelector = find("#repositorySelector");
+        ComboBox<String> repositorySelector = findOrWaitFor("#repositorySelector");
         assertEquals("test/test", repositorySelector.getValue());
     }
 }


### PR DESCRIPTION
Fixes #957. Tests broken as a result of this change have been updated to use the KeyboardShortcuts constants so things are more DRY.