### PR TITLE
Shortcuts are incorrect in some sections of user guide #1192

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -4,7 +4,7 @@
 
 Labels are created through GitHub's UI.
 
-- Select `New > Label` (<kbd>Ctrl</kbd> + <kbd>L</kbd>) from the menu.
+- Select `New > Label` (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>) from the menu.
 
 ## Label Groups
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -4,4 +4,4 @@
 
 Milestones are also created through GitHub's UI.
 
-- Select `New > Milestone` (<kbd>Ctrl</kbd> + <kbd>M</kbd>) from the menu.
+- Select `New > Milestone` (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd>) from the menu.


### PR DESCRIPTION
Fixes #1192.

Simple addition of the shift key to the shortcuts.