### PR TITLE
Show pencil icon for updates about edits #1109

### DIFF
--- a/src/main/java/github/TurboIssueEvent.java
+++ b/src/main/java/github/TurboIssueEvent.java
@@ -29,9 +29,10 @@ public class TurboIssueEvent {
     private static final String OCTICON_MILESTONE = "\uf075";
     private static final String OCTICON_ISSUE_CLOSED = "\uf028";
     private static final String OCTICON_ISSUE_OPENED = "\uf027";
-    private static final String OCTICON_MEGAPHONE = "\uf077";
+    private static final String OCTICON_PENCIL = "\uf058";
     private static final String OCTICON_PERSON = "\uf018";
     public static final String OCTICON_QUOTE = "\uf063";
+
 
     // Maximum time difference in seconds between label update events in the same group
     private static final long MAX_TIME_DIFF = 60;
@@ -147,7 +148,7 @@ public class TurboIssueEvent {
         switch (getType()) {
             case Renamed: {
                 HBox display = new HBox();
-                display.getChildren().addAll(octicon(OCTICON_MEGAPHONE),
+                display.getChildren().addAll(octicon(OCTICON_PENCIL),
                     conditionallyBold(bold,
                         new Text(String.format("%s renamed this issue %s.", actorName, time))));
                 return display;


### PR DESCRIPTION
Fixes #1109

Basically same PR as #1188.
Changed and renamed the megaphone constant to pencil.