### PR TITLE
Make sure most qualifiers throw Exception for invalid input #1174

### DIFF
--- a/src/main/java/filter/FilterException.java
+++ b/src/main/java/filter/FilterException.java
@@ -1,0 +1,8 @@
+package filter;
+
+@SuppressWarnings("serial")
+public class FilterException extends RuntimeException {
+    public FilterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/filter/FilterException.java
+++ b/src/main/java/filter/FilterException.java
@@ -1,7 +1,12 @@
 package filter;
 
+/**
+ * Thrown to indicate failure while processing a filter expression
+ * Exceptions that extend this class should provide an appropriate error message
+ * and reason that it occurs
+ */
 @SuppressWarnings("serial")
-public class FilterException extends RuntimeException {
+public abstract class FilterException extends RuntimeException {
     public FilterException(String message) {
         super(message);
     }

--- a/src/main/java/filter/ParseException.java
+++ b/src/main/java/filter/ParseException.java
@@ -1,8 +1,8 @@
 package filter;
 
 @SuppressWarnings("serial")
-public class ParseException extends RuntimeException {
+public class ParseException extends FilterException {
       public ParseException(String message) {
-         super(message);
+         super("Error in filter: " + message);
       }
  }

--- a/src/main/java/filter/ParseException.java
+++ b/src/main/java/filter/ParseException.java
@@ -1,5 +1,9 @@
 package filter;
 
+/**
+ *  Thrown to indicate failure to parse a filter expression due to 
+ *  unsupported syntax
+ */
 @SuppressWarnings("serial")
 public class ParseException extends FilterException {
       public ParseException(String message) {

--- a/src/main/java/filter/SemanticException.java
+++ b/src/main/java/filter/SemanticException.java
@@ -2,13 +2,18 @@ package filter;
 
 import filter.expression.QualifierType;
 
+/**
+ * Thrown to indicate failure to interpret a filter expression which may 
+ * be resulted from invalid qualifier inputs, multiple qualifiers which 
+ * should only appear once or simply an empty input.
+ */
 @SuppressWarnings("serial")
 public class SemanticException extends FilterException {
     
-    public static final String ERR_MSG = "\"%s\" expects %s";
+    public static final String ERROR_MESSAGE = "\"%s\" expects %s";
+
     public SemanticException(QualifierType type, String details) {
-        super(String.format(ERR_MSG, type, details));
-        System.out.println(String.format(ERR_MSG, type, details));
+        super(String.format(ERROR_MESSAGE, type, details));
     }
 
 }

--- a/src/main/java/filter/SemanticException.java
+++ b/src/main/java/filter/SemanticException.java
@@ -12,8 +12,8 @@ public class SemanticException extends FilterException {
     
     public static final String ERROR_MESSAGE = "\"%s\" expects %s";
 
-    public SemanticException(QualifierType type, String details) {
-        super(String.format(ERROR_MESSAGE, type, details));
+    public SemanticException(QualifierType type) {
+        super(String.format(ERROR_MESSAGE, type, type.getDescriptionOfValidInputs()));
     }
 
 }

--- a/src/main/java/filter/SemanticException.java
+++ b/src/main/java/filter/SemanticException.java
@@ -1,0 +1,14 @@
+package filter;
+
+import filter.expression.QualifierType;
+
+@SuppressWarnings("serial")
+public class SemanticException extends FilterException {
+    
+    public static final String ERR_MSG = "\"%s\" expects %s";
+    public SemanticException(QualifierType type, String details) {
+        super(String.format(ERR_MSG, type, details));
+        System.out.println(String.format(ERR_MSG, type, details));
+    }
+
+}

--- a/src/main/java/filter/expression/Qualifier.java
+++ b/src/main/java/filter/expression/Qualifier.java
@@ -339,11 +339,13 @@ public class Qualifier implements FilterExpression {
         case TITLE:
         case DESCRIPTION:
         case KEYWORD:
-            throw new QualifierApplicationException("Unnecessary filter: issue text cannot be changed by dragging");
+            throw new QualifierApplicationException(
+                "Unnecessary filter: issue text cannot be changed by dragging");
         case ID:
             throw new QualifierApplicationException("Unnecessary filter: id is immutable");
         case CREATED:
-            throw new QualifierApplicationException("Unnecessary filter: cannot change issue creation date");
+            throw new QualifierApplicationException(
+                "Unnecessary filter: cannot change issue creation date");
         case HAS:
         case NO:
         case IS:
@@ -358,9 +360,11 @@ public class Qualifier implements FilterExpression {
             applyAssignee(issue, model);
             break;
         case AUTHOR:
-            throw new QualifierApplicationException("Unnecessary filter: cannot change author of issue");
+            throw new QualifierApplicationException(
+                "Unnecessary filter: cannot change author of issue");
         case INVOLVES:
-            throw new QualifierApplicationException("Ambiguous filter: cannot change users involved with issue");
+            throw new QualifierApplicationException(
+                "Ambiguous filter: cannot change users involved with issue");
         case STATE:
             applyState(issue);
             break;
@@ -480,12 +484,12 @@ public class Qualifier implements FilterExpression {
 
     private static boolean shouldBeStripped(Qualifier q) {
         switch (q.getType()) {
-            case IN:
-            case SORT:
-            case COUNT:
-                return true;
-            default:
-                return false;
+        case IN:
+        case SORT:
+        case COUNT:
+            return true;
+        default:
+            return false;
         }
     }
 
@@ -503,19 +507,19 @@ public class Qualifier implements FilterExpression {
 
     public static boolean isMilestoneQualifier(Qualifier q) {
         switch (q.getType()) {
-            case MILESTONE:
-                return true;
-            default:
-                return false;
+        case MILESTONE:
+            return true;
+        default:
+            return false;
         }
     }
 
     public static boolean isUpdatedQualifier(Qualifier q) {
         switch (q.getType()) {
-            case UPDATED:
-                return true;
-            default:
-                return false;
+        case UPDATED:
+            return true;
+        default:
+            return false;
         }
     }
 
@@ -549,82 +553,82 @@ public class Qualifier implements FilterExpression {
         boolean isLabelGroup = false;
 
         switch (key) {
-            case "comments":
-                comparator = (a, b) -> a.getCommentCount() - b.getCommentCount();
-                break;
-            case "repo":
-                comparator = (a, b) -> a.getRepoId().compareTo(b.getRepoId());
-                break;
-            case "updated":
-            case "date":
+        case "comments":
+            comparator = (a, b) -> a.getCommentCount() - b.getCommentCount();
+            break;
+        case "repo":
+            comparator = (a, b) -> a.getRepoId().compareTo(b.getRepoId());
+            break;
+        case "updated":
+        case "date":
+            comparator = (a, b) -> a.getUpdatedAt().compareTo(b.getUpdatedAt());
+            break;
+        case "nonSelfUpdate":
+            if (isSortableByNonSelfUpdates) {
+                comparator = (a, b) ->
+                    a.getMetadata().getNonSelfUpdatedAt().compareTo(b.getMetadata().getNonSelfUpdatedAt());
+            } else {
                 comparator = (a, b) -> a.getUpdatedAt().compareTo(b.getUpdatedAt());
-                break;
-            case "nonSelfUpdate":
-                if (isSortableByNonSelfUpdates) {
-                    comparator = (a, b) ->
-                        a.getMetadata().getNonSelfUpdatedAt().compareTo(b.getMetadata().getNonSelfUpdatedAt());
+            }
+            break;
+        case "assignee":
+        case "as":
+            comparator = (a, b) -> {
+                Optional<String> aAssignee = a.getAssignee();
+                Optional<String> bAssignee = b.getAssignee();
+
+                if (!aAssignee.isPresent() && !bAssignee.isPresent()) {
+                    return 0;
+                } else if (!aAssignee.isPresent()) {
+                    return 1;
+                } else if (!bAssignee.isPresent()) {
+                    return -1;
                 } else {
-                    comparator = (a, b) -> a.getUpdatedAt().compareTo(b.getUpdatedAt());
+                    return aAssignee.get().compareTo(bAssignee.get());
                 }
-                break;
-            case "assignee":
-            case "as":
-                comparator = (a, b) -> {
-                    Optional<String> aAssignee = a.getAssignee();
-                    Optional<String> bAssignee = b.getAssignee();
+            };
+            break;
+        case "milestone":
+        case "m":
+            comparator = (a, b) -> {
+                Optional<TurboMilestone> aMilestone = model.getMilestoneOfIssue(a);
+                Optional<TurboMilestone> bMilestone = model.getMilestoneOfIssue(b);
 
-                    if (!aAssignee.isPresent() && !bAssignee.isPresent()) {
+                if (!aMilestone.isPresent() && !bMilestone.isPresent()) {
+                    return 0;
+                } else if (!aMilestone.isPresent()) {
+                    return 1;
+                } else if (!bMilestone.isPresent()) {
+                    return -1;
+                } else {
+                    Optional<LocalDate> aDueDate = aMilestone.get().getDueDate();
+                    Optional<LocalDate> bDueDate = bMilestone.get().getDueDate();
+
+                    if (!aDueDate.isPresent() && !bDueDate.isPresent()) {
                         return 0;
-                    } else if (!aAssignee.isPresent()) {
+                    } else if (!aDueDate.isPresent()) {
                         return 1;
-                    } else if (!bAssignee.isPresent()) {
+                    } else if (!bDueDate.isPresent()) {
                         return -1;
                     } else {
-                        return aAssignee.get().compareTo(bAssignee.get());
+                        return -(TurboMilestone.getDueDateComparator()
+                            .compare(aMilestone.get(), bMilestone.get()));
                     }
-                };
-                break;
-            case "milestone":
-            case "m":
-                comparator = (a, b) -> {
-                    Optional<TurboMilestone> aMilestone = model.getMilestoneOfIssue(a);
-                    Optional<TurboMilestone> bMilestone = model.getMilestoneOfIssue(b);
-
-                    if (!aMilestone.isPresent() && !bMilestone.isPresent()) {
-                        return 0;
-                    } else if (!aMilestone.isPresent()) {
-                        return 1;
-                    } else if (!bMilestone.isPresent()) {
-                        return -1;
-                    } else {
-                        Optional<LocalDate> aDueDate = aMilestone.get().getDueDate();
-                        Optional<LocalDate> bDueDate = bMilestone.get().getDueDate();
-
-                        if (!aDueDate.isPresent() && !bDueDate.isPresent()) {
-                            return 0;
-                        } else if (!aDueDate.isPresent()) {
-                            return 1;
-                        } else if (!bDueDate.isPresent()) {
-                            return -1;
-                        } else {
-                            return -(TurboMilestone.getDueDateComparator()
-                                    .compare(aMilestone.get(), bMilestone.get()));
-                        }
-                    }
-                };
-                break;
-            case "id":
-                comparator = (a, b) -> a.getId() - b.getId();
-                break;
-            case "state":
-            case "status":
-            case "s":
-                comparator = (a, b) -> Boolean.compare(b.isOpen(), a.isOpen());
-                break;
-            default:
-                // Doesn't match anything; assume it's a label group
-                isLabelGroup = true;
-                break;
+                }
+            };
+            break;
+        case "id":
+            comparator = (a, b) -> a.getId() - b.getId();
+            break;
+        case "state":
+        case "status":
+        case "s":
+            comparator = (a, b) -> Boolean.compare(b.isOpen(), a.isOpen());
+            break;
+        default:
+            // Doesn't match anything; assume it's a label group
+            isLabelGroup = true;
+            break;
         }
 
         if (isLabelGroup) {
@@ -697,7 +701,7 @@ public class Qualifier implements FilterExpression {
         } else if (numberRange.isPresent()) {
             return numberRange.get().encloses(issue.getId());
         }
-        throw new SemanticException(type, type.getDescriptionOfValidInputs());
+        throw new SemanticException(type);
     }
 
     private boolean satisfiesUpdatedHours(TurboIssue issue) {
@@ -708,7 +712,7 @@ public class Qualifier implements FilterExpression {
         } else if (number.isPresent()) {
             updatedRange = new NumberRange(null, number.get(), true);
         } else {
-            throw new SemanticException(type, type.getDescriptionOfValidInputs());
+            throw new SemanticException(type);
         }
 
         LocalDateTime dateOfUpdate = issue.getUpdatedAt();
@@ -717,7 +721,7 @@ public class Qualifier implements FilterExpression {
     }
 
     private boolean satisfiesRepo(TurboIssue issue) {
-        if (!content.isPresent()) return false;
+        if (!content.isPresent()) throw new SemanticException(type);
         return issue.getRepoId().equalsIgnoreCase(content.get());
     }
 
@@ -728,12 +732,12 @@ public class Qualifier implements FilterExpression {
         } else if (dateRange.isPresent()) {
             return dateRange.get().encloses(creationDate);
         } else {
-            throw new SemanticException(type, type.getDescriptionOfValidInputs());
+            throw new SemanticException(type);
         }
     }
 
     private boolean satisfiesHasConditions(TurboIssue issue) {
-        if (!content.isPresent()) return false;
+        if (!content.isPresent()) throw new SemanticException(type);
         switch (content.get()) {
         case "label":
         case "labels":
@@ -749,7 +753,7 @@ public class Qualifier implements FilterExpression {
             assert issue.getAssignee() != null;
             return issue.getAssignee().isPresent();
         default:
-            throw new SemanticException(type, type.getDescriptionOfValidInputs());
+            throw new SemanticException(type);
         }
     }
 
@@ -758,7 +762,7 @@ public class Qualifier implements FilterExpression {
     }
 
     private boolean satisfiesIsConditions(TurboIssue issue) {
-        if (!content.isPresent()) return false;
+        if (!content.isPresent()) throw new SemanticException(type);
         switch (content.get()) {
         case "open":
         case "closed":
@@ -775,19 +779,19 @@ public class Qualifier implements FilterExpression {
         case "unread":
             return !issue.isCurrentlyRead();
         default:
-            throw new SemanticException(type, type.getDescriptionOfValidInputs());
+            throw new SemanticException(type);
         }
     }
 
     private boolean stateSatisfies(TurboIssue issue) {
-        if (!content.isPresent()) return false;
+        if (!content.isPresent()) throw new SemanticException(type);
         String content = this.content.get().toLowerCase();
         if (content.contains("open")) {
             return issue.isOpen();
         } else if (content.contains("closed")) {
             return !issue.isOpen();
         } else {
-            throw new SemanticException(type, type.getDescriptionOfValidInputs());
+            throw new SemanticException(type);
         }
     }
 
@@ -888,7 +892,7 @@ public class Qualifier implements FilterExpression {
             case "description":
                 return bodySatisfies(issue);
             default:
-                return false;
+                throw new SemanticException(QualifierType.IN);
             }
         } else {
             return titleSatisfies(issue) || bodySatisfies(issue);
@@ -906,16 +910,16 @@ public class Qualifier implements FilterExpression {
     }
 
     private boolean typeSatisfies(TurboIssue issue) {
-        if (!content.isPresent()) return false;
+        if (!content.isPresent()) throw new SemanticException(type);
         String content = this.content.get().toLowerCase();
         switch (content) {
-            case "issue":
-                return !issue.isPullRequest();
-            case "pr":
-            case "pullrequest":
-                return issue.isPullRequest();
-            default:
-                throw new SemanticException(type, type.getDescriptionOfValidInputs());
+        case "issue":
+            return !issue.isPullRequest();
+        case "pr":
+        case "pullrequest":
+            return issue.isPullRequest();
+        default:
+            throw new SemanticException(type);
         }
     }
 

--- a/src/main/java/filter/expression/Qualifier.java
+++ b/src/main/java/filter/expression/Qualifier.java
@@ -17,11 +17,13 @@ import util.Utility;
 import backend.interfaces.IModel;
 import filter.MetaQualifierInfo;
 import filter.QualifierApplicationException;
+import filter.SemanticException;
 
 public class Qualifier implements FilterExpression {
 
     public static final Qualifier EMPTY = new Qualifier(QualifierType.EMPTY, "");
     public static final Qualifier FALSE = new Qualifier(QualifierType.FALSE, "");
+
 
     private final QualifierType type;
 
@@ -695,7 +697,7 @@ public class Qualifier implements FilterExpression {
         } else if (numberRange.isPresent()) {
             return numberRange.get().encloses(issue.getId());
         }
-        return false;
+        throw new SemanticException(type, type.getValidInputs());
     }
 
     private boolean satisfiesUpdatedHours(TurboIssue issue) {
@@ -706,7 +708,7 @@ public class Qualifier implements FilterExpression {
         } else if (number.isPresent()) {
             updatedRange = new NumberRange(null, number.get(), true);
         } else {
-            return false;
+            throw new SemanticException(type, type.getValidInputs());
         }
 
         LocalDateTime dateOfUpdate = issue.getUpdatedAt();
@@ -726,7 +728,7 @@ public class Qualifier implements FilterExpression {
         } else if (dateRange.isPresent()) {
             return dateRange.get().encloses(creationDate);
         } else {
-            return false;
+            throw new SemanticException(type, type.getValidInputs());
         }
     }
 
@@ -747,7 +749,7 @@ public class Qualifier implements FilterExpression {
             assert issue.getAssignee() != null;
             return issue.getAssignee().isPresent();
         default:
-            return false;
+            throw new SemanticException(type, type.getValidInputs());
         }
     }
 
@@ -773,7 +775,7 @@ public class Qualifier implements FilterExpression {
         case "unread":
             return !issue.isCurrentlyRead();
         default:
-            return false;
+            throw new SemanticException(type, type.getValidInputs());
         }
     }
 
@@ -785,7 +787,7 @@ public class Qualifier implements FilterExpression {
         } else if (content.contains("closed")) {
             return !issue.isOpen();
         } else {
-            return false;
+            throw new SemanticException(type, type.getValidInputs());
         }
     }
 
@@ -913,7 +915,7 @@ public class Qualifier implements FilterExpression {
             case "pullrequest":
                 return issue.isPullRequest();
             default:
-                return false;
+                throw new SemanticException(type, type.getValidInputs());
         }
     }
 

--- a/src/main/java/filter/expression/Qualifier.java
+++ b/src/main/java/filter/expression/Qualifier.java
@@ -697,7 +697,7 @@ public class Qualifier implements FilterExpression {
         } else if (numberRange.isPresent()) {
             return numberRange.get().encloses(issue.getId());
         }
-        throw new SemanticException(type, type.getValidInputs());
+        throw new SemanticException(type, type.getDescriptionOfValidInputs());
     }
 
     private boolean satisfiesUpdatedHours(TurboIssue issue) {
@@ -708,7 +708,7 @@ public class Qualifier implements FilterExpression {
         } else if (number.isPresent()) {
             updatedRange = new NumberRange(null, number.get(), true);
         } else {
-            throw new SemanticException(type, type.getValidInputs());
+            throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
 
         LocalDateTime dateOfUpdate = issue.getUpdatedAt();
@@ -728,7 +728,7 @@ public class Qualifier implements FilterExpression {
         } else if (dateRange.isPresent()) {
             return dateRange.get().encloses(creationDate);
         } else {
-            throw new SemanticException(type, type.getValidInputs());
+            throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
     }
 
@@ -749,7 +749,7 @@ public class Qualifier implements FilterExpression {
             assert issue.getAssignee() != null;
             return issue.getAssignee().isPresent();
         default:
-            throw new SemanticException(type, type.getValidInputs());
+            throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
     }
 
@@ -775,7 +775,7 @@ public class Qualifier implements FilterExpression {
         case "unread":
             return !issue.isCurrentlyRead();
         default:
-            throw new SemanticException(type, type.getValidInputs());
+            throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
     }
 
@@ -787,7 +787,7 @@ public class Qualifier implements FilterExpression {
         } else if (content.contains("closed")) {
             return !issue.isOpen();
         } else {
-            throw new SemanticException(type, type.getValidInputs());
+            throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
     }
 
@@ -915,7 +915,7 @@ public class Qualifier implements FilterExpression {
             case "pullrequest":
                 return issue.isPullRequest();
             default:
-                throw new SemanticException(type, type.getValidInputs());
+                throw new SemanticException(type, type.getDescriptionOfValidInputs());
         }
     }
 

--- a/src/main/java/filter/expression/QualifierType.java
+++ b/src/main/java/filter/expression/QualifierType.java
@@ -16,6 +16,7 @@ public enum QualifierType {
     REPO, SORT, STATE, TITLE, TYPE, UPDATED;
 
     private static final Map<String, QualifierType> ALIASES = initialiseAliases();
+    private static final Map<QualifierType, String> VALID_INPUTS = initialiseValidInputs();
 
     private static Map<String, QualifierType> initialiseAliases() {
         Map<String, QualifierType> aliases = new HashMap<>();
@@ -29,6 +30,27 @@ public enum QualifierType {
         aliases.put("body", DESCRIPTION);
         aliases.put("desc", DESCRIPTION);
         return Collections.unmodifiableMap(aliases);
+    }
+
+    // Ignore Qualifiers that expects a string where any user input would be valid
+    private static Map<QualifierType, String> initialiseValidInputs() {
+        Map<QualifierType, String> validInputs = new HashMap<>();
+        validInputs.put(ID, "a number or a number range");
+        validInputs.put(UPDATED, "a number or  a number range");
+        validInputs.put(STATE, "\"open\" or \"closed\"");
+        validInputs.put(HAS, "\"label\", \"milestone\", or \"assignee\"");
+        validInputs.put(NO, "\"label\", \"milestone\", or \"assignee\"");
+        validInputs.put(IN, "\"title\" or \"body\"");
+        validInputs.put(TYPE, "\"issue\" or \"pr\"");
+        validInputs.put(CREATED, "a date or a date range");
+        validInputs.put(REPO, "repo id");
+        
+        //Show only most common inputs to safe space
+        validInputs.put(IS, "\"open\", \"closed\", \"pr\", \"issue\", \"merged\","
+                + " \"read\", \"unread\", or \"unmerged\"");
+        validInputs.put(SORT, "\"comments\", \"repo\", \"updated\", \"id\", "
+                + " \"assignee\", \"label\", \"state\", or \"milestone\"");
+        return Collections.unmodifiableMap(validInputs);
     }
 
     /**
@@ -92,5 +114,12 @@ public enum QualifierType {
     @Override
     public String toString() {
         return name().toLowerCase();
+    }
+    
+    public String getValidInputs() {
+        String defaultExpectedInput = "string";
+        if (VALID_INPUTS.containsKey(this)) return VALID_INPUTS.get(this);
+        return defaultExpectedInput;
+
     }
 }

--- a/src/main/java/filter/expression/QualifierType.java
+++ b/src/main/java/filter/expression/QualifierType.java
@@ -16,7 +16,6 @@ public enum QualifierType {
     REPO, SORT, STATE, TITLE, TYPE, UPDATED;
 
     private static final Map<String, QualifierType> ALIASES = initialiseAliases();
-    private static final Map<QualifierType, String> VALID_INPUTS = initialiseValidInputs();
 
     private static Map<String, QualifierType> initialiseAliases() {
         Map<String, QualifierType> aliases = new HashMap<>();
@@ -30,27 +29,6 @@ public enum QualifierType {
         aliases.put("body", DESCRIPTION);
         aliases.put("desc", DESCRIPTION);
         return Collections.unmodifiableMap(aliases);
-    }
-
-    // Ignore Qualifiers that expects a string where any user input would be valid
-    private static Map<QualifierType, String> initialiseValidInputs() {
-        Map<QualifierType, String> validInputs = new HashMap<>();
-        validInputs.put(ID, "a number or a number range");
-        validInputs.put(UPDATED, "a number or  a number range");
-        validInputs.put(STATE, "\"open\" or \"closed\"");
-        validInputs.put(HAS, "\"label\", \"milestone\", or \"assignee\"");
-        validInputs.put(NO, "\"label\", \"milestone\", or \"assignee\"");
-        validInputs.put(IN, "\"title\" or \"body\"");
-        validInputs.put(TYPE, "\"issue\" or \"pr\"");
-        validInputs.put(CREATED, "a date or a date range");
-        validInputs.put(REPO, "repo id");
-        
-        //Show only most common inputs to safe space
-        validInputs.put(IS, "\"open\", \"closed\", \"pr\", \"issue\", \"merged\","
-                + " \"read\", \"unread\", or \"unmerged\"");
-        validInputs.put(SORT, "\"comments\", \"repo\", \"updated\", \"id\", "
-                + " \"assignee\", \"label\", \"state\", or \"milestone\"");
-        return Collections.unmodifiableMap(validInputs);
     }
 
     /**
@@ -116,10 +94,31 @@ public enum QualifierType {
         return name().toLowerCase();
     }
     
-    public String getValidInputs() {
-        String defaultExpectedInput = "string";
-        if (VALID_INPUTS.containsKey(this)) return VALID_INPUTS.get(this);
-        return defaultExpectedInput;
-
+    /**
+     * Returns short description of all inputs supported by a type of qualifier
+     * @return
+     */
+    public String getDescriptionOfValidInputs() {
+        
+        switch(this) {
+            case ID:
+            case UPDATED:
+                return "a number or a number range";
+            case STATE:
+                return "\"open\" or \"closed\"";
+            case HAS:
+            case NO:
+                return "\"label\", \"milestone\", or \"assignee\"";
+            case IN:
+                return "\"title\" or \"body\"";
+            case TYPE:
+                return "\"issue\" or \"pr\"";
+            case CREATED:
+                return "a date or a date range";
+            case REPO:
+                return "a repo id";
+            default:
+                return "a string";
+        }
     }
 }

--- a/src/main/java/ui/components/PanelMenuBar.java
+++ b/src/main/java/ui/components/PanelMenuBar.java
@@ -40,9 +40,10 @@ public class PanelMenuBar extends HBox {
     private final GUIController guiController;
     private Label closeButton;
     private final UI ui;
-    private String panelName = "Panel";
+    private String panelName = DEFAULT_PANEL_NAME;
     private Text nameText;
 
+    public static final String DEFAULT_PANEL_NAME = "Panel";
     public static final int NAME_DISPLAY_WIDTH = PANEL_WIDTH - 80;
     public static final int NAME_AREA_WIDTH = PANEL_WIDTH - 65;
     public static final int TOOLTIP_WRAP_WIDTH = 220; //prefWidth for longer tooltip

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -5,13 +5,12 @@ import static ui.components.KeyboardShortcuts.JUMP_TO_FILTER_BOX;
 import static ui.components.KeyboardShortcuts.MAXIMIZE_WINDOW;
 import static ui.components.KeyboardShortcuts.MINIMIZE_WINDOW;
 import static ui.components.KeyboardShortcuts.SWITCH_BOARD;
-
 import filter.expression.QualifierType;
 import ui.GUIController;
 import ui.GuiElement;
 import ui.components.PanelMenuBar;
 import backend.resource.TurboUser;
-import filter.ParseException;
+import filter.FilterException;
 import filter.Parser;
 import filter.expression.FilterExpression;
 import filter.expression.Qualifier;
@@ -179,11 +178,11 @@ public abstract class FilterPanel extends AbstractPanel {
             } else {
                 this.applyFilterExpression(Qualifier.EMPTY);
             }
-        } catch (ParseException ex) {
+        } catch (FilterException ex) {
             this.applyFilterExpression(Qualifier.EMPTY);
             // Overrides message in status bar
             UI.status.displayMessage("Panel " + (panelIndex + 1)
-                + ": Parse error in filter: " + ex.getMessage());
+                + ": " + ex.getMessage());
         }
     }
 

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -46,11 +46,12 @@ import java.util.stream.Collectors;
  */
 public abstract class FilterPanel extends AbstractPanel {
 
-    private ObservableList<GuiElement> elementsToDisplay = null;
+    private final UI ui;
 
     public PanelMenuBar panelMenuBar;
     protected FilterTextField filterTextField;
-    private final UI ui;
+    private ObservableList<GuiElement> elementsToDisplay = null;
+
 
     protected FilterExpression currentFilterExpression = Qualifier.EMPTY;
 
@@ -181,9 +182,22 @@ public abstract class FilterPanel extends AbstractPanel {
         } catch (FilterException ex) {
             this.applyFilterExpression(Qualifier.EMPTY);
             // Overrides message in status bar
-            UI.status.displayMessage("Panel " + (panelIndex + 1)
-                + ": " + ex.getMessage());
+            UI.status.displayMessage(getUniquePanelName(
+                panelMenuBar.getPanelName()) + ": " + ex.getMessage());
         }
+    }
+
+    /**
+     * Appends panel index to panel name if a panel is unnamed.
+     * This allows user to identify each panel with a unique name 
+     * @param panelName
+     * @return final panel name shown to users
+     */
+    private String getUniquePanelName(String panelName) {
+        if (panelName.equals(PanelMenuBar.DEFAULT_PANEL_NAME)) {
+            return PanelMenuBar.DEFAULT_PANEL_NAME + " " + (panelIndex + 1);
+        }
+        return PanelMenuBar.DEFAULT_PANEL_NAME + " " + panelName;
     }
 
     /**

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -45,13 +45,14 @@ public class FilterEvalTests {
     }
 
     /**
-     * Helper method for testing SemanticException thrown by different qualifiers
+     * Confirms that the input causes a Semantic Exception to be thrown
+     * with correct error message. Test fails if it doesn't.
      */
-    public void expectSemanticException(QualifierType type, String invalidInput) {
+    public void verifySemanticException(QualifierType type, String invalidInput) {
         TurboIssue issue = new TurboIssue(REPO, 1, "");
         thrown.expect(SemanticException.class);
-        thrown.expectMessage(String.format(SemanticException.ERR_MSG, type, 
-                type.getValidInputs()));
+        thrown.expectMessage(
+            String.format(SemanticException.ERROR_MESSAGE, type, type.getDescriptionOfValidInputs()));
         matches(invalidInput, issue);
     }
 
@@ -90,7 +91,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidId() {
-        expectSemanticException(QualifierType.ID, "id:something");
+        verifySemanticException(QualifierType.ID, "id:something");
     }
 
     private void testForPresenceOfKeywords(String prefix, TurboIssue issue) {
@@ -508,7 +509,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidState() {
-        expectSemanticException(QualifierType.STATE, "state:something");
+        verifySemanticException(QualifierType.STATE, "state:something");
     }
 
     @Test
@@ -555,7 +556,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidHas() {
-        expectSemanticException(QualifierType.HAS, "has:something");
+        verifySemanticException(QualifierType.HAS, "has:something");
     }
 
     @Test
@@ -602,7 +603,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidNo() {
-        expectSemanticException(QualifierType.NO, "no:something");
+        verifySemanticException(QualifierType.NO, "no:something");
     }
 
     @Test
@@ -620,7 +621,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidType() {
-        expectSemanticException(QualifierType.TYPE, "type:something");
+        verifySemanticException(QualifierType.TYPE, "type:something");
     }
 
     @Test
@@ -686,7 +687,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidIs() {
-        expectSemanticException(QualifierType.IS, "is:something");
+        verifySemanticException(QualifierType.IS, "is:something");
     }
 
     @Test
@@ -701,7 +702,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidCreated() {
-        expectSemanticException(QualifierType.CREATED, "created:nondate");
+        verifySemanticException(QualifierType.CREATED, "created:nondate");
     }
 
     @Test
@@ -728,7 +729,7 @@ public class FilterEvalTests {
 
     @Test
     public void invalidUpdated() {
-        expectSemanticException(QualifierType.UPDATED, "updated:nondate");
+        verifySemanticException(QualifierType.UPDATED, "updated:nondate");
     }
 
     @Test

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -36,87 +36,67 @@ public class FilterEvalTests {
         empty.setDefaultRepo(REPO);
     }
 
-    /**
-     * Helper method for testing an issue against a filter string in the context
-     * of an empty model.
-     */
-    public boolean matches(String filterExpr, TurboIssue issue) {
-        return Qualifier.process(empty, Parser.parse(filterExpr), issue);
-    }
-
-    /**
-     * Confirms that the input causes a Semantic Exception to be thrown
-     * with correct error message. Test fails if it doesn't.
-     */
-    public void verifySemanticException(QualifierType type, String invalidInput) {
-        TurboIssue issue = new TurboIssue(REPO, 1, "");
-        thrown.expect(SemanticException.class);
-        thrown.expectMessage(
-            String.format(SemanticException.ERROR_MESSAGE, type, type.getDescriptionOfValidInputs()));
-        matches(invalidInput, issue);
-    }
-
     @Test
-    public void invalid() {
+    public void checksInvalidQualifier() {
         TurboIssue issue = new TurboIssue(REPO, 1, "title");
-        assertEquals(false, matches("something:a", issue));
+        assertFalse(matches("something:a", issue));
     }
 
     @Test
-    public void falseQualifier() {
+    public void satisfiesFalseQualifier() {
         TurboIssue issue = new TurboIssue(REPO, 1, "1");
         TurboMilestone milestone = new TurboMilestone(REPO, 1, "v1.0");
 
         IModel model = TestUtils.modelWith(issue, milestone);
 
-        assertEquals(false, Qualifier.process(model, Qualifier.FALSE, issue));
+        assertFalse(Qualifier.process(model, Qualifier.FALSE, issue));
     }
 
     @Test
-    public void id() {
+    public void satisfiesId_validInputs() {
         TurboIssue issue1 = new TurboIssue(REPO, 1, "1");
 
-        assertEquals(true, matches("id:1", issue1));
-        assertEquals(true, matches("id:>=1", issue1));
-        assertEquals(true, matches("id:<=1", issue1));
-        assertEquals(false, matches("id:<1", issue1));
-        assertEquals(false, matches("id:>1", issue1));
-        assertEquals(false, matches("id:2", issue1));
+        assertTrue(matches("id:1", issue1));
+        assertTrue(matches("id:>=1", issue1));
+        assertTrue(matches("id:<=1", issue1));
+        assertFalse(matches("id:<1", issue1));
+        assertFalse(matches("id:>1", issue1));
+        assertFalse(matches("id:2", issue1));
 
-        assertEquals(true, matches("id:<2", issue1));
-        assertEquals(true, matches("id:<=2", issue1));
-        assertEquals(true, matches("id:>0", issue1));
-        assertEquals(true, matches("id:>=0", issue1));
+        assertTrue(matches("id:<2", issue1));
+        assertTrue(matches("id:<=2", issue1));
+        assertTrue(matches("id:>0", issue1));
+        assertTrue(matches("id:>=0", issue1));
     }
 
     @Test
-    public void invalidId() {
+    public void satisfiesId_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.ID, "id:something");
     }
 
     private void testForPresenceOfKeywords(String prefix, TurboIssue issue) {
 
         // Exact match
-        assertEquals(true, matches(prefix + "test", issue));
+        assertTrue(matches(prefix + "test", issue));
 
         // Substring
-        assertEquals(true, matches(prefix + "te", issue));
+        assertTrue(matches(prefix + "te", issue));
 
         // Implicit conjunction
-        assertEquals(true, matches(prefix + "is a", issue));
+        assertTrue(matches(prefix + "is a", issue));
 
         // Like above but out of order
-        assertEquals(true, matches(prefix + "a is", issue));
+        assertTrue(matches(prefix + "a is", issue));
     }
 
     @Test
-    public void title() {
+    public void satisfiesTitle_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "this is a test");
         testForPresenceOfKeywords("title:", issue);
     }
 
     @Test
-    public void body() {
+    public void satisfiesBody_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "");
         issue.setDescription("this is a test");
         testForPresenceOfKeywords("body:", issue);
@@ -125,36 +105,36 @@ public class FilterEvalTests {
     }
 
     @Test
-    public void in() {
+    public void satisfiesIn_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "");
         issue.setDescription("this is a test");
         testForPresenceOfKeywords("in:body ", issue);
 
         issue = new TurboIssue(REPO, 1, "this is a test");
         testForPresenceOfKeywords("in:title ", issue);
-
-        assertEquals(false, matches("in:something test", issue));
-        assertEquals(false, matches("in:something te", issue));
-        assertEquals(false, matches("in:something is a", issue));
-        assertEquals(false, matches("in:something a is", issue));
-    }
-
-    private void testMilestoneParsing(String milestoneQualifier, TurboIssue issue, IModel model) {
-        assertEquals(true, Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v1.0"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v1"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "1"), issue));
-
-        try {
-            assertEquals(true, Qualifier.process(model, Parser.parse(milestoneQualifier + ":."), issue));
-            fail(". is not a valid token on its own");
-        } catch (ParseException ignored) {
-        }
-        assertEquals(false, matches(milestoneQualifier + ":what", issue));
     }
 
     @Test
-    public void milestone() {
+    public void satisfiesIn_invalidInputs_throwSemanticException() {
+        verifySemanticException(QualifierType.IN, "in:something test");
+    }
+
+    private void testMilestoneParsing(String milestoneQualifier, TurboIssue issue, IModel model) {
+        assertTrue(Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v1.0"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v1"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "v"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse(milestoneQualifier + ":" + "1"), issue));
+
+        try {
+            assertTrue(Qualifier.process(model, Parser.parse(milestoneQualifier + ":."), issue));
+            fail(". is not a valid token on its own");
+        } catch (ParseException ignored) {
+        }
+        assertFalse(matches(milestoneQualifier + ":what", issue));
+    }
+
+    @Test
+    public void satisfiesMilestone_validInputs() {
         TurboMilestone milestone = new TurboMilestone(REPO, 1, "v1.0");
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
@@ -233,77 +213,77 @@ public class FilterEvalTests {
         FilterExpression noMilestoneAlias;
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-3"));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-2"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-1"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+1"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+2"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+3"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         // test: negation alias
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("-milestone:curr"));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(true, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertTrue(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         // test: no milestone in model should return qualifier false
         model = TestUtils.singletonModel(new Model(REPO,
@@ -314,71 +294,71 @@ public class FilterEvalTests {
                 new ArrayList<>()));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-3"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-2"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr-1"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+1"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+2"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
 
         noMilestoneAlias = Qualifier.replaceMilestoneAliases(model, Parser.parse("milestone:curr+3"));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin3));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrMin1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurr));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
-        assertEquals(false, Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin3));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrMin1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurr));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus1));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus2));
+        assertFalse(Qualifier.process(model, noMilestoneAlias, iCurrPlus3));
     }
 
     @Test
-    public void label() {
+    public void satisfiesLabel_validInputs() {
         TurboLabel label = TurboLabel.exclusive(REPO, "type", "bug");
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
@@ -386,17 +366,17 @@ public class FilterEvalTests {
 
         IModel model = TestUtils.modelWith(issue, label);
 
-        assertEquals(false, Qualifier.process(model, Parser.parse("label:type"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("label:type."), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("label:type.bug"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("label:bug"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("label:type"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("label:type."), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("label:type.bug"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("label:bug"), issue));
         try {
-            assertEquals(true, Qualifier.process(model, Parser.parse("label:.bug"), issue));
+            assertTrue(Qualifier.process(model, Parser.parse("label:.bug"), issue));
             fail(". cannot begin symbols");
         } catch (ParseException ignored) {
         }
         try {
-            assertEquals(false, Qualifier.process(model, Parser.parse("label:."), issue));
+            assertFalse(Qualifier.process(model, Parser.parse("label:."), issue));
             fail(". is not a valid token on its own");
         } catch (ParseException ignored) {
         }
@@ -417,7 +397,7 @@ public class FilterEvalTests {
             new ArrayList<>(),
             new ArrayList<>())));
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("label:t."), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("label:t."), issue));
 
         // Label without a group
 
@@ -428,24 +408,24 @@ public class FilterEvalTests {
 
         model = TestUtils.modelWith(issue, label);
 
-        assertEquals(false, Qualifier.process(model, Parser.parse("label:bug."), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("label:type.bug"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("label:type"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("label:bug"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("label:bug."), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("label:type.bug"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("label:type"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("label:bug"), issue));
         try {
-            assertEquals(true, Qualifier.process(model, Parser.parse("label:.bug"), issue));
+            assertTrue(Qualifier.process(model, Parser.parse("label:.bug"), issue));
             fail(". cannot begin symbols");
         } catch (ParseException ignored) {
         }
         try {
-            assertEquals(false, Qualifier.process(model, Parser.parse("label:."), issue));
+            assertFalse(Qualifier.process(model, Parser.parse("label:."), issue));
             fail(". is not a valid token on its own");
         } catch (ParseException ignored) {
         }
     }
 
     @Test
-    public void assignee() {
+    public void satisfiesAssignee_validInputs() {
         TurboUser user = new TurboUser(REPO, "bob", "alice");
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
@@ -453,26 +433,26 @@ public class FilterEvalTests {
 
         IModel model = TestUtils.modelWith(issue, user);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("assignee:BOB"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("assignee:bob"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("assignee:alice"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("assignee:o"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("assignee:lic"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("assignee:BOB"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("assignee:bob"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("assignee:alice"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("assignee:o"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("assignee:lic"), issue));
     }
 
     @Test
-    public void author() {
+    public void satisfiesAuthor_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "", "bob", null, false);
 
-        assertEquals(true, matches("author:BOB", issue));
-        assertEquals(true, matches("author:bob", issue));
-        assertEquals(false, matches("author:alice", issue));
-        assertEquals(true, matches("author:o", issue));
-        assertEquals(false, matches("author:lic", issue));
+        assertTrue(matches("author:BOB", issue));
+        assertTrue(matches("author:bob", issue));
+        assertFalse(matches("author:alice", issue));
+        assertTrue(matches("author:o", issue));
+        assertFalse(matches("author:lic", issue));
     }
 
     @Test
-    public void involves() {
+    public void satisfiesInvolves_validInput() {
         // involves = assignee || author
 
         // assignee
@@ -483,261 +463,270 @@ public class FilterEvalTests {
 
         IModel model = TestUtils.modelWith(issue, user);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:BOB"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:bob"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:alice"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:o"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:lic"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:BOB"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:bob"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:alice"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:o"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:lic"), issue));
 
         // author
         issue = new TurboIssue(REPO, 1, "", "bob", null, false);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:BOB"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:bob"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("involves:alice"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("involves:o"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("involves:lic"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:BOB"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:bob"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("involves:alice"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("involves:o"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("involves:lic"), issue));
     }
 
     @Test
-    public void state() {
+    public void satisfiesState_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "");
         issue.setOpen(false);
-        assertEquals(false, matches("state:open", issue));
-        assertEquals(true, matches("state:closed", issue));
+        assertFalse(matches("state:open", issue));
+        assertTrue(matches("state:closed", issue));
     }
 
     @Test
-    public void invalidState() {
+    public void satisfiesState_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.STATE, "state:something");
+        verifySemanticException(QualifierType.STATE, "state:1");
     }
 
     @Test
-    public void has() {
+    public void satisfiesHasConditions_validInputs() {
         TurboLabel label = TurboLabel.exclusive(REPO, "type", "bug");
         TurboUser user = new TurboUser(REPO, "bob", "alice");
         TurboMilestone milestone = new TurboMilestone(REPO, 1, "v1.0");
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
 
-        assertEquals(false, matches("has:label", issue));
-        assertEquals(false, matches("has:milestone", issue));
-        assertEquals(false, matches("has:m", issue));
-        assertEquals(false, matches("has:assignee", issue));
-        assertEquals(false, matches("has:as", issue));
+        assertFalse(matches("has:label", issue));
+        assertFalse(matches("has:milestone", issue));
+        assertFalse(matches("has:m", issue));
+        assertFalse(matches("has:assignee", issue));
+        assertFalse(matches("has:as", issue));
 
         issue.addLabel(label);
         IModel model = TestUtils.modelWith(issue, label);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:label"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:milestone"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:m"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:assignee"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:as"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:label"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:milestone"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:m"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:assignee"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:as"), issue));
 
         issue.setMilestone(milestone);
         model = TestUtils.modelWith(issue, label, milestone);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:label"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:milestone"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:m"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:assignee"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("has:as"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:label"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:milestone"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:m"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:assignee"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("has:as"), issue));
 
         issue.setAssignee(user);
         model = TestUtils.modelWith(issue, label, milestone, user);
 
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:label"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:milestone"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:m"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:assignee"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("has:as"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:label"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:milestone"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:m"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:assignee"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("has:as"), issue));
     }
 
     @Test
-    public void invalidHas() {
+    public void satisfiesHasConditions_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.HAS, "has:something");
+        verifySemanticException(QualifierType.HAS, "has:2011-1-1");
     }
 
     @Test
-    public void no() {
+    public void satisfiesNoConditions_validInputs() {
         TurboLabel label = TurboLabel.exclusive(REPO, "type", "bug");
         TurboUser user = new TurboUser(REPO, "bob", "alice");
         TurboMilestone milestone = new TurboMilestone(REPO, 1, "v1.0");
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
 
-        assertEquals(true, matches("no:label", issue));
-        assertEquals(true, matches("no:milestone", issue));
-        assertEquals(true, matches("no:m", issue));
-        assertEquals(true, matches("no:assignee", issue));
-        assertEquals(true, matches("no:as", issue));
+        assertTrue(matches("no:label", issue));
+        assertTrue(matches("no:milestone", issue));
+        assertTrue(matches("no:m", issue));
+        assertTrue(matches("no:assignee", issue));
+        assertTrue(matches("no:as", issue));
 
         issue.addLabel(label);
         IModel model = TestUtils.modelWith(issue, label);
 
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:label"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:milestone"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:m"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:assignee"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:as"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:label"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:milestone"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:m"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:assignee"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:as"), issue));
 
         issue.setMilestone(milestone);
         model = TestUtils.modelWith(issue, label, milestone);
 
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:label"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:milestone"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:m"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:assignee"), issue));
-        assertEquals(true, Qualifier.process(model, Parser.parse("no:as"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:label"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:milestone"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:m"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:assignee"), issue));
+        assertTrue(Qualifier.process(model, Parser.parse("no:as"), issue));
 
         issue.setAssignee(user);
         model = TestUtils.modelWith(issue, label, milestone, user);
 
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:label"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:milestone"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:m"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:assignee"), issue));
-        assertEquals(false, Qualifier.process(model, Parser.parse("no:as"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:label"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:milestone"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:m"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:assignee"), issue));
+        assertFalse(Qualifier.process(model, Parser.parse("no:as"), issue));
     }
 
     @Test
-    public void invalidNo() {
+    public void satisfiesNoConditions_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.NO, "no:something");
     }
 
     @Test
-    public void type() {
+    public void satisfiesType_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "", "", null, true);
 
-        assertEquals(false, matches("type:issue", issue));
-        assertEquals(true, matches("type:pr", issue));
+        assertFalse(matches("type:issue", issue));
+        assertTrue(matches("type:pr", issue));
 
         issue = new TurboIssue(REPO, 1, "", "", null, false);
 
-        assertEquals(true, matches("type:issue", issue));
-        assertEquals(false, matches("type:pr", issue));
+        assertTrue(matches("type:issue", issue));
+        assertFalse(matches("type:pr", issue));
     }
 
     @Test
-    public void invalidType() {
+    public void satisfiesType_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.TYPE, "type:something");
+        verifySemanticException(QualifierType.TYPE, "type:2011-1-1");
     }
 
     @Test
-    public void is() {
+    public void satisfiesIsConditions_validInputs() {
 
         TurboIssue issue = new TurboIssue(REPO, 1, "", "", null, true);
 
-        assertEquals(false, matches("is:issue", issue));
-        assertEquals(true, matches("is:pr", issue));
+        assertFalse(matches("is:issue", issue));
+        assertTrue(matches("is:pr", issue));
 
-        assertEquals(true, matches("is:open", issue));
-        assertEquals(true, matches("is:unmerged", issue));
-        assertEquals(false, matches("is:closed", issue));
-        assertEquals(false, matches("is:merged", issue));
+        assertTrue(matches("is:open", issue));
+        assertTrue(matches("is:unmerged", issue));
+        assertFalse(matches("is:closed", issue));
+        assertFalse(matches("is:merged", issue));
 
         issue.setOpen(false);
 
-        assertEquals(false, matches("is:open", issue));
-        assertEquals(false, matches("is:unmerged", issue));
-        assertEquals(true, matches("is:closed", issue));
-        assertEquals(true, matches("is:merged", issue));
+        assertFalse(matches("is:open", issue));
+        assertFalse(matches("is:unmerged", issue));
+        assertTrue(matches("is:closed", issue));
+        assertTrue(matches("is:merged", issue));
 
         issue = new TurboIssue(REPO, 1, "", "", null, false);
 
-        assertEquals(true, matches("is:issue", issue));
-        assertEquals(false, matches("is:pr", issue));
+        assertTrue(matches("is:issue", issue));
+        assertFalse(matches("is:pr", issue));
 
-        assertEquals(true, matches("is:open", issue));
-        assertEquals(false, matches("is:closed", issue));
+        assertTrue(matches("is:open", issue));
+        assertFalse(matches("is:closed", issue));
 
         // Not a PR
-        assertEquals(false, matches("is:unmerged", issue));
-        assertEquals(false, matches("is:merged", issue));
+        assertFalse(matches("is:unmerged", issue));
+        assertFalse(matches("is:merged", issue));
 
         issue.setOpen(false);
 
-        assertEquals(false, matches("is:open", issue));
-        assertEquals(true, matches("is:closed", issue));
+        assertFalse(matches("is:open", issue));
+        assertTrue(matches("is:closed", issue));
 
         // Not a PR
-        assertEquals(false, matches("is:unmerged", issue));
-        assertEquals(false, matches("is:merged", issue));
+        assertFalse(matches("is:unmerged", issue));
+        assertFalse(matches("is:merged", issue));
 
         // Read status
 
-        assertEquals(false, issue.isCurrentlyRead());
+        assertFalse(issue.isCurrentlyRead());
 
-        assertEquals(true, matches("is:unread", issue));
-        assertEquals(false, matches("is:read", issue));
+        assertTrue(matches("is:unread", issue));
+        assertFalse(matches("is:read", issue));
 
         issue.setUpdatedAt(LocalDateTime.of(2015, 2, 17, 2, 10));
         issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
 
-        assertEquals(true, matches("is:unread", issue));
-        assertEquals(false, matches("is:read", issue));
+        assertTrue(matches("is:unread", issue));
+        assertFalse(matches("is:read", issue));
 
         issue.setUpdatedAt(LocalDateTime.of(2015, 1, 1, 1, 1));
         issue.setMarkedReadAt(Optional.of(LocalDateTime.of(2015, 1, 6, 12, 15)));
 
-        assertEquals(false, matches("is:unread", issue));
-        assertEquals(true, matches("is:read", issue));
+        assertFalse(matches("is:unread", issue));
+        assertTrue(matches("is:read", issue));
     }
 
     @Test
-    public void invalidIs() {
+    public void satisfiesIs_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.IS, "is:something");
+        verifySemanticException(QualifierType.IS, "is:2011-1-1");
     }
 
     @Test
-    public void created() {
+    public void satisfiesCreatedDate_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "", "", LocalDateTime.of(2014, 12, 2, 12, 0), false);
 
-        assertEquals(false, matches("created:<2014-12-1", issue));
-        assertEquals(false, matches("created:<=2014-12-1", issue));
-        assertEquals(true, matches("created:>2014-12-1", issue));
-        assertEquals(true, matches("created:2014-12-2", issue));
+        assertFalse(matches("created:<2014-12-1", issue));
+        assertFalse(matches("created:<=2014-12-1", issue));
+        assertTrue(matches("created:>2014-12-1", issue));
+        assertTrue(matches("created:2014-12-2", issue));
     }
 
     @Test
-    public void invalidCreated() {
+    public void satisfiesCreationDate_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.CREATED, "created:nondate");
     }
 
     @Test
-    public void updated() {
+    public void satisfiesUpdatedHours_validInputs() {
         LocalDateTime now = LocalDateTime.now();
         Qualifier.setCurrentTime(now);
 
         TurboIssue issue = new TurboIssue(REPO, 1, "");
         issue.setUpdatedAt(now.minusDays(2));
 
-        assertEquals(false, matches("updated:<24", issue));
+        assertFalse(matches("updated:<24", issue));
         assertEquals(matches("updated:<24", issue),
             matches("updated:24", issue));
-        assertEquals(true, matches("updated:>24", issue));
+        assertTrue(matches("updated:>24", issue));
 
         issue = new TurboIssue(REPO, 1, "");
         issue.setUpdatedAt(now.minusDays(1));
 
-        assertEquals(true, matches("updated:<26", issue));
+        assertTrue(matches("updated:<26", issue));
         assertEquals(matches("updated:<26", issue),
             matches("updated:26", issue));
-        assertEquals(false, matches("updated:>26", issue));
+        assertFalse(matches("updated:>26", issue));
     }
 
     @Test
-    public void invalidUpdated() {
+    public void satisfiesUpdatedHours_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.UPDATED, "updated:nondate");
     }
 
     @Test
-    public void repo() {
+    public void satisfiesRepo_validInputs() {
         TurboIssue issue = new TurboIssue(REPO, 1, "");
 
-        assertEquals(true, matches("repo:" + REPO, issue));
-        assertEquals(false, matches("repo:something/else", issue));
+        assertTrue(matches("repo:" + REPO, issue));
+        assertFalse(matches("repo:something/else", issue));
+    }
+
+    @Test
+    public void satisfiesRepo_invalidInputs_throwSemanticException() {
+        verifySemanticException(QualifierType.REPO, "repo:2011-1-1");
     }
 
     @Test
@@ -765,5 +754,24 @@ public class FilterEvalTests {
         assertFalse(Qualifier.labelMatches("pri.hi", "p.high"));
         assertFalse(Qualifier.labelMatches("pi.hi", "p.high"));
         assertFalse(Qualifier.labelMatches(".", "p.high"));
+    }
+
+    /**
+     * Tests the filter string in the context of an empty model
+     */
+    public boolean matches(String filterExpr, TurboIssue issue) {
+        return Qualifier.process(empty, Parser.parse(filterExpr), issue);
+    }
+
+    /**
+     * Confirms that the input causes a Semantic Exception to be thrown
+     * with correct error message. Test fails if it doesn't.
+     */
+    public void verifySemanticException(QualifierType type, String invalidInput) {
+        TurboIssue issue = new TurboIssue(REPO, 1, "");
+        thrown.expect(SemanticException.class);
+        thrown.expectMessage(
+            String.format(SemanticException.ERROR_MESSAGE, type, type.getDescriptionOfValidInputs()));
+        matches(invalidInput, issue);
     }
 }


### PR DESCRIPTION
Fixes #1174 

- [X] create FilterException and subclassed by ParseException and SemanticException 
- [X] change applyStringFilter to catch `FilterException`
- [x] change id, state, has, no, in, type, is, created, updated, repo, 