### PR TITLE
Editing panel names: Adjust distance between tick mark and text box #1166

### DIFF
--- a/src/main/java/ui/components/PanelMenuBar.java
+++ b/src/main/java/ui/components/PanelMenuBar.java
@@ -42,7 +42,7 @@ public class PanelMenuBar extends HBox {
     private String panelName = "Panel";
     private Text nameText;
 
-    public static final int NAME_DISPLAY_WIDTH = PANEL_WIDTH - 70;
+    public static final int NAME_DISPLAY_WIDTH = PANEL_WIDTH - 80;
     public static final int NAME_AREA_WIDTH = PANEL_WIDTH - 65;
     public static final int TOOLTIP_WRAP_WIDTH = 220; //prefWidth for longer tooltip
 
@@ -93,6 +93,7 @@ public class PanelMenuBar extends HBox {
         nameArea.getChildren().add(nameBox);
         nameArea.setMinWidth(NAME_AREA_WIDTH);
         nameArea.setMaxWidth(NAME_AREA_WIDTH);
+        nameArea.setPadding(new Insets(0, 10, 0, 5));
         return nameArea;
     }
 

--- a/src/main/java/ui/components/PanelMenuBar.java
+++ b/src/main/java/ui/components/PanelMenuBar.java
@@ -7,7 +7,6 @@ import static ui.issuepanel.AbstractPanel.OCTICON_CLOSE_PANEL;
 import backend.interfaces.IModel;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
@@ -18,7 +17,6 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import ui.UI;
 import ui.issuepanel.FilterPanel;
-import ui.issuepanel.PanelControl;
 import util.events.ShowRenamePanelEvent;
 
 /**
@@ -31,6 +29,7 @@ public class PanelMenuBar extends HBox {
 
     private final HBox menuBarUndoButton;
     private final HBox menuBarConfirmButton;
+    private final HBox menuBarRenameButton;
     private final HBox menuBarCloseButton;
     private TextField renameableTextField;
     private final HBox menuBarNameArea;
@@ -44,8 +43,7 @@ public class PanelMenuBar extends HBox {
     private Text nameText;
 
     public static final int NAME_DISPLAY_WIDTH = PANEL_WIDTH - 70;
-    public static final int NAME_AREA_WIDTH = PANEL_WIDTH - 40;
-    public static final int NAME_AREA_EDIT_WIDTH = PANEL_WIDTH - 65; //width in the panel rename edit mode
+    public static final int NAME_AREA_WIDTH = PANEL_WIDTH - 65;
     public static final int TOOLTIP_WRAP_WIDTH = 220; //prefWidth for longer tooltip
 
     public PanelMenuBar(FilterPanel panel, IModel model, UI ui){
@@ -56,13 +54,16 @@ public class PanelMenuBar extends HBox {
         this.setMinWidth(PANEL_WIDTH);
         this.setMaxWidth(PANEL_WIDTH);
         menuBarNameArea = createNameArea();
+        menuBarRenameButton = createRenameButton();
         menuBarCloseButton = createCloseButton();
         menuBarConfirmButton = createOcticonButton(OCTICON_TICK_MARK, "confirmButton");
         menuBarUndoButton = createOcticonButton(OCTICON_UNDO, "undoButton");
 
+        menuBarRenameButton.setMaxWidth(27);
+        menuBarRenameButton.setMinWidth(27);
         menuBarConfirmButton.setMaxWidth(27);
         menuBarConfirmButton.setMinWidth(27);
-        this.getChildren().addAll(menuBarNameArea, menuBarCloseButton);
+        this.getChildren().addAll(menuBarNameArea, menuBarRenameButton, menuBarCloseButton);
         this.setPadding(new Insets(0, 0, 8, 0));
     }
 
@@ -87,27 +88,32 @@ public class PanelMenuBar extends HBox {
                 activateInplaceRename();
             }
         });
-        Tooltip.install(nameArea, new Tooltip("Edit the name of this panel"));
+        Tooltip.install(nameArea, new Tooltip("Double click to edit the name of this panel"));
 
-        HBox renameBox = new HBox();
-        renameButton = new Label(OCTICON_RENAME_PANEL);
-        renameButton.getStyleClass().addAll("octicon", "label-button");
-        renameButton.setId(model.getDefaultRepo() + "_col" + panel.panelIndex + "_renameButton");
-        renameButton.setOnMouseClicked(e -> {
-            e.consume();
-            activateInplaceRename();
-        });
-        renameBox.getChildren().add(renameButton);
-        renameBox.setAlignment(Pos.TOP_RIGHT);
-
-        nameArea.getChildren().addAll(nameBox, renameButton);
-        nameArea.setMinWidth(360);
-        nameArea.setMaxWidth(360);
+        nameArea.getChildren().add(nameBox);
+        nameArea.setMinWidth(NAME_AREA_WIDTH);
+        nameArea.setMaxWidth(NAME_AREA_WIDTH);
         return nameArea;
     }
 
     private void activateInplaceRename() {
         ui.triggerEvent(new ShowRenamePanelEvent(panel.panelIndex));
+    }
+
+    private HBox createRenameButton() {
+        HBox renameBox = new HBox();
+        renameButton = new Label(OCTICON_RENAME_PANEL);
+
+        renameButton.getStyleClass().addAll("octicon", "label-button");
+        renameButton.setId(model.getDefaultRepo() + "_col" + panel.panelIndex + "_renameButton");
+        renameButton.setOnMouseClicked((e) -> {
+            e.consume();
+            activateInplaceRename();
+        });
+        Tooltip.install(renameBox, new Tooltip("Edit the name of this panel"));
+
+        renameBox.getChildren().add(renameButton);
+        return renameBox;
     }
 
     private HBox createCloseButton() {
@@ -130,9 +136,8 @@ public class PanelMenuBar extends HBox {
         HBox buttonArea = new HBox();
 
         Label buttonType = new Label(octString);
-        buttonType.getStyleClass().addAll("octicon", "issue-event-icon");
+        buttonType.getStyleClass().addAll("octicon", "label-button");
         buttonType.setId(model.getDefaultRepo() + "_col" + panel.panelIndex + "_" + cssName);
-        buttonType.getStyleClass().add("label-button");
         buttonArea.getChildren().add(buttonType);
 
         return buttonArea;
@@ -185,11 +190,9 @@ public class PanelMenuBar extends HBox {
      * The confirm button and the undo button are added to the panel.
      */
     private void augmentRenameableTextField(){
-        menuBarNameArea.getChildren().removeAll(nameBox, renameButton);
-        this.getChildren().remove(menuBarCloseButton);
+        menuBarNameArea.getChildren().remove(nameBox);
+        this.getChildren().removeAll(menuBarRenameButton, menuBarCloseButton);
         menuBarNameArea.getChildren().addAll(renameableTextField);
-        menuBarNameArea.setMinWidth(NAME_AREA_EDIT_WIDTH);
-        menuBarNameArea.setMaxWidth(NAME_AREA_EDIT_WIDTH);
         Tooltip.install(menuBarConfirmButton, new Tooltip("Confirm this name change"));
         Tooltip undoTip = new Tooltip("Abandon this name change and go back to the previous name");
         undoTip.setPrefWidth(TOOLTIP_WRAP_WIDTH);
@@ -203,10 +206,8 @@ public class PanelMenuBar extends HBox {
     private void closeRenameableTextField() {
         menuBarNameArea.getChildren().remove(renameableTextField);
         this.getChildren().removeAll(menuBarConfirmButton, menuBarUndoButton);
-        this.getChildren().add(menuBarCloseButton);
-        menuBarNameArea.getChildren().addAll(nameBox, renameButton);
-        menuBarNameArea.setMinWidth(NAME_AREA_WIDTH);
-        menuBarNameArea.setMaxWidth(NAME_AREA_WIDTH);
+        menuBarNameArea.getChildren().add(nameBox);
+        this.getChildren().addAll(menuBarRenameButton, menuBarCloseButton);
         panel.requestFocus();
     }
 


### PR DESCRIPTION
Fixes #1166 

I refactored the code a bit by moving `renameButton` out of `nameArea`. 
Then I adjust the distance between the tick mark and the text box by adding padding to the `nameArea`.

Added a left padding too to make the panel name look nicer.
Removed two unused imports along the way.

Screenshot:
<img width="439" alt="screen shot 2016-01-13 at 3 32 43 am" src="https://cloud.githubusercontent.com/assets/2834397/12276445/c91ee590-b9b0-11e5-9981-a6836c6dd2d0.png">