### PR TITLE
Set up GUI test resources for unstable tests in `check` or `test` tasks #1185

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,8 @@ allprojects {
     assemble.dependsOn shadowJar
 }
 
+test.dependsOn generateUnstableTestResources
+
 task checkstyleHtml << {
     ant.xslt(in: checkstyleMain.reports.xml.destination,
              style: file('config/checkstyle/checkstyle-noframes-sorted.xsl'),


### PR DESCRIPTION
Fixes #1185, #1146 

This is done by adding a dependency to the `test` task.
This will fix the failure of `repositorySelectorTest` during `check` or `test` task.