### PR TITLE
Panel UI becomes blank when switching repo #1056

### DIFF
--- a/src/main/java/ui/listpanel/ListPanelCell.java
+++ b/src/main/java/ui/listpanel/ListPanelCell.java
@@ -5,12 +5,15 @@ import backend.resource.Model;
 import backend.resource.TurboIssue;
 import javafx.geometry.Pos;
 import javafx.scene.control.ListCell;
+import org.apache.logging.log4j.Logger;
+import util.HTLog;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
 public class ListPanelCell extends ListCell<TurboIssue> {
+    private static final Logger logger = HTLog.get(ListPanelCell.class);
 
     private final IModel model;
     private final int parentPanelIndex;
@@ -40,8 +43,13 @@ public class ListPanelCell extends ListCell<TurboIssue> {
         }
         this.issue = issue;
         Optional<Model> currentModel = model.getModelById(issue.getRepoId());
-        assert currentModel.isPresent() : "Invalid repo id " + issue.getRepoId()
-            + " for issue " + issue.getId();
+        if (!currentModel.isPresent()) {
+            // TODO: see issue #1089
+            logger.error("Model is not present for issue " + issue.getId() + " at " + issue.getRepoId());
+            setGraphic(getGraphic());
+            return;
+        }
+
         setGraphic(new ListPanelCard(currentModel.get(), issue, parent, issuesWithNewComments));
         this.setId(issue.getRepoId() + "_col" + parentPanelIndex + "_" + issue.getId());
     }


### PR DESCRIPTION
Fixes #1056 

This only prevents the crash but doesn't solve the root of the problem, which is the race between loading and removing repos. I've tried various async solutions but they can still fail in some cases (switching rapidly twice between hubturbo and teammates, race problem happens about 1 in 10 trials). This is due to the interleaving between the entire repo loading/updating and repo removal process: 

<pre>
Load:    --------[used]--[load models]--------[update UI]--->
Remove:  [unused]---------------------[delete]-------------->
</pre>

Problem happens e.g. when `hubturbo` is in `[unused]` but then becomes `[used]` shortly after due to the rapid switching.

One solution is to make the **entire** load/update process mutually exclusive with the removal process. The order doesn't matter, supposed for a certain `used` repo:

* If `Remove` -> `Load`, then the repo is properly present.
* If `Load` -> `Remove`, then the repo will not be in the `[unused]` set, hence is not removed.

I could open a separate issue for this, any opinion?