### PR TITLE
Prompt user to save current board if there are unsaved changes #1199

### DIFF
--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -214,18 +214,23 @@ public class Preferences { // NOPMD
     }
 
     /**
-     * Switches the board to the next one. Cycles through the boards one at a time.
-     * @return The new board selected
+     * Finds the next board in the list of boards. Circles through the boards one at a time.
+     * If {@code lastOpenBoard} exists, it will look for the board next to it.
+     * Otherwise it will just return the first board on the list.
+     *
+     * @return name of the next board
      */
-    public Optional<String> switchBoard() {
-        if (getLastOpenBoard().isPresent() && getAllBoards().size() > 1) {
-            List<String> boardNames = getAllBoardNames();
-            int lastBoard = boardNames.indexOf(getLastOpenBoard().get());
-            int index = (lastBoard + 1) % boardNames.size();
-            
-            setLastOpenBoard(boardNames.get(index));
+    public Optional<String> getNextBoardName() {
+        List<String> boardNames = getAllBoardNames();
+
+        if (boardNames.isEmpty()) {
+            return Optional.empty();
         }
-        return getLastOpenBoard();
+
+        int currentIndex = getLastOpenBoard().isPresent() ? boardNames.indexOf(getLastOpenBoard().get()) : -1;
+        int nextIndex = (currentIndex + 1) % boardNames.size();
+
+        return Optional.of(boardNames.get(nextIndex));
     }
 
     public void clearLastOpenBoard() {

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -218,6 +218,15 @@ public class MenuControl extends MenuBar {
      */
     private void onBoardOpen(String boardName, List<PanelInfo> panelInfos) {
         logger.info("Menu: Boards > Open > " + boardName);
+
+        if (isCurrentBoardDirty() && isUserAgreeableToSavingBorad()) {
+            saveBoard();
+
+            logger.info("Changes to the current board saved.");
+        } else {
+            logger.info("User abandoned unsaved changes.");
+        }
+
         openBoard(boardName, panelInfos);
     }
 
@@ -317,9 +326,9 @@ public class MenuControl extends MenuBar {
     }
 
     public void switchBoard() {
-        Optional<String> name = prefs.switchBoard();
+        Optional<String> name = prefs.getNextBoardName();
         if (name.isPresent()) {
-            onBoardOpen(name.get(), prefs.getBoardPanels(name.get()));
+            switchBoard(name.get());
         }
     }
 

--- a/src/test/java/guitests/PanelFocusTest.java
+++ b/src/test/java/guitests/PanelFocusTest.java
@@ -126,6 +126,10 @@ public class PanelFocusTest extends UITest {
         // 3. Open board
         pushKeys(SWITCH_BOARD);
 
+        // Abort saving changes to current board
+        waitUntilNodeAppears("No");
+        clickOn("No");
+
         // Check that first panel is on focus
         awaitCondition(() -> 0 == panelControl.getCurrentlySelectedPanel().get());
         // Check that first panel is shown by checking scrollbar position

--- a/src/test/java/tests/GetNextBoardNameTest.java
+++ b/src/test/java/tests/GetNextBoardNameTest.java
@@ -10,14 +10,14 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class BoardSwitchTest {
+public class GetNextBoardNameTest {
 
     private static final String BOARDNAME1 = "Board 1";
     private static final String BOARDNAME2 = "Board 2";
     private static final String BOARDNAME3 = "Board 3";
 
     @Test
-    public void boardsSwitchTest() {
+    public void getNextBoardNameTest_multipleBoards_lastOpenBoardExists_returnNextBoardName() {
         Preferences testPrefs = TestController.createTestPreferences();
 
         List<PanelInfo> board1 = new ArrayList<>();
@@ -28,32 +28,22 @@ public class BoardSwitchTest {
         testPrefs.addBoard(BOARDNAME2, board2);
         testPrefs.addBoard(BOARDNAME3, board3);
 
+
         testPrefs.setLastOpenBoard(BOARDNAME1);
+        assertEquals(BOARDNAME3, testPrefs.getNextBoardName().get());
 
-        testPrefs.switchBoard();
-        assertEquals(BOARDNAME3, testPrefs.getLastOpenBoard().get());
+        testPrefs.setLastOpenBoard(BOARDNAME3);
+        assertEquals(BOARDNAME2, testPrefs.getNextBoardName().get());
 
-        testPrefs.switchBoard();
-        assertEquals(BOARDNAME2, testPrefs.getLastOpenBoard().get());
+        testPrefs.setLastOpenBoard(BOARDNAME2);
+        assertEquals(BOARDNAME1, testPrefs.getNextBoardName().get());
 
-        testPrefs.switchBoard();
-        assertEquals(BOARDNAME1, testPrefs.getLastOpenBoard().get());
-
-        testPrefs.switchBoard();
-        assertEquals(BOARDNAME3, testPrefs.getLastOpenBoard().get());
-
+        testPrefs.setLastOpenBoard(BOARDNAME1);
+        assertEquals(BOARDNAME3, testPrefs.getNextBoardName().get());
     }
 
     @Test
-    public void noBoardSwitchTest() {
-        Preferences testPrefs = TestController.createTestPreferences();
-
-        testPrefs.switchBoard();
-        assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
-    }
-
-    @Test
-    public void noBoardOpenSwitchTest() {
+    public void getNextBoardNameTest_multipleBoards_noBoardOpen_returnFirstBoard() {
         Preferences testPrefs = TestController.createTestPreferences();
 
         List<PanelInfo> board1 = new ArrayList<>();
@@ -64,19 +54,28 @@ public class BoardSwitchTest {
         testPrefs.addBoard(BOARDNAME2, board2);
         testPrefs.addBoard(BOARDNAME3, board3);
 
-        testPrefs.switchBoard();
+        testPrefs.getNextBoardName();
+        assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
+        assertEquals(BOARDNAME3, testPrefs.getNextBoardName().get());
+    }
+
+    @Test
+    public void getNextBoardNameTest_noBoards_returnNothing() {
+        Preferences testPrefs = TestController.createTestPreferences();
+
+        testPrefs.getNextBoardName();
         assertEquals(false, testPrefs.getLastOpenBoard().isPresent());
     }
 
     @Test
-    public void oneBoardSwitchTest() {
+    public void getNextBoardNameTest_singleBoard_returnTheOnlyBoard() {
         Preferences testPrefs = TestController.createTestPreferences();
 
         List<PanelInfo> board1 = new ArrayList<>();
         testPrefs.addBoard(BOARDNAME1, board1);
         testPrefs.setLastOpenBoard(BOARDNAME1);
 
-        testPrefs.switchBoard();
+        testPrefs.getNextBoardName();
         assertEquals(BOARDNAME1, testPrefs.getLastOpenBoard().get());
     }
 

--- a/src/test/java/unstable/BoardDuplicateTests.java
+++ b/src/test/java/unstable/BoardDuplicateTests.java
@@ -63,6 +63,11 @@ public class BoardDuplicateTests extends UITest {
         clickOn("No");
         clickOn("Cancel");
         traverseHubTurboMenu("Boards", "Open", "New Board");
+
+        // Abort saving changes
+        waitUntilNodeAppears("No");
+        clickOn("No");
+
         waitAndAssertEquals(2, panelControl::getPanelCount);
     }
 }


### PR DESCRIPTION
Fixes #1198
Fixes #1199 

1. Save the initial panel info when a board is opened. 
2. When switching to another board, check if the current panel info is from the initial one. If so, prompt for save.
