### PR TITLE
Grayed out title is hard to read when the issue is selected #1080

### DIFF
--- a/src/main/resources/ui/hubturbo.css
+++ b/src/main/resources/ui/hubturbo.css
@@ -50,11 +50,12 @@
 }
 
 .issue-panel-name {
+    -fx-font-weight: bold;
     -fx-font-size: 14px;
 }
 
 .issue-panel-name-read {
-    -fx-text-fill: #808080;
+    -fx-font-weight: normal;
 }
 
 .issue-panel-closed .text {


### PR DESCRIPTION
Fixes #1080.
Use different font weight to distinguish read/unread.
In this case, bold font is used.

Unread (not selected):
![untitled](https://cloud.githubusercontent.com/assets/6754733/12016135/57983d02-ad82-11e5-8785-532743166398.png)

Unread (selected):
![untitled](https://cloud.githubusercontent.com/assets/6754733/12016160/9a369384-ad82-11e5-95d4-459158d3f6f7.png)

Read (not selected):
![untitled](https://cloud.githubusercontent.com/assets/6754733/12016171/c68e2f64-ad82-11e5-87b7-d73e14491f7d.png)

Read (selected):
![untitled](https://cloud.githubusercontent.com/assets/6754733/12016180/e341f244-ad82-11e5-8d85-e4b05193e008.png)