### PR TITLE
Recover from failed labels replace #1246

### DIFF
--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -20,10 +20,7 @@ import util.events.RepoOpeningEvent;
 import util.events.testevents.ClearLogicModelEvent;
 import util.events.testevents.ClearLogicModelEventHandler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -201,7 +198,9 @@ public class Logic {
      */
     public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> newLabels) {
         logger.info("Changing labels for " + issue + " on UI");
-        issue.setLabels(newLabels);
+        if (!models.replaceIssueLabels(issue, newLabels)) {
+           return CompletableFuture.completedFuture(false);
+        }
         refreshUI();
 
         return updateIssueLabelsOnRepo(issue, newLabels);
@@ -210,7 +209,7 @@ public class Logic {
     private CompletableFuture<Boolean> updateIssueLabelsOnRepo(TurboIssue issue, List<String> newLabels) {
         logger.info("Changing labels for " + issue + " on GitHub");
         return repoOpControl.replaceIssueLabels(issue, newLabels)
-                .thenApply(labels -> labels.containsAll(newLabels))
+                .thenApply(labels -> newLabels.containsAll(labels))
                 .exceptionally(Futures.withResult(false));
     }
 

--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -201,39 +201,65 @@ public class Logic {
         List<String> originalLabels = issue.getLabels();
 
         logger.info("Changing labels for " + issue + " on UI");
-        Optional<TurboIssue> replaceResult = models.replaceIssueLabels(issue.getRepoId(), issue.getId(), newLabels);
-        if (!replaceResult.isPresent()) {
+        /* Calls models to replace the issue's labels locally since the the reference to the issue here
+           could be invalidated by changes to the models elsewhere */
+        Optional<TurboIssue> localReplaceResult =
+                models.replaceIssueLabels(issue.getRepoId(), issue.getId(), newLabels);
+        if (!localReplaceResult.isPresent()) {
             return CompletableFuture.completedFuture(false);
         }
         refreshUI();
 
-        return updateIssueLabelsOnRepo(issue, newLabels)
-                .thenApply((isUpdateSuccessful) -> {
-                    if (isUpdateSuccessful) {
-                        return true;
-                    }
-                    logger.error("Unable to update model on server");
-                    revertLocalLabelsReplace(replaceResult.get(), originalLabels);
-                    return false;
-                });
+        return updateIssueLabelsOnServer(issue, newLabels)
+                .thenApply((isUpdateSuccessful) -> handleIssueLabelsUpdateOnServerResult(
+                            isUpdateSuccessful, localReplaceResult.get(), originalLabels));
     }
 
-    private Optional<TurboIssue> lookUpIssue(String repoId, int issueId) {
+    /**
+     * Gets the issue identified by {@code repoId} and {@code issueId} in {@link Logic#models}
+     * @param repoId
+     * @param issueId
+     * @return
+     */
+    private Optional<TurboIssue> getIssue(String repoId, int issueId) {
         Optional<Model> modelLookUpResult = models.getModelById(repoId);
-        if (!modelLookUpResult.isPresent()) {
-            logger.error("Model " + repoId + " not found in models");
-            return Optional.empty();
-        }
-        return modelLookUpResult.get().getIssueById(issueId);
+        return Utility.safeFlatMapOptional(modelLookUpResult,
+                (model) -> model.getIssueById(issueId),
+                () -> logger.error("Model " + repoId + " not found in models"));
     }
 
-    private CompletableFuture<Boolean> updateIssueLabelsOnRepo(TurboIssue issue, List<String> newLabels) {
+    private CompletableFuture<Boolean> updateIssueLabelsOnServer(TurboIssue issue, List<String> newLabels) {
         logger.info("Changing labels for " + issue + " on GitHub");
         return repoOpControl.replaceIssueLabels(issue, newLabels);
     }
 
+    /**
+     * Handles the result of updating an issue's labels on server. Current implementation includes
+     * reverting back to the original labels locally if the server update failed.
+     * @param isUpdateSuccessful
+     * @param localModifiedIssue
+     * @param originalLabels
+     * @return true if the server update is successful
+     */
+    private boolean handleIssueLabelsUpdateOnServerResult(boolean isUpdateSuccessful,
+                                                          TurboIssue localModifiedIssue,
+                                                          List<String> originalLabels) {
+        if (isUpdateSuccessful) {
+            return true;
+        }
+        logger.error("Unable to update model on server");
+        revertLocalLabelsReplace(localModifiedIssue, originalLabels);
+        return false;
+    }
+
+    /**
+     * Replaces labels of the issue in the {@link Logic#models} corresponding to {@code modifiedIssue} with
+     * {@code originalLabels} if the current labels on the issue is assigned at the same time as {@code modifiedIssue}
+     * @param modifiedIssue
+     * @param originalLabels
+     */
     private void revertLocalLabelsReplace(TurboIssue modifiedIssue, List<String> originalLabels) {
-        TurboIssue currentIssue = lookUpIssue(modifiedIssue.getRepoId(), modifiedIssue.getId()).orElse(modifiedIssue);
+        TurboIssue currentIssue = getIssue(modifiedIssue.getRepoId(), modifiedIssue.getId()).orElse(modifiedIssue);
         LocalDateTime originalLabelsModifiedAt = modifiedIssue.getLabelsLastModifiedAt();
         LocalDateTime currentLabelsAssignedAt = currentIssue.getLabelsLastModifiedAt();
         boolean isCurrentLabelsModifiedFromOriginalLabels = originalLabelsModifiedAt.isEqual(currentLabelsAssignedAt);

--- a/src/main/java/backend/RepoIO.java
+++ b/src/main/java/backend/RepoIO.java
@@ -160,7 +160,7 @@ public class RepoIO {
         return repoSource.downloadMetadata(repoId, issues);
     }
 
-    public CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels) {
+    public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> labels) {
         return repoSource.replaceIssueLabels(issue, labels);
     }
 

--- a/src/main/java/backend/control/RepoOpControl.java
+++ b/src/main/java/backend/control/RepoOpControl.java
@@ -56,9 +56,9 @@ public class RepoOpControl {
         return result;
     }
 
-    public CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels) {
+    public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> labels) {
         init(issue.getRepoId());
-        CompletableFuture<List<String>> result = new CompletableFuture<>();
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
         enqueue(new ReplaceIssueLabelsOp(repoIO, result, issue, labels));
         return result;
     }

--- a/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
+++ b/src/main/java/backend/control/operations/ReplaceIssueLabelsOp.java
@@ -11,14 +11,14 @@ import static util.Futures.chain;
 /**
  * This class represents a repository operation that replaces a list of labels assigned to an issue
  */
-public class ReplaceIssueLabelsOp implements RepoOp<List<String>> {
+public class ReplaceIssueLabelsOp implements RepoOp<Boolean> {
 
     private final RepoIO repoIO;
     private final TurboIssue issue;
     private final List<String> labels;
-    private final CompletableFuture<List<String>> result;
+    private final CompletableFuture<Boolean> result;
 
-    public ReplaceIssueLabelsOp(RepoIO repoIO, CompletableFuture<List<String>> result,
+    public ReplaceIssueLabelsOp(RepoIO repoIO, CompletableFuture<Boolean> result,
                                 TurboIssue issue, List<String> labels) {
         this.repoIO = repoIO;
         this.result = result;
@@ -33,7 +33,7 @@ public class ReplaceIssueLabelsOp implements RepoOp<List<String>> {
     }
 
     @Override
-    public CompletableFuture<List<String>> perform() {
+    public CompletableFuture<Boolean> perform() {
         return repoIO.replaceIssueLabels(issue, labels)
                 .thenApply(chain(result));
     }

--- a/src/main/java/backend/github/GitHubSource.java
+++ b/src/main/java/backend/github/GitHubSource.java
@@ -60,7 +60,7 @@ public class GitHubSource extends RepoSource {
     }
 
     @Override
-    public CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels) {
+    public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> labels) {
         return addTask(new ReplaceIssueLabelsTask(this, gitHub, issue.getRepoId(), issue.getId(), labels)).response;
     }
 

--- a/src/main/java/backend/github/ReplaceIssueLabelsTask.java
+++ b/src/main/java/backend/github/ReplaceIssueLabelsTask.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class ReplaceIssueLabelsTask extends GitHubRepoTask<List<String>> {
+public class ReplaceIssueLabelsTask extends GitHubRepoTask<Boolean> {
 
     private final String repoId;
     private final int issueId;
@@ -24,13 +24,13 @@ public class ReplaceIssueLabelsTask extends GitHubRepoTask<List<String>> {
     @Override
     public void run() {
         try {
-            response.complete(
+            List<String> responseLabels =
                     repo.setLabels(repoId, issueId, labels).stream()
                             .map(Label::getName)
-                            .collect(Collectors.toList())
-            );
+                            .collect(Collectors.toList());
+            response.complete(responseLabels.containsAll(labels));
         } catch (IOException e) {
-            response.completeExceptionally(e);
+            response.complete(false);
         }
     }
 }

--- a/src/main/java/backend/github/UpdateIssuesTask.java
+++ b/src/main/java/backend/github/UpdateIssuesTask.java
@@ -40,7 +40,7 @@ public class UpdateIssuesTask extends GitHubRepoTask<GitHubRepoTask.Result<Turbo
 
         List<TurboIssue> updated = updatedIssues.isEmpty()
             ? existing
-            : TurboIssue.reconcile(model.getRepoId(), existing, updatedIssues);
+            : TurboIssue.reconcile(existing, updatedIssues);
         updated = TurboIssue.combineWithPullRequests(updated, updatedPullRequests);
 
         response.complete(new Result<>(updated, changes.middle, changes.right));

--- a/src/main/java/backend/interfaces/RepoSource.java
+++ b/src/main/java/backend/interfaces/RepoSource.java
@@ -40,7 +40,7 @@ public abstract class RepoSource implements TaskRunner {
 
     public abstract CompletableFuture<Boolean> isRepositoryValid(String repoId);
 
-    public abstract CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels);
+    public abstract CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> labels);
 
     public abstract CompletableFuture<ImmutablePair<Integer, Long>> getRateLimitResetTime();
 

--- a/src/main/java/backend/resource/Model.java
+++ b/src/main/java/backend/resource/Model.java
@@ -5,6 +5,7 @@ import backend.interfaces.IBaseModel;
 import backend.resource.serialization.SerializableModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import util.Utility;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -191,19 +192,19 @@ public class Model implements IBaseModel {
     }
 
     /**
-     * Assigns {@code labels} to issue {@code issueId}
+     * Replaces labels of an issue specified by {@code issueId} with {@code labels}
      * @param issueId
      * @param labels
      * @return the modified TurboIssue if successful
      */
     public synchronized Optional<TurboIssue> replaceIssueLabels(int issueId, List<String> labels) {
         Optional<TurboIssue> issueLookUpResult = getIssueById(issueId);
-        if (!issueLookUpResult.isPresent()) {
-            logger.error("Issue " + issueId + " not found in model for " + repoId);
-            return Optional.empty();
-        }
-        issueLookUpResult.get().setLabels(labels);
-        return Optional.of(new TurboIssue(issueLookUpResult.get()));
+        return Utility.safeFlatMapOptional(issueLookUpResult,
+                (issue) -> {
+                    issue.setLabels(labels);
+                    return Optional.of(new TurboIssue(issue));
+                },
+                () -> logger.error("Issue " + issueId + " not found in model for " + repoId));
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -84,32 +84,19 @@ public class MultiModel implements IModel {
     }
 
     /**
-     * Assigns {@code labels} to an issue corresponding to the argument {@code issue} in this MultiModel
-     * @param issue
+     * Assigns {@code labels} to issue {@code issueId} in {@code repoId}
+     * @param repoId
+     * @param issueId
      * @param labels
-     * @return true if labels are successfully assigned
+     * @return the modified TurboIssue if successful
      */
-    public synchronized boolean replaceIssueLabels(TurboIssue issue, List<String> labels) {
-        Optional<TurboIssue> issueLookUpResult = lookUpIssue(issue);
-        if (!issueLookUpResult.isPresent()) {
-            logger.error("Issue " + issue + " not found in models");
-            return false;
-        }
-        issueLookUpResult.get().setLabels(labels);
-        return true;
-    }
-
-    /**
-     * Looks up an issue corresponding to the argument {@code issue} in this MultiModel
-     * @param issue
-     * @return true if labels are successfully assigned
-     */
-    public synchronized Optional<TurboIssue> lookUpIssue(TurboIssue issue) {
-        Optional<Model> modelLookUpResult = getModelById(issue.getRepoId());
+    public synchronized Optional<TurboIssue> replaceIssueLabels(String repoId, int issueId, List<String> labels) {
+        Optional<Model> modelLookUpResult = getModelById(repoId);
         if (!modelLookUpResult.isPresent()) {
+            logger.error("Model " + repoId + " not found in models");
             return Optional.empty();
         }
-        return modelLookUpResult.get().getIssueById(issue.getId());
+        return modelLookUpResult.get().replaceIssueLabels(issueId, labels);
     }
 
     public synchronized void insertMetadata(String repoId, Map<Integer, IssueMetadata> metadata, String currentUser) {

--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -5,6 +5,7 @@ import backend.interfaces.IModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import prefs.Preferences;
+import util.Utility;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -84,7 +85,7 @@ public class MultiModel implements IModel {
     }
 
     /**
-     * Assigns {@code labels} to issue {@code issueId} in {@code repoId}
+     * Replaces labels of an issue specified by {@code issueId} in {@code repoId} with {@code labels}
      * @param repoId
      * @param issueId
      * @param labels
@@ -92,11 +93,9 @@ public class MultiModel implements IModel {
      */
     public synchronized Optional<TurboIssue> replaceIssueLabels(String repoId, int issueId, List<String> labels) {
         Optional<Model> modelLookUpResult = getModelById(repoId);
-        if (!modelLookUpResult.isPresent()) {
-            logger.error("Model " + repoId + " not found in models");
-            return Optional.empty();
-        }
-        return modelLookUpResult.get().replaceIssueLabels(issueId, labels);
+        return Utility.safeFlatMapOptional(modelLookUpResult,
+                (model) -> model.replaceIssueLabels(issueId, labels),
+                () -> logger.error("Model " + repoId + " not found in models"));
     }
 
     public synchronized void insertMetadata(String repoId, Map<Integer, IssueMetadata> metadata, String currentUser) {

--- a/src/main/java/backend/resource/MultiModel.java
+++ b/src/main/java/backend/resource/MultiModel.java
@@ -83,6 +83,35 @@ public class MultiModel implements IModel {
         return this;
     }
 
+    /**
+     * Assigns {@code labels} to an issue corresponding to the argument {@code issue} in this MultiModel
+     * @param issue
+     * @param labels
+     * @return true if labels are successfully assigned
+     */
+    public synchronized boolean replaceIssueLabels(TurboIssue issue, List<String> labels) {
+        Optional<TurboIssue> issueLookUpResult = lookUpIssue(issue);
+        if (!issueLookUpResult.isPresent()) {
+            logger.error("Issue " + issue + " not found in models");
+            return false;
+        }
+        issueLookUpResult.get().setLabels(labels);
+        return true;
+    }
+
+    /**
+     * Looks up an issue corresponding to the argument {@code issue} in this MultiModel
+     * @param issue
+     * @return true if labels are successfully assigned
+     */
+    public synchronized Optional<TurboIssue> lookUpIssue(TurboIssue issue) {
+        Optional<Model> modelLookUpResult = getModelById(issue.getRepoId());
+        if (!modelLookUpResult.isPresent()) {
+            return Optional.empty();
+        }
+        return modelLookUpResult.get().getIssueById(issue.getId());
+    }
+
     public synchronized void insertMetadata(String repoId, Map<Integer, IssueMetadata> metadata, String currentUser) {
         models.get(repoId).getIssues().forEach(issue -> {
             if (metadata.containsKey(issue.getId())) {
@@ -158,7 +187,7 @@ public class MultiModel implements IModel {
     }
 
     @Override
-    public Optional<Model> getModelById(String repoId) {
+    public synchronized Optional<Model> getModelById(String repoId) {
         return models.containsKey(repoId)
             ? Optional.of(models.get(repoId))
             : Optional.empty();

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -246,8 +246,10 @@ public class TurboIssue {
     /**
      * Takes lists of TurboIssues and reconciles the changes between them,
      * returning a list of TurboIssues with updates from the second.
+     * @param existing
+     * @param changed
      */
-    public static List<TurboIssue> reconcile(String repoId, List<TurboIssue> existing, List<TurboIssue> changed) {
+    public static List<TurboIssue> reconcile(List<TurboIssue> existing, List<TurboIssue> changed) {
         List<TurboIssue> existingCopy = new ArrayList<>(existing);
         for (TurboIssue issue : changed) {
             int id = issue.getId();

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -63,12 +63,8 @@ public class TurboIssue {
     private IssueMetadata metadata;
     private Optional<LocalDateTime> markedReadAt;
 
-    /**
-     * The following fields are used to control concurrent modifications to this issue.
-     */
     /* This field records the most recently modified time of the issue's labels. Any method that updates
-       the labels must also update this field. If this is empty, the most recently modified time can
-       be considered to be the updatedAt time */
+       the labels must also update this field. If this is empty, updatedAt time is used instead */
     private Optional<LocalDateTime> labelsLastModifiedAt = Optional.empty();
 
     @SuppressWarnings("unused")
@@ -124,6 +120,7 @@ public class TurboIssue {
         this.metadata = issue.metadata;
         this.repoId = issue.repoId;
         this.markedReadAt = issue.markedReadAt;
+        this.labelsLastModifiedAt = Optional.of(issue.getLabelsLastModifiedAt());
     }
 
     public TurboIssue(String repoId, Issue issue) {
@@ -414,7 +411,7 @@ public class TurboIssue {
     }
 
     public List<String> getLabels() {
-        return new ArrayList<>(labels);
+        return labels;
     }
 
     public void setLabels(List<String> labels) {

--- a/src/main/java/backend/resource/TurboIssue.java
+++ b/src/main/java/backend/resource/TurboIssue.java
@@ -255,7 +255,9 @@ public class TurboIssue {
             int id = issue.getId();
 
             Optional<Integer> correspondingIssueIndex = findIssueWithId(existingCopy, id);
-            if (correspondingIssueIndex.isPresent()) {
+            if (!correspondingIssueIndex.isPresent()) {
+                existingCopy.add(new TurboIssue(issue));
+            } else {
                 TurboIssue existingIssue = existingCopy.get(correspondingIssueIndex.get());
                 TurboIssue newIssue = new TurboIssue(issue);
 
@@ -266,8 +268,6 @@ public class TurboIssue {
                 newIssue.reconcile(existingIssue);
 
                 existingCopy.set(correspondingIssueIndex.get(), newIssue);
-            } else {
-                existingCopy.add(new TurboIssue(issue));
             }
         }
         return existingCopy;

--- a/src/main/java/backend/stub/DummySource.java
+++ b/src/main/java/backend/stub/DummySource.java
@@ -49,7 +49,7 @@ public class DummySource extends RepoSource {
     }
 
     @Override
-    public CompletableFuture<List<String>> replaceIssueLabels(TurboIssue issue, List<String> labels) {
+    public CompletableFuture<Boolean> replaceIssueLabels(TurboIssue issue, List<String> labels) {
         return addTask(new ReplaceIssueLabelsTask(this, dummy, issue.getRepoId(), issue.getId(), labels)).response;
     }
 

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -220,7 +220,7 @@ public class UI extends Application implements EventDispatcher {
     private void initApplicationState() {
         // In the future, when more arguments are passed to logic,
         // we can pass them in the form of an array.
-        logic = new Logic(uiManager, prefs);
+        logic = new Logic(uiManager, prefs, Optional.empty());
         // TODO clear cache if necessary
         refreshTimer = new TickingTimer("Refresh Timer", REFRESH_PERIOD,
             status::updateTimeToRefresh, logic::refresh, TimeUnit.SECONDS);

--- a/src/main/java/util/Utility.java
+++ b/src/main/java/util/Utility.java
@@ -1,9 +1,15 @@
 package util;
 
-import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
-import java.awt.Rectangle;
-import java.awt.Toolkit;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.egit.github.core.RepositoryId;
+import ui.UI;
+import util.events.ShowErrorDialogEvent;
+
+import javax.swing.*;
+import java.awt.*;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,21 +22,11 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import javax.swing.UIManager;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.eclipse.egit.github.core.RepositoryId;
-
-import ui.UI;
-import util.events.ShowErrorDialogEvent;
-
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
 
 public final class Utility {
 
@@ -326,6 +322,24 @@ public final class Utility {
     // TODO: remove once #1078 is solved from all repoIds normalization
     public static Set<String> convertSetToLowerCase(Set<String> originalSet) {
         return originalSet.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    }
+
+    /**
+     * If a value is present in the optional, applies mapping function to it and return the result,
+     * otherwise executes the ifEmpty function and returns an empty optional
+     * @param optional
+     * @param mapper
+     * @param ifEmpty
+     * @return
+     */
+    public static <T, U> Optional<U> safeFlatMapOptional(Optional<T> optional,
+                                                         Function<? super T, Optional<U>> mapper,
+                                                         Runnable ifEmpty) {
+        if (optional.isPresent()) {
+            return mapper.apply(optional.get());
+        }
+        ifEmpty.run();
+        return Optional.empty();
     }
 
     private Utility() {}

--- a/src/test/java/tests/LogicTests.java
+++ b/src/test/java/tests/LogicTests.java
@@ -4,6 +4,8 @@ import backend.Logic;
 import backend.RepoIO;
 import backend.UIManager;
 import backend.control.RepoOpControl;
+import backend.resource.Model;
+import backend.resource.MultiModel;
 import backend.resource.TurboIssue;
 import org.junit.Test;
 import prefs.Preferences;
@@ -11,21 +13,23 @@ import ui.UI;
 import util.events.EventDispatcher;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LogicTests {
     private final Logic logic;
     private final RepoIO mockedRepoIO;
+    private final MultiModel mockedMultiModel;
 
     public LogicTests() throws NoSuchFieldException, IllegalAccessException {
         Preferences mockedPreferences = mock(Preferences.class);
@@ -33,63 +37,60 @@ public class LogicTests {
         UI.events = mock(EventDispatcher.class);
 
         mockedRepoIO = mock(RepoIO.class);
+        mockedMultiModel = mock(MultiModel.class);
 
-        logic = new Logic(mock(UIManager.class), mockedPreferences);
+        logic = new Logic(mock(UIManager.class), mockedPreferences, Optional.of(mockedMultiModel));
         Field repoOpControlField = logic.getClass().getDeclaredField("repoOpControl");
         repoOpControlField.setAccessible(true);
         repoOpControlField.set(logic, new RepoOpControl(mockedRepoIO));
     }
 
     /**
-     * Tests that all issue's labels are replaced with new labels when
-     * the new labels are different from the current ones
+     * Tests that replaceIssueLabels succeed when both models and repoIO succeeded
      */
     @Test
-    public void testReplaceIssueLabelsNonOverlapping() throws ExecutionException, InterruptedException {
+    public void testReplaceIssueLabelsSuccessful() throws ExecutionException, InterruptedException {
         TurboIssue issue = createIssueWithLabels(Arrays.asList("label1", "label2"));
-        List<String> newLabels = Arrays.asList("label3", "label4");
-        mockRepoIOReplaceIssueLabelsResult(newLabels);
+        mockRepoIOReplaceIssueLabelsResult(true);
+        mockMultiModelReplaceIssueLabels(Optional.of(issue), Optional.empty());
 
-        boolean status = logic.replaceIssueLabels(issue, newLabels).get();
-
-        assertTrue(status);
-        assertEquals(newLabels, issue.getLabels());
+        assertTrue(logic.replaceIssueLabels(issue, new ArrayList<>()).get());
     }
 
     /**
-     * Tests that all issue's labels remain the same if the new labels are the same as the current ones
+     * Tests that replaceIssueLabels failed when models return empty result
      */
     @Test
-    public void testReplaceIssueLabelsNoChange() throws ExecutionException, InterruptedException {
-        List<String> labels = Arrays.asList("label1", "label2");
-        TurboIssue issue = createIssueWithLabels(labels);
-        mockRepoIOReplaceIssueLabelsResult(labels);
+    public void testReplaceIssueLabelsRepoIOFailed() throws ExecutionException, InterruptedException {
+        TurboIssue issue = createIssueWithLabels(Arrays.asList("label1", "label2"));
+        mockRepoIOReplaceIssueLabelsResult(true);
+        mockMultiModelReplaceIssueLabels(Optional.empty(), Optional.empty());
 
-        boolean status = logic.replaceIssueLabels(issue, labels).get();
-
-        assertTrue(status);
-        assertEquals(labels, issue.getLabels());
+        assertFalse(logic.replaceIssueLabels(issue, new ArrayList<>()).get());
     }
 
     /**
-     * Tests that the returned status is false when the returned result from RepoIO is inconsistent
-     * with the given labels argument
+     * Tests that replaceIssueLabels failed when repoIO failed to update labels
      */
     @Test
-    public void testReplaceIssueLabelsInconsistent() throws ExecutionException, InterruptedException {
-        TurboIssue issue = createIssueWithLabels(Arrays.asList("label1", "label2", "label3"));
-        mockRepoIOReplaceIssueLabelsResult(Arrays.asList("label3", "label4"));
+    public void testReplaceIssueLabelsModelsFailed() throws ExecutionException, InterruptedException {
+        TurboIssue issue = createIssueWithLabels(Arrays.asList("label1", "label2"));
+        mockRepoIOReplaceIssueLabelsResult(false);
+        mockMultiModelReplaceIssueLabels(Optional.of(issue), Optional.empty());
 
-        boolean status = logic.replaceIssueLabels(issue, Arrays.asList("label1", "label2")).get();
-
-        assertFalse(status);
+        assertFalse(logic.replaceIssueLabels(issue, new ArrayList<>()).get());
     }
 
-    private void mockRepoIOReplaceIssueLabelsResult(List<String> resultLabels) {
-        CompletableFuture<List<String>> resultFuture = new CompletableFuture<>();
-        resultFuture.complete(resultLabels);
+    private void mockRepoIOReplaceIssueLabelsResult(boolean replaceResult) {
         when(mockedRepoIO.replaceIssueLabels(any(TurboIssue.class), anyListOf(String.class)))
-                .thenReturn(resultFuture);
+                .thenReturn(CompletableFuture.completedFuture(replaceResult));
+    }
+
+    private void mockMultiModelReplaceIssueLabels(Optional<TurboIssue> replaceResult,
+                                                  Optional<Model> modelLookUpResult) {
+        when(mockedMultiModel.replaceIssueLabels(anyString(), anyInt(), anyListOf(String.class)))
+                .thenReturn(replaceResult);
+        when(mockedMultiModel.getModelById(anyString())).thenReturn(modelLookUpResult);
     }
 
     public static TurboIssue createIssueWithLabels(List<String> labels) {

--- a/src/test/java/tests/LogicTests.java
+++ b/src/test/java/tests/LogicTests.java
@@ -59,7 +59,7 @@ public class LogicTests {
      * Tests that replaceIssueLabels succeed when both models and repoIO succeeded
      */
     @Test
-    public void testReplaceIssueLabelsSuccessful() throws ExecutionException, InterruptedException {
+    public void replaceIssueLabels_successful() throws ExecutionException, InterruptedException {
         TurboIssue issue = createIssueWithLabels(1, Arrays.asList("label1", "label2"));
         mockRepoIOReplaceIssueLabelsResult(true);
         mockMultiModelReplaceIssueLabels(Optional.of(issue), Optional.empty());
@@ -71,7 +71,7 @@ public class LogicTests {
      * Tests that replaceIssueLabels failed when models return empty result
      */
     @Test
-    public void testReplaceIssueLabelsRepoIOFailed() throws ExecutionException, InterruptedException {
+    public void replaceIssueLabels_repoIOFailed() throws ExecutionException, InterruptedException {
         TurboIssue issue = createIssueWithLabels(1, Arrays.asList("label1", "label2"));
         mockRepoIOReplaceIssueLabelsResult(true);
         mockMultiModelReplaceIssueLabels(Optional.empty(), Optional.empty());
@@ -83,7 +83,7 @@ public class LogicTests {
      * Tests that replaceIssueLabels failed when repoIO failed to update labels
      */
     @Test
-    public void testReplaceIssueLabelsModelsFailed() throws ExecutionException, InterruptedException {
+    public void replaceIssueLabels_modelsFailed() throws ExecutionException, InterruptedException {
         TurboIssue issue = createIssueWithLabels(1, Arrays.asList("label1", "label2"));
         mockRepoIOReplaceIssueLabelsResult(false);
         mockMultiModelReplaceIssueLabels(Optional.of(issue), Optional.empty());
@@ -96,7 +96,7 @@ public class LogicTests {
      * new labels then revert back to original labels when repoIO failed to update labels
      */
     @Test
-    public void testReplaceIssueLabelsRevert() throws ExecutionException, InterruptedException {
+    public void replaceIssueLabels_modelsFailed_revert() throws ExecutionException, InterruptedException {
         List<String> originalLabels = Arrays.asList("label1", "label2");
         List<String> newLabels = Arrays.asList("label3", "label4");
 
@@ -116,13 +116,13 @@ public class LogicTests {
      * {@link Logic#replaceIssueLabels(TurboIssue, List)} is called
      */
     @Test
-    public void testReplaceIssueLabelsNoRevert() throws ExecutionException, InterruptedException {
+    public void replaceIssueLabels_timeNotMatched_noRevert() throws ExecutionException, InterruptedException {
         List<String> originalLabels = Arrays.asList("label1", "label2");
         List<String> newLabels = Arrays.asList("label3", "label4");
 
         TurboIssue issue = createIssueWithLabels(1, originalLabels);
-        Thread.sleep(10);
-        TurboIssue modifiedIssue = createIssueWithLabels(1, originalLabels);
+        TurboIssue modifiedIssue = TestUtils.delayThenGet(
+                10, () -> createIssueWithLabels(1, originalLabels));
 
         Model mockedModel = mock(Model.class);
         when(mockedModel.replaceIssueLabels(issue.getId(), newLabels)).thenReturn(Optional.of(issue));

--- a/src/test/java/tests/ModelTests.java
+++ b/src/test/java/tests/ModelTests.java
@@ -267,4 +267,35 @@ public class ModelTests {
         assertEquals(Optional.<TurboUser>empty(), modelUpdated.getUserByLogin("User 11"));
         assertEquals("User 10", modelUpdated.getUserByLogin("User 10").get().getLoginName());
     }
+
+    /**
+     * Tests that replaceIssueLabels returns Optional.empty() if the model for the
+     * issue given in the argument can't be found
+     */
+    @Test
+    public void testReplaceIssueLabelsIssueNotFound() {
+        Model model = new Model("testrepo");
+        assertEquals(Optional.empty(), model.replaceIssueLabels(1, new ArrayList<>()));
+    }
+
+    /**
+     * Tests that replaceIssueLabels finds issue with the right id and successfully modify the issue's labels
+     */
+    @Test
+    public void testReplaceIssueLabels() {
+        String repoId = "testowner/testrepo";
+        List<String> originalLabels = Arrays.asList("label1", "label2");
+        List<String> newLabels = Arrays.asList("label3", "label4");
+
+        TurboIssue issue1 = LogicTests.createIssueWithLabels(1, originalLabels);
+        TurboIssue issue2 = LogicTests.createIssueWithLabels(2, originalLabels);
+        TurboIssue issue3 = LogicTests.createIssueWithLabels(3, originalLabels);
+        List<TurboIssue> issues = Arrays.asList(issue3, issue2, issue1);
+
+        Model model = new Model(repoId, issues, new ArrayList<TurboLabel>(),
+                                new ArrayList<TurboMilestone>(), new ArrayList<TurboUser>());
+        Optional<TurboIssue> result = model.replaceIssueLabels(issue1.getId(), newLabels);
+        assertEquals(1, result.get().getId());
+        assertEquals(newLabels, result.get().getLabels());
+    }
 }

--- a/src/test/java/tests/ModelTests.java
+++ b/src/test/java/tests/ModelTests.java
@@ -273,7 +273,7 @@ public class ModelTests {
      * issue given in the argument can't be found
      */
     @Test
-    public void testReplaceIssueLabelsIssueNotFound() {
+    public void replaceIssueLabels_issueNotFound() {
         Model model = new Model("testrepo");
         assertEquals(Optional.empty(), model.replaceIssueLabels(1, new ArrayList<>()));
     }
@@ -282,7 +282,7 @@ public class ModelTests {
      * Tests that replaceIssueLabels finds issue with the right id and successfully modify the issue's labels
      */
     @Test
-    public void testReplaceIssueLabels() {
+    public void replaceIssueLabels_successful() {
         String repoId = "testowner/testrepo";
         List<String> originalLabels = Arrays.asList("label1", "label2");
         List<String> newLabels = Arrays.asList("label3", "label4");

--- a/src/test/java/tests/MultiModelTest.java
+++ b/src/test/java/tests/MultiModelTest.java
@@ -2,6 +2,7 @@ package tests;
 
 import backend.RepoIO;
 import backend.json.JSONStoreStub;
+import backend.resource.Model;
 import backend.resource.MultiModel;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,12 +12,16 @@ import ui.UI;
 import ui.components.StatusUIStub;
 import util.events.EventDispatcherStub;
 
-import java.util.Locale;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MultiModelTest {
 
@@ -62,4 +67,35 @@ public class MultiModelTest {
         assertEquals(false, models.getModelById(repoId2).isPresent());
     }
 
+    /**
+     * Tests that replaceIssueLabels returns Optional.empty() if the model for the
+     * issue given in the argument can't be found
+     */
+    @Test
+    public void testReplaceIssueLabelsModelNotFound() {
+        MultiModel models = new MultiModel(mock(Preferences.class));
+        assertEquals(Optional.empty(), models.replaceIssueLabels("nonexistentrepo", 1, new ArrayList<>()));
+    }
+
+    /**
+     * Tests that replaceIssueLabels called the Model with the same id as the argument
+     * repoId and invoke replaceIssueLabels on that Model
+     */
+    @Test
+    public void testReplaceIssueLabels() {
+        String repoId = "testowner/testrepo";
+        int issueId = 1;
+        List<String> labels = Arrays.asList("label1", "label2");
+
+        Model mockedModel = mock(Model.class);
+        when(mockedModel.getRepoId()).thenReturn(repoId);
+        when(mockedModel.getIssues()).thenReturn(new ArrayList<>());
+
+        MultiModel models = new MultiModel(mock(Preferences.class));
+        models.queuePendingRepository(repoId);
+        models.addPending(mockedModel);
+
+        models.replaceIssueLabels(repoId, issueId, labels);
+        verify(mockedModel).replaceIssueLabels(issueId, labels);
+    }
 }

--- a/src/test/java/tests/MultiModelTest.java
+++ b/src/test/java/tests/MultiModelTest.java
@@ -72,7 +72,7 @@ public class MultiModelTest {
      * issue given in the argument can't be found
      */
     @Test
-    public void testReplaceIssueLabelsModelNotFound() {
+    public void replaceIssueLabels_modelNotFound() {
         MultiModel models = new MultiModel(mock(Preferences.class));
         assertEquals(Optional.empty(), models.replaceIssueLabels("nonexistentrepo", 1, new ArrayList<>()));
     }
@@ -82,7 +82,7 @@ public class MultiModelTest {
      * repoId and invoke replaceIssueLabels on that Model
      */
     @Test
-    public void testReplaceIssueLabels() {
+    public void replaceIssueLabels_successful() {
         String repoId = "testowner/testrepo";
         int issueId = 1;
         List<String> labels = Arrays.asList("label1", "label2");

--- a/src/test/java/tests/TestUtils.java
+++ b/src/test/java/tests/TestUtils.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 public final class TestUtils {
 
@@ -128,5 +129,29 @@ public final class TestUtils {
                 .withQueryStringParameter("state", "all")
                 .withQueryStringParameter("per_page", "100")
                 .withQueryStringParameter("page", Integer.toString(page));
+    }
+
+    /**
+     * Delays for a specified time then calls a function and returns its result
+     * @param delay time to be delayed in milliseconds
+     * @param supplier
+     * @return
+     * @throws InterruptedException
+     */
+    public static <T> T delayThenGet(long delay, Supplier<T> supplier) throws InterruptedException {
+        Thread.sleep(delay);
+        return supplier.get();
+    }
+
+    /**
+     * Delays for a specified time then runs a function
+     * @param delay time to be delayed in milliseconds
+     * @param runnable
+     * @return
+     * @throws InterruptedException
+     */
+    public static void delayThenRun(long delay, Runnable runnable) throws InterruptedException {
+        Thread.sleep(delay);
+        runnable.run();
     }
 }

--- a/src/test/java/tests/TurboIssueTests.java
+++ b/src/test/java/tests/TurboIssueTests.java
@@ -118,7 +118,7 @@ public class TurboIssueTests {
      * modified time is equal to the issue's updatedAt time
      */
     @Test
-    public void testGetLabelsModifiedAtInitially() {
+    public void getLabelsModifiedAt_initial() {
         TurboIssue issue = new TurboIssue("testrepo", 1, "Issue title");
         assertEquals(issue.getUpdatedAt(), issue.getLabelsLastModifiedAt());
     }
@@ -127,22 +127,19 @@ public class TurboIssueTests {
      * Tests that labels modified time is updated properly when methods mutating the issue' labels is called
      */
     @Test
-    public void testGetLabelsModifiedAtUpdate() throws InterruptedException {
+    public void getLabelsModifiedAt_updated() throws InterruptedException {
         TurboIssue issue = new TurboIssue("testrepo", 1, "Issue title");
 
         LocalDateTime checkPoint = issue.getLabelsLastModifiedAt();
-        Thread.sleep(10);
-        issue.setLabels(new ArrayList<>());
+        TestUtils.delayThenRun(10, () -> issue.setLabels(new ArrayList<>()));
         assertTrue(issue.getLabelsLastModifiedAt().isAfter(checkPoint));
 
         checkPoint = issue.getLabelsLastModifiedAt();
-        Thread.sleep(10);
-        issue.addLabel("label");
+        TestUtils.delayThenRun(10, () -> issue.addLabel("label"));
         assertTrue(issue.getLabelsLastModifiedAt().isAfter(checkPoint));
 
         checkPoint = issue.getLabelsLastModifiedAt();
-        Thread.sleep(10);
-        issue.addLabel(new TurboLabel("testrepo", "label"));
+        TestUtils.delayThenRun(10, () -> issue.addLabel(new TurboLabel("testrepo", "label")));
         assertTrue(issue.getLabelsLastModifiedAt().isAfter(checkPoint));
     }
 
@@ -151,11 +148,11 @@ public class TurboIssueTests {
      * it overrides the original issue's labels
      */
     @Test
-    public void testReconcileUpdatedLabelsOverride() throws InterruptedException {
+    public void reconcile_moreRecentlyUpdated_Override() throws InterruptedException {
         TurboIssue originalIssue = LogicTests.createIssueWithLabels(1, new ArrayList<>());
-        Thread.sleep(10);
         List<String> newLabels = Arrays.asList("label1", "label2");
-        TurboIssue updatedIssue = LogicTests.createIssueWithLabels(1, newLabels);
+        TurboIssue updatedIssue = TestUtils.delayThenGet(
+                10, () -> LogicTests.createIssueWithLabels(1, newLabels));
 
         List<TurboIssue> updatedList = TurboIssue.reconcile(Arrays.asList(originalIssue),
                                                             Arrays.asList(updatedIssue));
@@ -167,11 +164,11 @@ public class TurboIssueTests {
      * then the updated issue's labels
      */
     @Test
-    public void testReconcileUpdatedLabelsRetained() throws InterruptedException {
+    public void reconcile_stale_retained() throws InterruptedException {
         TurboIssue updatedIssue = LogicTests.createIssueWithLabels(1, new ArrayList<>());
-        Thread.sleep(10);
         List<String> originalLabels = Arrays.asList("label1", "label2");
-        TurboIssue originalIssue = LogicTests.createIssueWithLabels(1, originalLabels);
+        TurboIssue originalIssue = TestUtils.delayThenGet(
+                10, () -> LogicTests.createIssueWithLabels(1, originalLabels));
 
         List<TurboIssue> updatedList = TurboIssue.reconcile(Arrays.asList(originalIssue),
                                                             Arrays.asList(updatedIssue));


### PR DESCRIPTION
Fixes #1246.

* Mitigate some concurrency issues by synchronising various methods in `Model`, `MultiModel` and `TurboIssue` and using issue lookup in models.
>The root cause for this is that `MultiModel` is not properly synchronised i.e. although its methods are synchronised, its internal states can be retrieved and read/modified somewhere else, technically changing the `MultiModel`'s state without synchronisation. An example is that we can assign labels to a dangling `TurboIssue` out of nowhere and the models' state and `Ui` is changed. The `queue` helps to solve this by making the end-to-end operation on `MultiModel` mutually execlusive. However the operation includes incremental steps of downloading and local models update, which cause other operations to be laggy. So a solution that doesn't trades off speed or correctness involves seperating the end-to-end download and end-to-end local updates, which would requires major changes and planning.

* Reconciling labels updates from GitHub and local changes using physical time timestamp. This requires all mutating actions on labels to update the timestamp. Making the labels getter return a new list leads to regression so this is probably violated somewhere by codes that get the labels list and modify it directly.

* Display error message and reverting to previous labels if failed to update on GitHub. This is also achieved through the labels modification timestamps. I was intending to have a `Retry` dialog box but that needs changes up at the `UI` level which probably conflicts with the current labels picker refactoring.