### PR TITLE
 Improve or change panel element selection in tests #933 

### DIFF
--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -51,6 +51,7 @@ public abstract class FilterPanel extends AbstractPanel {
     protected HBox nameBox;
     protected HBox menuBarNameArea;
     protected Label renameButton;
+    protected Label closeButton;
     protected PanelNameTextField renameTextField;
     protected FilterTextField filterTextField;
     
@@ -173,7 +174,7 @@ public abstract class FilterPanel extends AbstractPanel {
     private HBox createCloseButton() {
         HBox closeArea = new HBox();
         
-        Label closeButton = new Label(CLOSE_PANEL);
+        closeButton = new Label(CLOSE_PANEL);
         closeButton.setId(model.getDefaultRepo() + "_col" + panelIndex + "_closeButton");
         closeButton.getStyleClass().add("label-button");
         closeButton.setOnMouseClicked((e) -> {
@@ -308,6 +309,26 @@ public abstract class FilterPanel extends AbstractPanel {
     
     public PanelInfo getCurrentInfo() {
         return new PanelInfo(this.panelName, filterTextField.getText());
+    }
+
+    public Text getNameText() {
+        return this.nameText;
+    }
+
+    public FilterTextField getFilterTextField() {
+        return this.filterTextField;
+    }
+
+    public PanelNameTextField getRenameTextField() {
+        return this.renameTextField;
+    }
+
+    public Label getRenameButton() {
+        return this.renameButton;
+    }
+
+    public Label getCloseButton() {
+        return this.closeButton;
     }
 
     public TransformationList<TurboIssue, TurboIssue> getIssueList() {

--- a/src/test/java/guitests/PanelRenameTest.java
+++ b/src/test/java/guitests/PanelRenameTest.java
@@ -9,7 +9,10 @@ import org.junit.Test;
 import org.loadui.testfx.utils.FXTestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import ui.TestController;
 import ui.UI;
+import ui.issuepanel.FilterPanel;
+import ui.issuepanel.PanelControl;
 import ui.components.PanelNameTextField;
 import util.PlatformEx;
 import util.events.ShowRenamePanelEvent;
@@ -32,6 +35,8 @@ public class PanelRenameTest extends UITest {
     public void panelRenameTest() {
         
         Random rand = new Random();
+        UI ui = TestController.getUI();
+        PanelControl panels = ui.getPanelControl();
         
         // Test for saving panel name
         
@@ -44,7 +49,8 @@ public class PanelRenameTest extends UITest {
         sleep(EVENT_DELAY);
         type("Renamed panel");
         push(KeyCode.ESCAPE);
-        Text panelNameText0 = find("#dummy/dummy_col0_nameText");
+        FilterPanel panel0 = (FilterPanel) panels.getPanel(0);
+        Text panelNameText0 = panel0.getNameText();
         assertEquals("Panel", panelNameText0.getText());
         sleep(EVENT_DELAY);
         
@@ -56,7 +62,8 @@ public class PanelRenameTest extends UITest {
         sleep(EVENT_DELAY);
         type("   Renamed panel  ");
         push(KeyCode.ENTER);
-        Text panelNameText1 = find("#dummy/dummy_col1_nameText");
+        FilterPanel panel1 = (FilterPanel) panels.getPanel(1);
+        Text panelNameText1 = panel1.getNameText();
         assertEquals("Renamed panel", panelNameText1.getText());
         sleep(EVENT_DELAY);
 
@@ -68,7 +75,8 @@ public class PanelRenameTest extends UITest {
         sleep(EVENT_DELAY);
         push(KeyCode.BACK_SPACE);
         push(KeyCode.ENTER);
-        Text panelNameText2 = find("#dummy/dummy_col2_nameText");
+        FilterPanel panel2 = (FilterPanel) panels.getPanel(2);
+        Text panelNameText2 = panel2.getNameText();
         assertEquals("Panel", panelNameText2.getText());
         sleep(EVENT_DELAY);
         
@@ -82,7 +90,8 @@ public class PanelRenameTest extends UITest {
         PanelNameTextField renameTextField3 = find("#dummy/dummy_col3_renameTextField");
         renameTextField3.setText(randomName3);
         push(KeyCode.ENTER);
-        Text panelNameText3 = find("#dummy/dummy_col3_nameText");
+        FilterPanel panel3 = (FilterPanel) panels.getPanel(3);
+        Text panelNameText3 = panel3.getNameText();
         assertEquals(randomName3, panelNameText3.getText());
         sleep(EVENT_DELAY);
         
@@ -96,7 +105,8 @@ public class PanelRenameTest extends UITest {
         PanelNameTextField renameTextField4 = find("#dummy/dummy_col4_renameTextField");
         renameTextField4.setText(randomName4);
         push(KeyCode.ENTER);
-        Text panelNameText4 = find("#dummy/dummy_col4_nameText");
+        FilterPanel panel4 = (FilterPanel) panels.getPanel(4);
+        Text panelNameText4 = panel4.getNameText();
         assertEquals(randomName4, panelNameText4.getText());
         sleep(EVENT_DELAY);
 
@@ -110,7 +120,8 @@ public class PanelRenameTest extends UITest {
         PanelNameTextField renameTextField5 = find("#dummy/dummy_col5_renameTextField");
         renameTextField5.setText(randomName5);
         push(KeyCode.ENTER);
-        Text panelNameText5 = find("#dummy/dummy_col5_nameText");
+        FilterPanel panel5 = (FilterPanel) panels.getPanel(5);
+        Text panelNameText5 = panel5.getNameText();
         assertEquals("Panel", panelNameText5.getText());
         sleep(EVENT_DELAY);
         
@@ -128,7 +139,8 @@ public class PanelRenameTest extends UITest {
         renameTextField6.positionCaret(randomCaret6);
         type("characters that will not be added");
         push(KeyCode.ENTER);
-        Text panelNameText6 = find("#dummy/dummy_col6_nameText");
+        FilterPanel panel6 = (FilterPanel) panels.getPanel(6);
+        Text panelNameText6 = panel6.getNameText();
         assertEquals(randomName6, panelNameText6.getText());
         sleep(EVENT_DELAY);
         
@@ -148,7 +160,8 @@ public class PanelRenameTest extends UITest {
         push(KeyCode.ENTER);
         String expected = (randomName7.substring(0, randomCaret7) + 
                 randomString.substring(0, 4) + randomName7.substring(randomCaret7, randomName7.length()));
-        Text panelNameText7 = find("#dummy/dummy_col7_nameText");
+        FilterPanel panel7 = (FilterPanel) panels.getPanel(7);
+        Text panelNameText7 = panel7.getNameText();
         assertEquals(expected, panelNameText7.getText());
         sleep(EVENT_DELAY);
         

--- a/src/test/java/guitests/PanelsTest.java
+++ b/src/test/java/guitests/PanelsTest.java
@@ -1,6 +1,5 @@
-package unstable;
+package guitests;
 
-import guitests.UITest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/src/test/java/tests/BoardSwitchTest.java
+++ b/src/test/java/tests/BoardSwitchTest.java
@@ -10,71 +10,74 @@ import java.util.ArrayList;
 import org.junit.Test;
 
 public class BoardSwitchTest {
-    
+
     Preferences testPrefs;
+    private static final String BOARDNAME1 = "Board 1";
+    private static final String BOARDNAME2 = "Board 2";
+    private static final String BOARDNAME3 = "Board 3";
 
     @Test
     public void boardsSwitchTest() {
-        testPrefs = new Preferences(true);
-        
+        testPrefs = new Preferences(false);
+
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
         List<PanelInfo> board2 = new ArrayList<PanelInfo>();
         List<PanelInfo> board3 = new ArrayList<PanelInfo>();
-        
-        testPrefs.addBoard("Board 1", board1);
-        testPrefs.addBoard("Board 2", board2);
-        testPrefs.addBoard("Board 3", board3);
-        
-        testPrefs.setLastOpenBoard("Board 1");
-        
+
+        testPrefs.addBoard(BOARDNAME1, board1);
+        testPrefs.addBoard(BOARDNAME2, board2);
+        testPrefs.addBoard(BOARDNAME3, board3);
+
+        testPrefs.setLastOpenBoard(BOARDNAME1);
+
         testPrefs.switchBoard();
-        assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
-        
+        assertEquals(BOARDNAME3, testPrefs.getLastOpenBoard().get());
+
         testPrefs.switchBoard();
-        assertEquals("Board 2", testPrefs.getLastOpenBoard().get());
-        
+        assertEquals(BOARDNAME2, testPrefs.getLastOpenBoard().get());
+
         testPrefs.switchBoard();
-        assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
-        
+        assertEquals(BOARDNAME1, testPrefs.getLastOpenBoard().get());
+
         testPrefs.switchBoard();
-        assertEquals("Board 3", testPrefs.getLastOpenBoard().get());
-        
+        assertEquals(BOARDNAME3, testPrefs.getLastOpenBoard().get());
+
     }
-    
+
     @Test
     public void noBoardSwitchTest() {
-        testPrefs = new Preferences(true);
-        
+        testPrefs = new Preferences(false);
+
         testPrefs.switchBoard();
         assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
     }
-    
+
     @Test
     public void noBoardOpenSwitchTest() {
-        testPrefs = new Preferences(true);
-        
+        testPrefs = new Preferences(false);
+
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
         List<PanelInfo> board2 = new ArrayList<PanelInfo>();
         List<PanelInfo> board3 = new ArrayList<PanelInfo>();
-        
-        testPrefs.addBoard("Board 1", board1);
-        testPrefs.addBoard("Board 2", board2);
-        testPrefs.addBoard("Board 3", board3);
-        
+
+        testPrefs.addBoard(BOARDNAME1, board1);
+        testPrefs.addBoard(BOARDNAME2, board2);
+        testPrefs.addBoard(BOARDNAME3, board3);
+
         testPrefs.switchBoard();
         assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
     }
-    
+
     @Test
     public void oneBoardSwitchTest() {
-        testPrefs = new Preferences(true);
-        
+        testPrefs = new Preferences(false);
+
         List<PanelInfo> board1 = new ArrayList<PanelInfo>();
-        testPrefs.addBoard("Board 1", board1);
-        testPrefs.setLastOpenBoard("Board 1");
-        
+        testPrefs.addBoard(BOARDNAME1, board1);
+        testPrefs.setLastOpenBoard(BOARDNAME1);
+
         testPrefs.switchBoard();
-        assertEquals("Board 1", testPrefs.getLastOpenBoard().get());
+        assertEquals(BOARDNAME1, testPrefs.getLastOpenBoard().get());
     }
 
 }

--- a/src/test/java/unstable/PanelsTest.java
+++ b/src/test/java/unstable/PanelsTest.java
@@ -1,14 +1,20 @@
 package unstable;
 
 import guitests.UITest;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import ui.TestController;
+import ui.issuepanel.FilterPanel;
+import ui.issuepanel.PanelControl;
 import static ui.components.KeyboardShortcuts.CREATE_RIGHT_PANEL;
 import static ui.components.KeyboardShortcuts.MAXIMIZE_WINDOW;
 
 import org.junit.Test;
 import org.loadui.testfx.exceptions.NoNodesFoundException;
 
+import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
 import ui.UI;
 import util.events.PanelClickedEventHandler;
@@ -25,6 +31,7 @@ public class PanelsTest extends UITest {
     // TODO check if interactions result in any effects
     @Test
     public void panelsTest() {
+        PanelControl panels = TestController.getUI().getPanelControl();
 
         Bool eventTriggered = new Bool();
 
@@ -40,7 +47,10 @@ public class PanelsTest extends UITest {
 
         // Drag
         // TODO check whether panels are actually reordered
-        drag("#dummy/dummy_col1_closeButton").to("#dummy/dummy_col0_closeButton");
+
+        Label closeButton0 = ((FilterPanel) panels.getPanel(0)).getCloseButton();
+        Label closeButton1 = ((FilterPanel) panels.getPanel(1)).getCloseButton();
+        drag(closeButton1).to(closeButton0);
 
         // Click
         eventTriggered.value = false;


### PR DESCRIPTION
Fixes #933 

Those tests involving more than 1 panels, especially if the ordering of the panels may change, were changed to use ```TextController``` to directly access panels instead of using IDs which are more fallible.