### PR TITLE
gradle build doesn't work #1084

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
 
     project.ext {
         log4jVersion = '2.3'
-        controlsfxVersion = '8.40.10-SNAPSHOT'
+        controlsfxVersion = '8.40.10'
         gsonVersion = '2.3.1'
         guavaVersion = '18.0'
         jnaVersion = '4.1.0'


### PR DESCRIPTION
Fixes #1084.

We don't really have a choice, seeing as the old version has been removed. Just have to make sure tests pass.