### PR TITLE
Add a 'new' option for the 'Boards' menu #1142

### DIFF
--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -87,7 +87,45 @@ public class MenuControl extends MenuBar {
         return file;
 
     }
-    
+
+    /**
+     * Creates an empty board. User will be prompted to
+     * confirm the action if there are unclosed panels.
+     */
+    private void onBoardNew() {
+        logger.info("Menu: Boards > New");
+
+        if (!isNewBoardCreationDialogConfirmed()) {
+            logger.info("New board creation cancelled");
+            return;
+        }
+
+        panels.closeAllPanels();
+        onBoardSaveAs();
+    }
+
+    /**
+     * Returns a boolean indicating whether we can proceed with
+     * the new board creation. If there are no panels open, it
+     * returns true; else a dialog is shown for the user to confirm.
+     */
+    private boolean isNewBoardCreationDialogConfirmed() {
+        List<PanelInfo> panelList = panels.getCurrentPanelInfos();
+        if (panelList.isEmpty()) {
+            return true;
+        }
+
+        Alert dlg = new Alert(AlertType.CONFIRMATION, "");
+        dlg.initModality(Modality.APPLICATION_MODAL);
+        dlg.setTitle("Confirmation");
+        dlg.getDialogPane().setHeaderText("Create a new board");
+        dlg.getDialogPane().setContentText("Are you sure you want to create a new board?" +
+                " All unsaved changes to the current board will be lost.");
+        Optional<ButtonType> response = dlg.showAndWait();
+        return response.isPresent() &&
+                response.get().getButtonData() == ButtonData.OK_DONE;
+    }
+
     private void onBoardSave() {
         logger.info("Menu: Boards > Save");
         
@@ -114,17 +152,11 @@ public class MenuControl extends MenuBar {
         logger.info("Menu: Boards > Save as");
 
         List<PanelInfo> panelList = panels.getCurrentPanelInfos();
-
-        if (panelList.isEmpty()) {
-            logger.info("Did not save new board");
-            return;
-        }
-
         BoardNameDialog dlg = new BoardNameDialog(prefs, mainStage);
         Optional<String> response = dlg.showAndWait();
         ui.showMainStage();
         panels.selectFirstPanel();
-        
+
         if (response.isPresent()) {
             String boardName = response.get().trim();
             prefs.addBoard(boardName, panelList);
@@ -179,6 +211,9 @@ public class MenuControl extends MenuBar {
     }
 
     private MenuItem[] createBoardsMenu() {
+        MenuItem newBoard = new MenuItem("New");
+        newBoard.setOnAction(e -> onBoardNew());
+
         MenuItem saveAs = new MenuItem("Save as");
         saveAs.setOnAction(e -> onBoardSaveAs());
         
@@ -211,7 +246,7 @@ public class MenuControl extends MenuBar {
 
         Menu autoCreate = boardAutoCreator.generateBoardAutoCreateMenu();
 
-        return new MenuItem[] {save, saveAs, open, delete, autoCreate};
+        return new MenuItem[] {newBoard, save, saveAs, open, delete, autoCreate};
     }
     
     public void switchBoard() {

--- a/src/main/java/ui/issuepanel/PanelControl.java
+++ b/src/main/java/ui/issuepanel/PanelControl.java
@@ -121,6 +121,9 @@ public class PanelControl extends HBox {
     }
 
     public void selectPanel(int index) {
+        if (getPanelCount() == 0) {
+            return;
+        }
         assert index >= 0 && index < getPanelCount();
         setCurrentlySelectedPanel(Optional.of(index));
         scrollToPanel(index);

--- a/src/test/java/unstable/MenuControlTest.java
+++ b/src/test/java/unstable/MenuControlTest.java
@@ -61,7 +61,7 @@ public class MenuControlTest extends UITest {
         // Testing board save when no board is open because nothing has been saved
         // Expected: prompts user to save as new board
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         type("Board 1");
         push(KeyCode.ESCAPE);
         PlatformEx.waitOnFxThread();
@@ -81,7 +81,16 @@ public class MenuControlTest extends UITest {
         assertEquals(1, panelControl.getNumberOfSavedBoards());
         assertEquals(2, panelControl.getPanelCount());
         assertEquals(ui.getTitle(), String.format(uiTitle, "Board 1"));
-        
+
+        // Testing board create new and cancel
+        // Expected: nothing happens
+        click("Boards");
+        push(KeyCode.DOWN).push(KeyCode.ENTER);
+        click("Cancel");
+        PlatformEx.waitOnFxThread();
+        assertEquals(1, panelControl.getNumberOfSavedBoards());
+        assertEquals(2, panelControl.getPanelCount());
+
         // Testing board switch keyboard shortcut when there is only one saved board
         // Expected: nothing happens
         press(SWITCH_BOARD);
@@ -92,7 +101,7 @@ public class MenuControlTest extends UITest {
         assertEquals(3, panelControl.getPanelCount());
         
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 2");
         click("OK");
         PlatformEx.waitOnFxThread();
@@ -102,21 +111,21 @@ public class MenuControlTest extends UITest {
         // Testing invalid board names
         // Expected: save button disabled
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("");
         Button saveButton1 = (Button) find("#boardsavebutton");
         assertEquals(true, saveButton1.isDisabled());
         push(KeyCode.ESCAPE);
 
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("   ");
         Button saveButton2 = (Button) find("#boardsavebutton");
         assertEquals(true, saveButton2.isDisabled());
         click("Cancel");
 
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("   none  ");
         Button saveButton3 = (Button) find("#boardsavebutton");
         assertEquals(true, saveButton3.isDisabled());
@@ -129,7 +138,7 @@ public class MenuControlTest extends UITest {
 
         // Testing board open
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
         push(KeyCode.RIGHT);
         push(KeyCode.ENTER); // Opening Board "2"
         PlatformEx.waitOnFxThread();
@@ -150,14 +159,31 @@ public class MenuControlTest extends UITest {
         // Testing board save
         press(CLOSE_PANEL);
         click("Boards");
-        push(KeyCode.DOWN);
+        push(KeyCode.DOWN).push(KeyCode.DOWN);
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
         assertEquals(2, panelControl.getNumberOfSavedBoards());
-        
+
+        // Testing board create new and confirm
+        click("Boards");
+        push(KeyCode.DOWN).push(KeyCode.ENTER);
+        click("OK");
+        assertEquals(0, panelControl.getPanelCount());
+        ((TextField) find("#boardnameinput")).setText("empty");
+        push(KeyCode.ENTER);
+        assertEquals(0, panelControl.getPanelCount());
+        assertEquals(ui.getTitle(), String.format(uiTitle, "empty"));
+        assertEquals(3, panelControl.getNumberOfSavedBoards());
+        click("Boards");
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
+        push(KeyCode.RIGHT);
+        push(KeyCode.DOWN);
+        push(KeyCode.ENTER); // Deleting current board (empty): no board is set as open
+        click("OK");
+
         // Testing board delete
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
         push(KeyCode.RIGHT);
         push(KeyCode.DOWN);
         push(KeyCode.ENTER); // Deleting current board (Board 1): no board is set as open
@@ -174,7 +200,7 @@ public class MenuControlTest extends UITest {
         // Testing board save when no board is open because current board was closed
         // Expected: prompts user to save as new board
         click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.ENTER);
+        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
         ((TextField) find("#boardnameinput")).setText("Board 1");
         click("OK");
         PlatformEx.waitOnFxThread();


### PR DESCRIPTION
Add an option for new empty board. Current panels will be closed and the empty board will be saved. Fixes #1142 .

The codes could be refactored as the method has many overlaps with the existing `onBoardSaveAs()`. However, that method forbids a save of an empty board.