### PR TITLE
Make warning in Board Name Dialog to be more noticeable #1239

### DIFF
--- a/src/main/java/ui/BoardNameDialog.java
+++ b/src/main/java/ui/BoardNameDialog.java
@@ -93,6 +93,7 @@ public final class BoardNameDialog extends Dialog<String> {
         grid.add(nameArea, 0, 0);
         
         errorText = new Text("");
+        errorText.getStyleClass().add("text-red");
         grid.add(errorText, 0, 1);
         
         getDialogPane().setContent(grid);

--- a/src/main/resources/ui/hubturbo.css
+++ b/src/main/resources/ui/hubturbo.css
@@ -241,3 +241,7 @@
     -fx-font-size: 13px;
     -fx-wrap-text: true;
 }
+
+.text-red {
+    -fx-fill: red;
+}


### PR DESCRIPTION
Fixes #1239 

Hi, new-comer is here :) Please help to correct me if I made mistakes.

#### Changes
Set the color fill of the `errorText` to be red color by defining a new css class `text-red`.
Using `-fx-fill` in css because I tried using `-fx-text-fill` but it seems like it doesn't work on Text object. 

#### Sample screenshot
![screen shot 2016-02-07 at 02 17 56](https://cloud.githubusercontent.com/assets/4332224/12868757/2af94dd2-cd48-11e5-8e70-e955f7c4117d.png)
![screen shot 2016-02-07 at 02 18 04](https://cloud.githubusercontent.com/assets/4332224/12868758/31536208-cd48-11e5-9896-1e1eed452102.png)