### PR TITLE
HT not refreshing #1214

### DIFF
--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -86,4 +86,8 @@
         <Class name="tests.MilestoneUpdateServiceTests" />
         <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
     </Match>
+    <Match>
+        <Class name="tests.LogicTests" />
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -77,12 +77,7 @@ public class Logic {
         return repoIO.isRepositoryValid(repoId);
     }
 
-    public void refresh(boolean isNotificationPaneShowing) {
-        // TODO fix refresh to take into account the possible pending actions associated with the notification pane
-        if (isNotificationPaneShowing) {
-            logger.info("Notification Pane is currently showing, not going to refresh. ");
-            return;
-        }
+    public void refresh() {
         String message = "Refreshing " + models.toModels().stream()
                 .map(Model::getRepoId)
                 .collect(Collectors.joining(", "));

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -199,33 +199,42 @@ public class Logic {
      * @return True if label replacement on GitHub was a success, false otherwise.
      */
     public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> newLabels) {
-        eagerlyUpdateIssueLabels(issue, newLabels);
+        boolean isLabelsChanged = updateIssueLabels(issue, newLabels);
 
+        if (isLabelsChanged) {
+            logger.info("Changing labels for " + issue + " on UI");
+            refreshUI();
+        }
+
+        return updateIssueLabelsOnRepo(issue, newLabels);
+    }
+
+    /**
+     * Updates an issue with a set of labels
+     * @return true if changes are made to the labels on the issue
+     */
+    private Boolean updateIssueLabels(TurboIssue issue, List<String> labels) {
+        boolean isLabelsUnchanged = issue.getLabels().size() == labels.size() && issue.getLabels().containsAll(labels);
+        if (isLabelsUnchanged) {
+            logger.info("No changes to labels of " + issue);
+            return false;
+        }
+
+        issue.setLabels(labels);
+        return true;
+    }
+
+    /**
+     * Updates an issue on the repository with a set of labels
+     * @param issue
+     * @param newLabels
+     * @return
+     */
+    private CompletableFuture<Boolean> updateIssueLabelsOnRepo(TurboIssue issue, List<String> newLabels) {
         logger.info("Changing labels for " + issue + " on GitHub");
         return repoOpControl.replaceIssueLabels(issue, newLabels)
                 .thenApply(labels -> labels.containsAll(newLabels))
                 .exceptionally(Futures.withResult(false));
-    }
-
-    /**
-     * Assigns a list of labels to an issue offline and immediately reflect the change on the UI without
-     * concerning whether the labels have been updated on the remote repo's data source
-     *
-     * The UI will not be force refreshed if the set of labels are the same as the existing labels
-     * assigned to the issue.
-     * @param issue
-     * @param labels
-     */
-    private void eagerlyUpdateIssueLabels(TurboIssue issue, List<String> labels) {
-        logger.info("Changing labels for " + issue + " on UI");
-
-        if (issue.getLabels().size() == labels.size() && issue.getLabels().containsAll(labels)) {
-            return;
-        }
-
-        issue.setLabels(labels);
-        refreshUI();
-
     }
 
     /**

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -203,10 +203,7 @@ public class Logic {
 
         logger.info("Changing labels for " + issue + " on GitHub");
         return repoOpControl.replaceIssueLabels(issue, newLabels)
-                .thenApply(labels -> {
-                    eagerlyUpdateIssueLabels(issue, labels);
-                    return true;
-                })
+                .thenApply(labels -> labels.containsAll(newLabels))
                 .exceptionally(Futures.withResult(false));
     }
 

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -192,44 +192,21 @@ public class Logic {
     }
 
     /**
-     * Replaces labels of issue on GitHub
+     * Replaces existing labels with new labels in the issue object, the UI, and the server, in that order.
+     * Server update is done after the local update to reduce the lag between the user action and the UI response
      *
-     * @param issue The issue whose labels are to be replaced on GitHub.
-     * @param newLabels The list of new labels to be applied on the issue.
-     * @return True if label replacement on GitHub was a success, false otherwise.
+     * @param issue The issue object whose labels are to be replaced.
+     * @param newLabels The list of new labels to be assigned to the issue.
+     * @return true if label replacement on GitHub was a success, false otherwise.
      */
     public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> newLabels) {
-        boolean isLabelsChanged = updateIssueLabels(issue, newLabels);
-
-        if (isLabelsChanged) {
-            logger.info("Changing labels for " + issue + " on UI");
-            refreshUI();
-        }
+        logger.info("Changing labels for " + issue + " on UI");
+        issue.setLabels(newLabels);
+        refreshUI();
 
         return updateIssueLabelsOnRepo(issue, newLabels);
     }
 
-    /**
-     * Updates an issue with a set of labels
-     * @return true if changes are made to the labels on the issue
-     */
-    private Boolean updateIssueLabels(TurboIssue issue, List<String> labels) {
-        boolean isLabelsUnchanged = issue.getLabels().size() == labels.size() && issue.getLabels().containsAll(labels);
-        if (isLabelsUnchanged) {
-            logger.info("No changes to labels of " + issue);
-            return false;
-        }
-
-        issue.setLabels(labels);
-        return true;
-    }
-
-    /**
-     * Updates an issue on the repository with a set of labels
-     * @param issue
-     * @param newLabels
-     * @return
-     */
     private CompletableFuture<Boolean> updateIssueLabelsOnRepo(TurboIssue issue, List<String> newLabels) {
         logger.info("Changing labels for " + issue + " on GitHub");
         return repoOpControl.replaceIssueLabels(issue, newLabels)

--- a/src/main/java/backend/control/RepoOpControl.java
+++ b/src/main/java/backend/control/RepoOpControl.java
@@ -1,18 +1,16 @@
 package backend.control;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.*;
-
+import backend.RepoIO;
+import backend.control.ops.*;
+import backend.resource.Model;
+import backend.resource.TurboIssue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import backend.RepoIO;
-import backend.control.ops.OpenRepoOp;
-import backend.control.ops.RemoveRepoOp;
-import backend.control.ops.RepoOp;
-import backend.control.ops.UpdateModelOp;
-import backend.resource.Model;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
 
 
 /**
@@ -55,6 +53,13 @@ public class RepoOpControl {
         init(oldModel.getRepoId());
         CompletableFuture<Model> result = new CompletableFuture<>();
         enqueue(new UpdateModelOp(oldModel, repoIO, result));
+        return result;
+    }
+
+    public CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels) {
+        init(issue.getRepoId());
+        CompletableFuture<List<String>> result = new CompletableFuture<>();
+        enqueue(new ReplaceIssueLabelsOp(repoIO, result, issue, labels));
         return result;
     }
 

--- a/src/main/java/backend/control/RepoOpControl.java
+++ b/src/main/java/backend/control/RepoOpControl.java
@@ -1,7 +1,7 @@
 package backend.control;
 
 import backend.RepoIO;
-import backend.control.ops.*;
+import backend.control.operations.*;
 import backend.resource.Model;
 import backend.resource.TurboIssue;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/backend/control/operations/OpenRepoOp.java
+++ b/src/main/java/backend/control/operations/OpenRepoOp.java
@@ -1,4 +1,4 @@
-package backend.control.ops;
+package backend.control.operations;
 
 import static util.Futures.chain;
 
@@ -7,26 +7,26 @@ import java.util.concurrent.CompletableFuture;
 import backend.RepoIO;
 import backend.resource.Model;
 
-public class UpdateModelOp implements RepoOp<Model> {
+public class OpenRepoOp implements RepoOp<Model> {
 
-    private final Model oldModel;
+    private final String repoId;
     private final RepoIO repoIO;
     private final CompletableFuture<Model> result;
 
-    public UpdateModelOp(Model oldModel, RepoIO repoIO, CompletableFuture<Model> result) {
-        this.oldModel = oldModel;
+    public OpenRepoOp(String repoId, RepoIO repoIO, CompletableFuture<Model> result) {
+        this.repoId = repoId;
         this.repoIO = repoIO;
         this.result = result;
     }
 
     @Override
     public String repoId() {
-        return oldModel.getRepoId();
+        return repoId;
     }
 
     @Override
     public CompletableFuture<Model> perform() {
-        return repoIO.updateModel(oldModel)
+        return repoIO.openRepository(repoId)
             .thenApply(chain(result));
     }
 }

--- a/src/main/java/backend/control/operations/RemoveRepoOp.java
+++ b/src/main/java/backend/control/operations/RemoveRepoOp.java
@@ -1,4 +1,4 @@
-package backend.control.ops;
+package backend.control.operations;
 
 import static util.Futures.chain;
 

--- a/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
+++ b/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
@@ -1,4 +1,4 @@
-package backend.control.ops;
+package backend.control.operations;
 
 import backend.RepoIO;
 import backend.resource.TurboIssue;

--- a/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
+++ b/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
@@ -8,6 +8,9 @@ import java.util.concurrent.CompletableFuture;
 
 import static util.Futures.chain;
 
+/**
+ * This class represents a repository operation that replaces a list of labels assigned to an issue
+ */
 public class ReplaceIssueLabelsOp implements RepoOp<List<String>> {
 
     private final RepoIO repoIO;

--- a/src/main/java/backend/control/operations/RepoOp.java
+++ b/src/main/java/backend/control/operations/RepoOp.java
@@ -1,4 +1,4 @@
-package backend.control.ops;
+package backend.control.operations;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/src/main/java/backend/control/operations/UpdateModelOp.java
+++ b/src/main/java/backend/control/operations/UpdateModelOp.java
@@ -1,4 +1,4 @@
-package backend.control.ops;
+package backend.control.operations;
 
 import static util.Futures.chain;
 
@@ -7,26 +7,26 @@ import java.util.concurrent.CompletableFuture;
 import backend.RepoIO;
 import backend.resource.Model;
 
-public class OpenRepoOp implements RepoOp<Model> {
+public class UpdateModelOp implements RepoOp<Model> {
 
-    private final String repoId;
+    private final Model oldModel;
     private final RepoIO repoIO;
     private final CompletableFuture<Model> result;
 
-    public OpenRepoOp(String repoId, RepoIO repoIO, CompletableFuture<Model> result) {
-        this.repoId = repoId;
+    public UpdateModelOp(Model oldModel, RepoIO repoIO, CompletableFuture<Model> result) {
+        this.oldModel = oldModel;
         this.repoIO = repoIO;
         this.result = result;
     }
 
     @Override
     public String repoId() {
-        return repoId;
+        return oldModel.getRepoId();
     }
 
     @Override
     public CompletableFuture<Model> perform() {
-        return repoIO.openRepository(repoId)
+        return repoIO.updateModel(oldModel)
             .thenApply(chain(result));
     }
 }

--- a/src/main/java/backend/control/ops/ReplaceIssueLabelsOp.java
+++ b/src/main/java/backend/control/ops/ReplaceIssueLabelsOp.java
@@ -1,0 +1,37 @@
+package backend.control.ops;
+
+import backend.RepoIO;
+import backend.resource.TurboIssue;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static util.Futures.chain;
+
+public class ReplaceIssueLabelsOp implements RepoOp<List<String>> {
+
+    private final RepoIO repoIO;
+    private final TurboIssue issue;
+    private final List<String> labels;
+    private final CompletableFuture<List<String>> result;
+
+    public ReplaceIssueLabelsOp(RepoIO repoIO, CompletableFuture<List<String>> result,
+                                TurboIssue issue, List<String> labels) {
+        this.repoIO = repoIO;
+        this.result = result;
+
+        this.issue = issue;
+        this.labels = labels;
+    }
+
+    @Override
+    public String repoId() {
+        return issue.getRepoId();
+    }
+
+    @Override
+    public CompletableFuture<List<String>> perform() {
+        return repoIO.replaceIssueLabels(issue, labels)
+                .thenApply(chain(result));
+    }
+}

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -239,7 +239,7 @@ public class MenuControl extends MenuBar {
                 // we trigger the notification timeout action first before refreshing
                 ui.hideNotification();
             }
-            ui.logic.refresh(false);
+            ui.logic.refresh();
         });
         refreshMenuItem.setAccelerator(REFRESH);
         return refreshMenuItem;

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -181,7 +181,7 @@ public class UI extends Application implements EventDispatcher {
     }
 
     protected void registerTestEvents() {
-        registerEvent((UILogicRefreshEventHandler) e -> Platform.runLater(() -> logic.refresh(false)));
+        registerEvent((UILogicRefreshEventHandler) e -> Platform.runLater(logic::refresh));
     }
 
     private void initPreApplicationState() {
@@ -212,7 +212,7 @@ public class UI extends Application implements EventDispatcher {
         logic = new Logic(uiManager, prefs);
         // TODO clear cache if necessary
         refreshTimer = new TickingTimer("Refresh Timer", REFRESH_PERIOD,
-            status::updateTimeToRefresh, () -> logic.refresh(isNotificationPaneShowing()), TimeUnit.SECONDS);
+            status::updateTimeToRefresh, logic::refresh, TimeUnit.SECONDS);
         refreshTimer.start();
         undoController = new UndoController(notificationController);
     }
@@ -313,7 +313,7 @@ public class UI extends Application implements EventDispatcher {
                     boolean shouldRefresh = browserComponent.hasBviewChanged();
                     if (shouldRefresh) {
                         logger.info("Browser view has changed; refreshing");
-                        logic.refresh(isNotificationPaneShowing());
+                        logic.refresh();
                         refreshTimer.restart();
                     }
                 }

--- a/src/test/java/tests/LogicTests.java
+++ b/src/test/java/tests/LogicTests.java
@@ -1,0 +1,85 @@
+package tests;
+
+import backend.Logic;
+import backend.RepoIO;
+import backend.UIManager;
+import backend.control.RepoOpControl;
+import backend.resource.TurboIssue;
+import org.junit.Test;
+import prefs.Preferences;
+import ui.UI;
+import util.events.EventDispatcher;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogicTests {
+    private final Logic logic;
+    private final RepoIO mockedRepoIO;
+
+    public LogicTests() throws NoSuchFieldException, IllegalAccessException {
+        Preferences mockedPreferences = mock(Preferences.class);
+        when(mockedPreferences.getLastViewedRepository()).thenReturn(Optional.empty());
+        UI.events = mock(EventDispatcher.class);
+
+        mockedRepoIO = mock(RepoIO.class);
+
+        logic = new Logic(mock(UIManager.class), mockedPreferences);
+        Field repoOpControlField = logic.getClass().getDeclaredField("repoOpControl");
+        repoOpControlField.setAccessible(true);
+        repoOpControlField.set(logic, new RepoOpControl(mockedRepoIO));
+    }
+
+    /**
+     * Tests that all issue's labels are removed if an empty list is passed into replaceIssueLabels
+     */
+    @Test
+    public void testReplaceIssueLabelsEmptyList() throws ExecutionException, InterruptedException {
+        TurboIssue issue = new TurboIssue("testowner/testrepo", 1, "Issue title");
+        List<String> oldLabels = Arrays.asList("label1", "label2");
+        issue.setLabels(oldLabels);
+
+        CompletableFuture<List<String>> resultLabels = new CompletableFuture<>();
+        resultLabels.complete(new ArrayList<>());
+        when(mockedRepoIO.replaceIssueLabels(any(TurboIssue.class), anyListOf(String.class)))
+                .thenReturn(resultLabels);
+
+        boolean status = logic.replaceIssueLabels(issue, new ArrayList<>()).get();
+
+        assertTrue(status);
+        assertEquals(0, issue.getLabels().size());
+    }
+
+    /**
+     * Tests that all issue's labels are replaced with new labels passed in
+     */
+    @Test
+    public void  testReplaceIssueLabels() throws ExecutionException, InterruptedException {
+        TurboIssue issue = new TurboIssue("testowner/testrepo", 1, "Issue title");
+        List<String> oldLabels = Arrays.asList("label1", "label2");
+        issue.setLabels(oldLabels);
+
+        List<String> newLabels = Arrays.asList("label3", "label4");
+        CompletableFuture<List<String>> resultLabels = new CompletableFuture<>();
+        resultLabels.complete(newLabels);
+        when(mockedRepoIO.replaceIssueLabels(any(TurboIssue.class), anyListOf(String.class)))
+                .thenReturn(resultLabels);
+
+        boolean status = logic.replaceIssueLabels(issue, newLabels).get();
+
+        assertTrue(status);
+        assertEquals(resultLabels.get(), issue.getLabels());
+    }
+}

--- a/src/test/java/tests/TurboIssueTests.java
+++ b/src/test/java/tests/TurboIssueTests.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
-public class TurboIssueTest {
+public class TurboIssueTests {
 
     private static final String REPO = "testrepo/testrepo";
 


### PR DESCRIPTION
Fixes #1214 

* Remove refresh block when undo pane is showing.
* Make `replaceIssueLabels` mutually exclusive with other repo operations.
* Eager update is now more immediate.