### PR TITLE
Nondeterministic tests #952

### DIFF
--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -52,10 +52,10 @@
 
     <Match>
         <Or>
-            <Class name="unstable.SavedLoginTest"/>
+            <Class name="guitests.SavedLoginTest"/>
             <Class name="guitests.WrongLastViewedTest"/>
         </Or>
-        <Method name="setupMethod" />
+        <Method name="beforeStageStarts" />
         <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
     </Match>
 

--- a/src/main/java/prefs/GlobalConfig.java
+++ b/src/main/java/prefs/GlobalConfig.java
@@ -94,6 +94,11 @@ public class GlobalConfig {
         lastOpenBoard = Optional.empty();
     }
 
+    public void clearAllBoards() {
+        clearLastOpenBoard();
+        savedBoards.clear();
+    }
+
     public List<String> getLastOpenFilters() {
         return lastSessionPanels.stream().map(PanelInfo::getPanelFilter).collect(Collectors.toList());
     }

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -147,6 +147,10 @@ public class Preferences { // NOPMD
         return global.getBoardPanels(board);
     }
 
+    public void clearAllBoards() {
+        global.clearAllBoards();
+    }
+
     /**
      * Session configuration
      */

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -57,6 +57,8 @@ public class UI extends Application implements EventDispatcher {
     public static final int VERSION_MINOR = 19;
     public static final int VERSION_PATCH = 0;
 
+    public static final String WINDOW_TITLE = "HubTurbo %s (%s)";
+
     public static final String ARG_UPDATED_TO = "--updated-to";
 
     private static final double WINDOW_DEFAULT_PROPORTION = 0.6;
@@ -584,8 +586,8 @@ public class UI extends Application implements EventDispatcher {
 
     public void updateTitle() {
         String openBoard = prefs.getLastOpenBoard().orElse("none");
-        String title = String.format("HubTurbo " + Utility.version(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
-                + " (%s)", openBoard);
+        String version = Utility.version(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+        String title = String.format(WINDOW_TITLE, version, openBoard);
         mainStage.setTitle(title);
     }
 

--- a/src/test/java/guitests/PanelFocusTest.java
+++ b/src/test/java/guitests/PanelFocusTest.java
@@ -17,6 +17,7 @@ import prefs.ConfigFileHandler;
 import prefs.GlobalConfig;
 import prefs.PanelInfo;
 import prefs.Preferences;
+import ui.TestController;
 import ui.issuepanel.PanelControl;
 
 public class PanelFocusTest extends UITest {
@@ -28,28 +29,21 @@ public class PanelFocusTest extends UITest {
 
     @Override
     public void beforeStageStarts() {
-        ConfigFileHandler configFileHandler =
-            new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
-        GlobalConfig globalConfig = new GlobalConfig();
-
-        PanelInfo test1 = new PanelInfo();
-        PanelInfo test2 = new PanelInfo();
-        PanelInfo test3 = new PanelInfo();
-        List<PanelInfo> panels = new ArrayList<>();
-        panels.add(test1);
-        panels.add(test2);
-        panels.add(test3);
-
-        globalConfig.setPanelInfo(panels);
-        configFileHandler.saveGlobalConfig(globalConfig);
+        createDefaultPanels();
     }
 
-    // All tests kept in one method to control execution flow
     @Test
     public void panelFocusOnActionsTest() throws IllegalAccessException {
 
-        PanelControl panelControl = (PanelControl) find("#dummy/dummy_col0").getParent();
+        PanelControl panelControl = TestController.getUI().getPanelControl();
 
+        panelFocus_focusedPanel_focusCorrectOnStartup(panelControl);
+        panelFocus_focusedPanel_focusCorrectOnCreatingPanels(panelControl);
+        panelFocus_firstPanel_firstPanelShown(panelControl);
+
+    }
+
+    private void panelFocus_focusedPanel_focusCorrectOnStartup(PanelControl panelControl) {
         /**
          * Testing Panel Focus on Startup
          * ==============================
@@ -83,8 +77,9 @@ public class PanelFocusTest extends UITest {
         pushKeys(KeyCode.F);
         awaitCondition(() ->
             2 == panelControl.getCurrentlySelectedPanel().get());
+    }
 
-
+    private void panelFocus_focusedPanel_focusCorrectOnCreatingPanels(PanelControl panelControl) {
         /**
          * Testing Panel Focus on Creating Panels
          * ======================================
@@ -106,7 +101,10 @@ public class PanelFocusTest extends UITest {
         awaitCondition(() -> 0 == panelControl.getCurrentlySelectedPanel().get());
         type("  ");
         awaitCondition(() -> 0 == panelControl.getCurrentlySelectedPanel().get());
+    }
 
+    private void panelFocus_firstPanel_firstPanelShown(PanelControl panelControl)
+        throws IllegalAccessException {
         /**
          * Testing First Panel is shown (i.e. scrollbar is set to left end)
          * and on focus upon Opening Board
@@ -134,5 +132,22 @@ public class PanelFocusTest extends UITest {
         ScrollPane panelsScrollPaneReflection =
             (ScrollPane) FieldUtils.readField(panelControl, "panelsScrollPane", true);
         assertEquals(0, panelsScrollPaneReflection.getHvalue(), 0.001);
+    }
+
+    private void createDefaultPanels() {
+        ConfigFileHandler configFileHandler =
+            new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
+        GlobalConfig globalConfig = new GlobalConfig();
+
+        PanelInfo test1 = new PanelInfo();
+        PanelInfo test2 = new PanelInfo();
+        PanelInfo test3 = new PanelInfo();
+        List<PanelInfo> panels = new ArrayList<>();
+        panels.add(test1);
+        panels.add(test2);
+        panels.add(test3);
+
+        globalConfig.setPanelInfo(panels);
+        configFileHandler.saveGlobalConfig(globalConfig);
     }
 }

--- a/src/test/java/guitests/RemovableRepoListAndModelsTest.java
+++ b/src/test/java/guitests/RemovableRepoListAndModelsTest.java
@@ -28,7 +28,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
     }
 
     @Override
-    public void setupMethod() {
+    public void beforeStageStarts() {
         // setup test json with last viewed repo "dummy/dummy"
         // obviously the json for that repo doesn't exist
         ConfigFileHandler configFileHandler =

--- a/src/test/java/guitests/RepositorySelectorTest.java
+++ b/src/test/java/guitests/RepositorySelectorTest.java
@@ -1,14 +1,18 @@
-package unstable;
+package guitests;
 
-import guitests.UITest;
-import javafx.scene.control.ComboBox;
-import javafx.scene.input.KeyCode;
-import javafx.stage.Stage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.loadui.testfx.Assertions.assertNodeExists;
+
+import java.io.File;
 
 import org.eclipse.egit.github.core.RepositoryId;
 import org.junit.Test;
 import org.loadui.testfx.utils.FXTestUtils;
 
+import javafx.scene.control.ComboBox;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Stage;
 import prefs.ConfigFileHandler;
 import prefs.GlobalConfig;
 import prefs.Preferences;
@@ -16,12 +20,6 @@ import ui.TestController;
 import ui.UI;
 import util.PlatformEx;
 import util.events.testevents.PrimaryRepoChangedEventHandler;
-
-import java.io.File;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.loadui.testfx.Assertions.assertNodeExists;
 
 public class RepositorySelectorTest extends UITest {
 
@@ -50,11 +48,11 @@ public class RepositorySelectorTest extends UITest {
     }
 
     @Override
-    public void setupMethod() {
+    public void beforeStageStarts() {
         // setup test json with last viewed repo "dummy/dummy"
         // obviously the json for that repo doesn't exist
         ConfigFileHandler configFileHandler =
-                new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
+            new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
         GlobalConfig globalConfig = new GlobalConfig();
         globalConfig.setLastLoginCredentials("test", "test");
         globalConfig.setLastViewedRepository("dummy/dummy");
@@ -65,14 +63,16 @@ public class RepositorySelectorTest extends UITest {
     public void repositorySelectorTest() {
         // check if test json is present
         File testConfig = new File(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
-        if (!(testConfig.exists() && testConfig.isFile())) {
+        boolean testConfigExists = testConfig.exists() && testConfig.isFile();
+        if (!testConfigExists) {
             fail();
         }
 
         // now we check if the login dialog pops up because the "dummy/dummy" json
         // doesn't exist and there are no other valid repo json files
         assertNodeExists("#repoOwnerField");
-        type("dummy").push(KeyCode.TAB).type("dummy").push(KeyCode.ENTER);
+        type("dummy").push(KeyCode.TAB);
+        type("dummy").push(KeyCode.ENTER);
         ComboBox<String> comboBox = find("#repositorySelector");
         assertEquals(1, comboBox.getItems().size());
         assertEquals("dummy/dummy", primaryRepo);
@@ -148,5 +148,4 @@ public class RepositorySelectorTest extends UITest {
         RepositoryId lastViewedRepository = testPref.getLastViewedRepository().get();
         assertEquals("dummy4/dummy4", lastViewedRepository.generateId());
     }
-
 }

--- a/src/test/java/guitests/SavedLoginTest.java
+++ b/src/test/java/guitests/SavedLoginTest.java
@@ -1,21 +1,23 @@
-package unstable;
+package guitests;
 
-import backend.RepoIO;
-import guitests.UITest;
-import javafx.scene.control.ComboBox;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
 import org.junit.Test;
 import org.loadui.testfx.utils.FXTestUtils;
+
+import backend.RepoIO;
+import javafx.scene.control.ComboBox;
 import prefs.ConfigFileHandler;
 import prefs.GlobalConfig;
 import prefs.Preferences;
 import ui.TestController;
 import ui.UI;
-import ui.components.StatusUIStub;
-
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-
-import static org.junit.Assert.assertEquals;
+import ui.components.StatusUI;
+import util.events.EventDispatcher;
 
 public class SavedLoginTest extends UITest {
 
@@ -25,12 +27,13 @@ public class SavedLoginTest extends UITest {
     }
 
     @Override
-    public void setupMethod() {
-        UI.status = new StatusUIStub(); // to avoid NPE
+    public void beforeStageStarts() {
+        UI.status = mock(StatusUI.class);
+        UI.events = mock(EventDispatcher.class);
         // setup test json with last viewed repo "test/test"
         // and then create the corresponding repo json file
         ConfigFileHandler configFileHandler =
-                new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
+            new ConfigFileHandler(Preferences.DIRECTORY, Preferences.TEST_CONFIG_FILE);
         GlobalConfig globalConfig = new GlobalConfig();
         globalConfig.setLastLoginCredentials("test", "test");
         globalConfig.setLastViewedRepository("test/test");

--- a/src/test/java/guitests/SavedLoginTest.java
+++ b/src/test/java/guitests/SavedLoginTest.java
@@ -47,7 +47,8 @@ public class SavedLoginTest extends UITest {
     }
 
     @Test
-    public void savedLoginTest() throws InterruptedException {
+    public void savedLogin_lastSavedLoginCredentials_shouldAllowLoginWithoutPrompting()
+        throws InterruptedException {
         ComboBox<String> repositorySelector = find("#repositorySelector");
         assertEquals("test/test", repositorySelector.getValue());
     }

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -1,32 +1,8 @@
 package guitests;
 
-import backend.interfaces.RepoStore;
-import com.google.common.util.concurrent.SettableFuture;
-import javafx.geometry.Point2D;
-import javafx.scene.Node;
-import javafx.scene.Parent;
-import javafx.scene.control.ComboBoxBase;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyCombination;
-import javafx.scene.input.MouseButton;
-import javafx.stage.Stage;
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.loadui.testfx.FXScreenController;
-import org.loadui.testfx.GuiTest;
-import org.loadui.testfx.exceptions.NoNodesFoundException;
-import org.loadui.testfx.exceptions.NoNodesVisibleException;
-import org.loadui.testfx.utils.FXTestUtils;
-import prefs.Preferences;
-import ui.UI;
-import util.PlatformEx;
-import util.PlatformSpecific;
+import static com.google.common.io.Files.getFileExtension;
 
-import java.awt.*;
+import java.awt.Robot;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,7 +14,33 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
-import static com.google.common.io.Files.getFileExtension;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.loadui.testfx.FXScreenController;
+import org.loadui.testfx.GuiTest;
+import org.loadui.testfx.exceptions.NoNodesFoundException;
+import org.loadui.testfx.exceptions.NoNodesVisibleException;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import backend.interfaces.RepoStore;
+import javafx.geometry.Point2D;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.ComboBoxBase;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Stage;
+import prefs.Preferences;
+import ui.UI;
+import util.PlatformEx;
+import util.PlatformSpecific;
 
 public class UITest extends GuiTest {
 
@@ -92,7 +94,7 @@ public class UITest extends GuiTest {
         return Collections.unmodifiableMap(specialChars);
     }
 
-    public void setupMethod() {
+    public void beforeStageStarts() {
         // method to be overridden if anything needs to be done (e.g. to the json) before the stage starts
     }
 
@@ -121,7 +123,7 @@ public class UITest extends GuiTest {
             assert testConfig.delete();
         }
         clearTestFolder();
-        setupMethod();
+        beforeStageStarts();
 
         if (stage == null) {
             launchApp();

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -249,38 +249,25 @@ public class UITest extends GuiTest {
     }
 
     public void waitUntilNodeAppears(String selector) {
-        while (!existsQuiet(selector)) {
-            PlatformEx.waitOnFxThread();
-            sleep(100);
-        }
+        awaitCondition(() -> existsQuiet(selector));
     }
 
     public void waitUntilNodeDisappears(String selector) {
-        while (existsQuiet(selector)) {
-            PlatformEx.waitOnFxThread();
-            sleep(100);
-        }
+        awaitCondition(() -> !existsQuiet(selector));
     }
 
     public void waitUntilNodeAppears(Matcher<Object> matcher) {
-        while (!findQuiet(matcher).isPresent()) { // no `exists` for matcher, so using find
-            PlatformEx.waitOnFxThread();
-            sleep(100);
-        }
+        // We use find because there's no `exists` for matchers
+        awaitCondition(() -> findQuiet(matcher).isPresent());
     }
 
     public void waitUntilNodeDisappears(Matcher<Object> matcher) {
-        while (findQuiet(matcher).isPresent()) { // no `exists` for matcher, so using find
-            PlatformEx.waitOnFxThread();
-            sleep(100);
-        }
+        // We use find because there's no `exists` for matchers
+        awaitCondition(() -> !findQuiet(matcher).isPresent());
     }
 
     public <T extends Node> void waitUntil(String selector, Predicate<T> condition) {
-        while (!condition.test(find(selector))) {
-            PlatformEx.waitOnFxThread();
-            sleep(100);
-        }
+        awaitCondition(() -> condition.test(find(selector)));
     }
 
     public <T extends Node> T findOrWaitFor(String selector) {

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.logging.log4j.LogManager;
@@ -387,6 +388,13 @@ public class UITest extends GuiTest {
     }
 
     /**
+     * Waits for the result of a function, then asserts that it is equal to some value.
+     */
+    public <T> void waitAndAssertEquals(T expected, Supplier<T> actual) {
+        awaitCondition(() -> expected.equals(actual.get()));
+    }
+
+    /**
      * Automate menu traversal by clicking them in order of input parameter
      *
      * @param menuNames array of strings of menu item names in sequence of traversal
@@ -400,7 +408,7 @@ public class UITest extends GuiTest {
     public <T> void waitForValue(ComboBoxBase<T> comboBoxBase) {
         waitUntil(comboBoxBase, c -> c.getValue() != null);
     }
-    
+
     @Override
     public GuiTest type(String text) {
         for (int i = 0; i < text.length(); i++) {

--- a/src/test/java/guitests/ValidLoginTest.java
+++ b/src/test/java/guitests/ValidLoginTest.java
@@ -1,13 +1,11 @@
-package unstable;
+package guitests;
 
-import guitests.UITest;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
 import org.junit.Test;
 import org.loadui.testfx.utils.FXTestUtils;
 
-import static org.junit.Assert.assertEquals;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 
 public class ValidLoginTest extends UITest {
 
@@ -19,14 +17,14 @@ public class ValidLoginTest extends UITest {
     @Test
     public void validLoginTest() throws InterruptedException {
         TextField repoOwnerField = find("#repoOwnerField");
-        doubleClick(repoOwnerField);
-        doubleClick(repoOwnerField);
+        click(repoOwnerField);
+        selectAll();
         type("test").push(KeyCode.TAB);
         type("test").push(KeyCode.TAB);
         type("test").push(KeyCode.TAB);
         type("test");
         click("Sign in");
         ComboBox<String> repositorySelector = findOrWaitFor("#repositorySelector");
-        assertEquals("test/test", repositorySelector.getValue());
+        awaitCondition(() -> "test/test".equals(repositorySelector.getValue()));
     }
 }

--- a/src/test/java/guitests/WrongLastViewedTest.java
+++ b/src/test/java/guitests/WrongLastViewedTest.java
@@ -25,7 +25,7 @@ public class WrongLastViewedTest extends UITest {
     }
 
     @Override
-    public void setupMethod() {
+    public void beforeStageStarts() {
         UI.status = new StatusUIStub();
         UI.events = new EventDispatcherStub();
 

--- a/src/test/java/unstable/BoardTests.java
+++ b/src/test/java/unstable/BoardTests.java
@@ -38,7 +38,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void creatingAndClosingPanels() {
+    public void boards_panelCount_creatingAndClosingPanels() {
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();
 
@@ -60,7 +60,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void saveWhenNoBoardOpen() {
+    public void boards_saveDialog_willSaveWhenNoBoardOpen() {
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();
 
@@ -75,7 +75,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void boardNotSavedOnCancellation() {
+    public void boards_saveDialog_willNotSaveOnCancellation() {
         PanelControl panelControl = TestController.getUI().getPanelControl();
 
         traverseMenu("Boards", "Save");
@@ -87,14 +87,14 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void switchWhenNoBoardOpen() {
+    public void boards_lastOpenedBoard_switchingWhenNoBoardIsOpen() {
         // Switching when no board is open should do nothing
         pushKeys(SWITCH_BOARD);
         assertFalse(UI.prefs.getLastOpenBoard().isPresent());
     }
 
     @Test
-    public void boardSaveAs() {
+    public void boards_panelCount_boardsSaveSuccessfully() {
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();
 
@@ -113,7 +113,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void switchingBoardWithOnlyOneSaved() {
+    public void baords_lastOpenedBoard_cannotSwitchBoardWithOnlyOneSaved() {
 
         Preferences prefs = UI.prefs;
 
@@ -126,7 +126,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void switchingBoardWithManySaved() {
+    public void boards_lastOpenedBoard_canSwitchBoardWithOnlyOneSaved() {
 
         Preferences prefs = UI.prefs;
 
@@ -148,7 +148,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void boardNameValidation() {
+    public void boards_validation_displaysFeedbackOnFailingValidation() {
         tryBoardName("");
         tryBoardName("   ");
         tryBoardName("   none  ");
@@ -164,7 +164,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void openingBoard() {
+    public void boards_panelCount_boardsCanBeOpenedSuccessfully() {
 
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();
@@ -186,7 +186,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void savingBoard() {
+    public void boards_panelCount_boardsCanBeSavedSuccessfully() {
 
         PanelControl panelControl = TestController.getUI().getPanelControl();
 
@@ -207,7 +207,7 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void deleteBoard() {
+    public void boards_panelCount_boardsCanBeDeletedSuccessfully() {
 
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();
@@ -225,9 +225,9 @@ public class BoardTests extends UITest {
     }
 
     @Test
-    public void noBoardsOpen() {
+    public void boards_panelCount_nothingHappensWhenNoBoardIsOpen() {
 
-        deleteBoard();
+        boards_panelCount_boardsCanBeDeletedSuccessfully();
 
         UI ui = TestController.getUI();
         PanelControl panelControl = ui.getPanelControl();

--- a/src/test/java/unstable/BoardTests.java
+++ b/src/test/java/unstable/BoardTests.java
@@ -3,6 +3,7 @@ package unstable;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.loadui.testfx.controls.Commons.hasText;
 import static ui.components.KeyboardShortcuts.*;
 
 import org.junit.Before;
@@ -48,13 +49,13 @@ public class BoardTests extends UITest {
         press(CREATE_LEFT_PANEL);
         waitAndAssertEquals(2, panelControl::getPanelCount);
 
-        clickMenu("Panels", "Create");
+        traverseMenu("Panels", "Create");
         waitAndAssertEquals(3, panelControl::getPanelCount);
-        clickMenu("Panels", "Create (Left)");
+        traverseMenu("Panels", "Create (Left)");
         waitAndAssertEquals(4, panelControl::getPanelCount);
-        clickMenu("Panels", "Close");
+        traverseMenu("Panels", "Close");
         waitAndAssertEquals(3, panelControl::getPanelCount);
-        clickMenu("Panels", "Close");
+        traverseMenu("Panels", "Close");
         waitAndAssertEquals(2, panelControl::getPanelCount);
     }
 
@@ -68,7 +69,7 @@ public class BoardTests extends UITest {
         assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("none"));
 
         // Saving when no board is open should prompt the user to save a new board
-        clickMenu("Boards", "Save");
+        traverseMenu("Boards", "Save");
         type("Board 1");
         push(KeyCode.ESCAPE);
     }
@@ -77,7 +78,7 @@ public class BoardTests extends UITest {
     public void boardNotSavedOnCancellation() {
         PanelControl panelControl = TestController.getUI().getPanelControl();
 
-        clickMenu("Boards", "Save");
+        traverseMenu("Boards", "Save");
         type("Board 1");
         push(KeyCode.ESCAPE);
 
@@ -105,7 +106,7 @@ public class BoardTests extends UITest {
     }
 
     private void saveBoardWithName(String name) {
-        clickMenu("Boards", "Save as");
+        traverseMenu("Boards", "Save as");
         waitUntilNodeAppears("#boardnameinput");
         ((TextField) find("#boardnameinput")).setText(name);
         click("OK");
@@ -154,19 +155,12 @@ public class BoardTests extends UITest {
     }
 
     private void tryBoardName(String name) {
-        clickMenu("Boards", "Save as");
+        traverseMenu("Boards", "Save as");
         waitUntilNodeAppears("#boardnameinput");
         ((TextField) find("#boardnameinput")).setText(name);
         assertTrue(find("#boardsavebutton").isDisabled());
         pushKeys(KeyCode.ESCAPE);
         waitUntilNodeDisappears("#boardnameinput");
-    }
-
-    private void selectNthMenuItem(int n) {
-        for (int i = 0; i < n; i++) {
-            push(KeyCode.DOWN);
-        }
-        push(KeyCode.ENTER);
     }
 
     @Test
@@ -181,19 +175,13 @@ public class BoardTests extends UITest {
         saveBoardWithName("Board 2");
 
         // We're at Board 2 now
-        assertEquals(2, panelControl.getPanelCount());
+        waitAndAssertEquals(2, panelControl::getPanelCount);
         assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 2"));
 
-        // This navigates to the second item on the submenu under 'Open',
-        // 'Board 1'. We do this because trying to click it will move the
-        // mouse over 'Delete' and click the wrong node.
-        // There isn't a good solution to this without more specialised
-        // ways to move the mouse.
-        clickMenu("Boards", "Open");
-        selectNthMenuItem(2);
+        traverseMenu("Boards", "Open", "Board 1");
 
         // We've switched to Board 1
-        assertEquals(1, panelControl.getPanelCount());
+        waitAndAssertEquals(1, panelControl::getPanelCount);
         assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 1"));
     }
 
@@ -204,16 +192,15 @@ public class BoardTests extends UITest {
 
         saveBoardWithName("Board 1");
         pushKeys(CREATE_RIGHT_PANEL);
+        awaitCondition(() -> 2 == panelControl.getPanelCount());
 
-        clickMenu("Boards", "Open");
-        selectNthMenuItem(1);
+        traverseMenu("Boards", "Open", "Board 1");
 
         // Without having saved, we lose the extra panel
         waitAndAssertEquals(1, panelControl::getPanelCount);
 
         pushKeys(CREATE_RIGHT_PANEL);
-        clickMenu("Boards", "Save");
-        selectNthMenuItem(1);
+        traverseMenu("Boards", "Save");
 
         // After saving, the panel is there
         waitAndAssertEquals(2, panelControl::getPanelCount);
@@ -227,8 +214,8 @@ public class BoardTests extends UITest {
 
         saveBoardWithName("Board 1");
 
-        clickMenu("Boards", "Delete");
-        selectNthMenuItem(1);
+        traverseMenu("Boards", "Delete", "Board 1");
+        waitUntilNodeAppears(hasText("OK"));
         click("OK");
 
         // No board is open now
@@ -251,7 +238,8 @@ public class BoardTests extends UITest {
         assertFalse(UI.prefs.getLastOpenBoard().isPresent());
 
         // Saving will prompt the user to save as a new board
-        clickMenu("Boards", "Save");
+        traverseMenu("Boards", "Save");
+        waitUntilNodeAppears("#boardnameinput");
         ((TextField) find("#boardnameinput")).setText("Board 1");
         click("OK");
 

--- a/src/test/java/unstable/BoardTests.java
+++ b/src/test/java/unstable/BoardTests.java
@@ -1,0 +1,266 @@
+package unstable;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static ui.components.KeyboardShortcuts.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import guitests.UITest;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import prefs.Preferences;
+import ui.TestController;
+import ui.UI;
+import ui.issuepanel.PanelControl;
+import util.PlatformEx;
+import util.Utility;
+
+public class BoardTests extends UITest {
+
+    /**
+     * The initial state is one panel with no filter, and no saved boards
+     */
+    private static void reset() {
+        UI ui = TestController.getUI();
+        ui.getPanelControl().closeAllPanels();
+        ui.getPanelControl().createNewPanelAtStart();
+        UI.prefs.clearAllBoards();
+        ui.updateTitle();
+    }
+
+    @Before
+    public void before() {
+        PlatformEx.runAndWait(BoardTests::reset);
+    }
+
+    @Test
+    public void creatingAndClosingPanels() {
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        press(CLOSE_PANEL);
+        waitAndAssertEquals(0, panelControl::getPanelCount);
+        press(CREATE_RIGHT_PANEL);
+        waitAndAssertEquals(1, panelControl::getPanelCount);
+        press(CREATE_LEFT_PANEL);
+        waitAndAssertEquals(2, panelControl::getPanelCount);
+
+        clickMenu("Panels", "Create");
+        waitAndAssertEquals(3, panelControl::getPanelCount);
+        clickMenu("Panels", "Create (Left)");
+        waitAndAssertEquals(4, panelControl::getPanelCount);
+        clickMenu("Panels", "Close");
+        waitAndAssertEquals(3, panelControl::getPanelCount);
+        clickMenu("Panels", "Close");
+        waitAndAssertEquals(2, panelControl::getPanelCount);
+    }
+
+    @Test
+    public void saveWhenNoBoardOpen() {
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        // No board is open
+        assertEquals(0, panelControl.getNumberOfSavedBoards());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("none"));
+
+        // Saving when no board is open should prompt the user to save a new board
+        clickMenu("Boards", "Save");
+        type("Board 1");
+        push(KeyCode.ESCAPE);
+    }
+
+    @Test
+    public void boardNotSavedOnCancellation() {
+        PanelControl panelControl = TestController.getUI().getPanelControl();
+
+        clickMenu("Boards", "Save");
+        type("Board 1");
+        push(KeyCode.ESCAPE);
+
+        // No board is saved on cancellation
+        waitAndAssertEquals(0, panelControl::getNumberOfSavedBoards);
+    }
+
+    @Test
+    public void switchWhenNoBoardOpen() {
+        // Switching when no board is open should do nothing
+        pushKeys(SWITCH_BOARD);
+        assertFalse(UI.prefs.getLastOpenBoard().isPresent());
+    }
+
+    @Test
+    public void boardSaveAs() {
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        saveBoardWithName("Board 1");
+
+        waitAndAssertEquals(1, panelControl::getNumberOfSavedBoards);
+        assertEquals(1, panelControl.getPanelCount());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 1"));
+    }
+
+    private void saveBoardWithName(String name) {
+        clickMenu("Boards", "Save as");
+        waitUntilNodeAppears("#boardnameinput");
+        ((TextField) find("#boardnameinput")).setText(name);
+        click("OK");
+    }
+
+    @Test
+    public void switchingBoardWithOnlyOneSaved() {
+
+        Preferences prefs = UI.prefs;
+
+        saveBoardWithName("Board 1");
+
+        // Nothing happens
+        press(SWITCH_BOARD);
+        assertTrue(prefs.getLastOpenBoard().isPresent());
+        assertEquals("Board 1", prefs.getLastOpenBoard().get());
+    }
+
+    @Test
+    public void switchingBoardWithManySaved() {
+
+        Preferences prefs = UI.prefs;
+
+        saveBoardWithName("Board 1");
+        saveBoardWithName("Board 2");
+
+        assertTrue(prefs.getLastOpenBoard().isPresent());
+        assertEquals("Board 2", prefs.getLastOpenBoard().get());
+
+        // Wraps around to the first board
+        press(SWITCH_BOARD);
+        assertTrue(prefs.getLastOpenBoard().isPresent());
+        assertEquals("Board 1", prefs.getLastOpenBoard().get());
+
+        // Back to the second board
+        press(SWITCH_BOARD);
+        assertTrue(prefs.getLastOpenBoard().isPresent());
+        assertEquals("Board 2", prefs.getLastOpenBoard().get());
+    }
+
+    @Test
+    public void boardNameValidation() {
+        tryBoardName("");
+        tryBoardName("   ");
+        tryBoardName("   none  ");
+    }
+
+    private void tryBoardName(String name) {
+        clickMenu("Boards", "Save as");
+        waitUntilNodeAppears("#boardnameinput");
+        ((TextField) find("#boardnameinput")).setText(name);
+        assertTrue(find("#boardsavebutton").isDisabled());
+        pushKeys(KeyCode.ESCAPE);
+        waitUntilNodeDisappears("#boardnameinput");
+    }
+
+    private void selectNthMenuItem(int n) {
+        for (int i = 0; i < n; i++) {
+            push(KeyCode.DOWN);
+        }
+        push(KeyCode.ENTER);
+    }
+
+    @Test
+    public void openingBoard() {
+
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        // Board 1 has 1 panel, Board 2 has 2
+        saveBoardWithName("Board 1");
+        pushKeys(CREATE_RIGHT_PANEL);
+        saveBoardWithName("Board 2");
+
+        // We're at Board 2 now
+        assertEquals(2, panelControl.getPanelCount());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 2"));
+
+        // This navigates to the second item on the submenu under 'Open',
+        // 'Board 1'. We do this because trying to click it will move the
+        // mouse over 'Delete' and click the wrong node.
+        // There isn't a good solution to this without more specialised
+        // ways to move the mouse.
+        clickMenu("Boards", "Open");
+        selectNthMenuItem(2);
+
+        // We've switched to Board 1
+        assertEquals(1, panelControl.getPanelCount());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 1"));
+    }
+
+    @Test
+    public void savingBoard() {
+
+        PanelControl panelControl = TestController.getUI().getPanelControl();
+
+        saveBoardWithName("Board 1");
+        pushKeys(CREATE_RIGHT_PANEL);
+
+        clickMenu("Boards", "Open");
+        selectNthMenuItem(1);
+
+        // Without having saved, we lose the extra panel
+        waitAndAssertEquals(1, panelControl::getPanelCount);
+
+        pushKeys(CREATE_RIGHT_PANEL);
+        clickMenu("Boards", "Save");
+        selectNthMenuItem(1);
+
+        // After saving, the panel is there
+        waitAndAssertEquals(2, panelControl::getPanelCount);
+    }
+
+    @Test
+    public void deleteBoard() {
+
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        saveBoardWithName("Board 1");
+
+        clickMenu("Boards", "Delete");
+        selectNthMenuItem(1);
+        click("OK");
+
+        // No board is open now
+        assertEquals(0, panelControl.getNumberOfSavedBoards());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("none"));
+
+    }
+
+    @Test
+    public void noBoardsOpen() {
+
+        deleteBoard();
+
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        // Switching board has no effect
+        assertFalse(UI.prefs.getLastOpenBoard().isPresent());
+        pushKeys(SWITCH_BOARD);
+        assertFalse(UI.prefs.getLastOpenBoard().isPresent());
+
+        // Saving will prompt the user to save as a new board
+        clickMenu("Boards", "Save");
+        ((TextField) find("#boardnameinput")).setText("Board 1");
+        click("OK");
+
+        assertEquals(1, panelControl.getNumberOfSavedBoards());
+        assertEquals(ui.getTitle(), getUiTitleWithOpenBoard("Board 1"));
+    }
+
+    private static String getUiTitleWithOpenBoard(String boardName) {
+        String version = Utility.version(UI.VERSION_MAJOR, UI.VERSION_MINOR, UI.VERSION_PATCH);
+        return String.format(UI.WINDOW_TITLE, version, boardName);
+    }
+}

--- a/src/test/java/unstable/BoardTests.java
+++ b/src/test/java/unstable/BoardTests.java
@@ -251,4 +251,37 @@ public class BoardTests extends UITest {
         String version = Utility.version(UI.VERSION_MAJOR, UI.VERSION_MINOR, UI.VERSION_PATCH);
         return String.format(UI.WINDOW_TITLE, version, boardName);
     }
+
+    @Test
+    public void boards_panelCount_nothingHappensWhenNewBoardIsCancelled() {
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        assertEquals(0, panelControl.getNumberOfSavedBoards());
+        assertEquals(1, panelControl.getPanelCount());
+
+        traverseMenu("Boards", "New");
+        press(KeyCode.ESCAPE);
+        assertEquals(0, panelControl.getNumberOfSavedBoards());
+        assertEquals(1, panelControl.getPanelCount());
+    }
+
+    @Test
+    public void boards_panelCount_newBoardCreated() {
+
+        UI ui = TestController.getUI();
+        PanelControl panelControl = ui.getPanelControl();
+
+        traverseMenu("Boards", "New");
+        waitUntilNodeAppears(hasText("OK"));
+        click("OK");
+
+        waitUntilNodeAppears("#boardnameinput");
+        ((TextField) find("#boardnameinput")).setText("empty");
+        waitUntilNodeAppears(hasText("OK"));
+        click("OK");
+
+        waitAndAssertEquals(0, panelControl::getPanelCount);
+        waitAndAssertEquals(ui.getTitle(), () -> getUiTitleWithOpenBoard("empty"));
+    }
 }

--- a/src/test/java/unstable/KeyboardShortcutsConfigTest.java
+++ b/src/test/java/unstable/KeyboardShortcutsConfigTest.java
@@ -68,7 +68,7 @@ public class KeyboardShortcutsConfigTest extends UITest {
         click("Use default key");
         reloadPrefs(testPref);
         assertEquals(KeyboardShortcuts.getDefaultKeyboardShortcuts().get("MARK_AS_READ"),
-                testPref.getKeyboardShortcuts().get("MARK_AS_READ"));
+            testPref.getKeyboardShortcuts().get("MARK_AS_READ"));
     }
 
     @Test
@@ -84,7 +84,7 @@ public class KeyboardShortcutsConfigTest extends UITest {
         click("Use default key");
         reloadPrefs(testPref);
         assertEquals(KeyboardShortcuts.getDefaultKeyboardShortcuts().get("MARK_AS_READ"),
-                testPref.getKeyboardShortcuts().get("MARK_AS_READ"));
+            testPref.getKeyboardShortcuts().get("MARK_AS_READ"));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class KeyboardShortcutsConfigTest extends UITest {
         click("Use default key");
         reloadPrefs(testPref);
         assertEquals(KeyboardShortcuts.getDefaultKeyboardShortcuts().get("MARK_AS_UNREAD"),
-                testPref.getKeyboardShortcuts().get("MARK_AS_UNREAD"));
+            testPref.getKeyboardShortcuts().get("MARK_AS_UNREAD"));
     }
 
     private static void reloadPrefs(Preferences prefs) {

--- a/src/test/java/unstable/MenuControlTest.java
+++ b/src/test/java/unstable/MenuControlTest.java
@@ -1,216 +1,26 @@
 package unstable;
 
-import guitests.UITest;
-import javafx.scene.input.KeyCode;
-import javafx.scene.control.Button;
-import javafx.scene.control.TextField;
+import static ui.components.KeyboardShortcuts.REFRESH;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
+import guitests.UITest;
 import ui.UI;
-import ui.TestController;
-import ui.components.KeyboardShortcuts;
-import ui.issuepanel.PanelControl;
-import prefs.Preferences;
 import util.PlatformEx;
 import util.events.ModelUpdatedEventHandler;
-import util.Utility;
-import static org.junit.Assert.assertEquals;
-import static ui.components.KeyboardShortcuts.*;
 
 public class MenuControlTest extends UITest {
-
-    private boolean modelUpdatedEventTriggered = false; // NOPMD
-
     @Test
-    public void menuControlTest() {
-        
-        UI ui = TestController.getUI();
-        PanelControl panelControl = ui.getPanelControl();
-        Preferences testPref = UI.prefs;
-        
-        String uiTitle = ("HubTurbo " + 
-        Utility.version(UI.VERSION_MAJOR, UI.VERSION_MINOR, UI.VERSION_PATCH) + " (%s)");
-        
-        UI.events.registerEvent((ModelUpdatedEventHandler) e -> modelUpdatedEventTriggered = true);
-        
-        press(CLOSE_PANEL);
-        assertEquals(0, panelControl.getPanelCount());
-        press(CREATE_RIGHT_PANEL);
-        assertEquals(1, panelControl.getPanelCount());
-        press(CREATE_LEFT_PANEL);
-        assertEquals(2, panelControl.getPanelCount());
+    public void refresh() {
+        final AtomicInteger triggered = new AtomicInteger(0);
 
-        click("Panels");
-        click("Create");
-        assertEquals(3, panelControl.getPanelCount());
-        click("Panels");
-        click("Create (Left)");
-        assertEquals(4, panelControl.getPanelCount());
-        click("Panels");
-        click("Close");
-        assertEquals(3, panelControl.getPanelCount());
-        click("Panels");
-        click("Close");
-        assertEquals(2, panelControl.getPanelCount());
+        PlatformEx.runAndWait(() ->
+            UI.events.registerEvent((ModelUpdatedEventHandler) e ->
+                triggered.incrementAndGet()));
 
-        assertEquals(0, panelControl.getNumberOfSavedBoards());
-        
-        assertEquals(ui.getTitle(), String.format(uiTitle, "none"));
-        
-        // Testing board save when no board is open because nothing has been saved
-        // Expected: prompts user to save as new board
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        type("Board 1");
-        push(KeyCode.ESCAPE);
-        PlatformEx.waitOnFxThread();
-        assertEquals(0, panelControl.getNumberOfSavedBoards());
-        
-        // Testing board open keyboard shortcut when no board is saved
-        // Expected: nothing happens
-        pushKeys(SWITCH_BOARD);
-        assertEquals(false, testPref.getLastOpenBoard().isPresent());
-        
-        // Testing board save as
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("Board 1");
-        click("OK");
-        PlatformEx.waitOnFxThread();
-        assertEquals(1, panelControl.getNumberOfSavedBoards());
-        assertEquals(2, panelControl.getPanelCount());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "Board 1"));
-
-        // Testing board create new and cancel
-        // Expected: nothing happens
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.ENTER);
-        click("Cancel");
-        PlatformEx.waitOnFxThread();
-        assertEquals(1, panelControl.getNumberOfSavedBoards());
-        assertEquals(2, panelControl.getPanelCount());
-
-        // Testing board switch keyboard shortcut when there is only one saved board
-        // Expected: nothing happens
-        press(SWITCH_BOARD);
-        assertEquals(true, testPref.getLastOpenBoard().isPresent());
-        assertEquals("Board 1", testPref.getLastOpenBoard().get());
-
-        press(CREATE_RIGHT_PANEL);
-        assertEquals(3, panelControl.getPanelCount());
-        
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("Board 2");
-        click("OK");
-        PlatformEx.waitOnFxThread();
-        assertEquals(2, panelControl.getNumberOfSavedBoards());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "Board 2"));
-        
-        // Testing invalid board names
-        // Expected: save button disabled
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("");
-        Button saveButton1 = (Button) find("#boardsavebutton");
-        assertEquals(true, saveButton1.isDisabled());
-        push(KeyCode.ESCAPE);
-
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("   ");
-        Button saveButton2 = (Button) find("#boardsavebutton");
-        assertEquals(true, saveButton2.isDisabled());
-        click("Cancel");
-
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("   none  ");
-        Button saveButton3 = (Button) find("#boardsavebutton");
-        assertEquals(true, saveButton3.isDisabled());
-        push(KeyCode.ESCAPE);
-
-        press(CLOSE_PANEL);
-        press(CLOSE_PANEL);
-        press(CLOSE_PANEL);
-        assertEquals(0, panelControl.getPanelCount());
-
-        // Testing board open
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
-        push(KeyCode.ENTER); // Opening Board "2"
-        PlatformEx.waitOnFxThread();
-        assertEquals(3, panelControl.getPanelCount());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "Board 2"));
-
-        // Testing First Panel selected
-        assertEquals(0, (int) panelControl.getCurrentlySelectedPanel().get());
-        press(KeyboardShortcuts.JUMP_TO_NTH_ISSUE_KEYS.get(1));
-        assertEquals(0, (int) panelControl.getCurrentlySelectedPanel().get());
-        
-        // Testing board open keyboard shortcut
-        press(SWITCH_BOARD);
-        assertEquals(true, testPref.getLastOpenBoard().isPresent());
-        assertEquals("Board 1", testPref.getLastOpenBoard().get());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "Board 1"));
-        
-        // Testing board save
-        press(CLOSE_PANEL);
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN);
-        push(KeyCode.ENTER);
-        PlatformEx.waitOnFxThread();
-        assertEquals(2, panelControl.getNumberOfSavedBoards());
-
-        // Testing board create new and confirm
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.ENTER);
-        click("OK");
-        assertEquals(0, panelControl.getPanelCount());
-        ((TextField) find("#boardnameinput")).setText("empty");
-        push(KeyCode.ENTER);
-        assertEquals(0, panelControl.getPanelCount());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "empty"));
-        assertEquals(3, panelControl.getNumberOfSavedBoards());
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
-        push(KeyCode.DOWN);
-        push(KeyCode.ENTER); // Deleting current board (empty): no board is set as open
-        click("OK");
-
-        // Testing board delete
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
-        push(KeyCode.DOWN);
-        push(KeyCode.ENTER); // Deleting current board (Board 1): no board is set as open
-        click("OK");
-        PlatformEx.waitOnFxThread();
-        assertEquals(1, panelControl.getNumberOfSavedBoards());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "none"));
-        
-        // Testing board open keyboard shortcut when there are saved boards but none is open
-        // Expected: nothing happens
-        pushKeys(SWITCH_BOARD);
-        assertEquals(false, testPref.getLastOpenBoard().isPresent());
-        
-        // Testing board save when no board is open because current board was closed
-        // Expected: prompts user to save as new board
-        click("Boards");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
-        ((TextField) find("#boardnameinput")).setText("Board 1");
-        click("OK");
-        PlatformEx.waitOnFxThread();
-        assertEquals(2, panelControl.getNumberOfSavedBoards());
-        assertEquals(ui.getTitle(), String.format(uiTitle, "Board 1"));
-        
-        click("View");
-        click("Refresh");
-        push(KeyboardShortcuts.REFRESH.getCode());
-        assertEquals(true, modelUpdatedEventTriggered);
-        modelUpdatedEventTriggered = false;
+        press(REFRESH);
+        waitAndAssertEquals(1, triggered::get);
     }
 }

--- a/src/test/java/unstable/MenuControlTest.java
+++ b/src/test/java/unstable/MenuControlTest.java
@@ -13,7 +13,7 @@ import util.events.ModelUpdatedEventHandler;
 
 public class MenuControlTest extends UITest {
     @Test
-    public void refresh() {
+    public void refresh_refreshCount_refreshTriggersCorrectEvent() {
         final AtomicInteger triggered = new AtomicInteger(0);
 
         PlatformEx.runAndWait(() ->

--- a/src/test/java/unstable/MetadataUpdateTest.java
+++ b/src/test/java/unstable/MetadataUpdateTest.java
@@ -1,15 +1,11 @@
 package unstable;
 
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
-import org.loadui.testfx.utils.TestUtils;
 
 import guitests.UITest;
 import javafx.scene.input.KeyCode;
 import ui.UI;
 import ui.components.FilterTextField;
-import util.PlatformEx;
 import util.events.testevents.UpdateDummyRepoEvent;
 
 public class MetadataUpdateTest extends UITest {
@@ -22,19 +18,16 @@ public class MetadataUpdateTest extends UITest {
         ensureMetadataDownloadIsTriggered();
         ensureMetadataIsReceived();
 
-        TestUtils.awaitCondition(() ->
-            findQuiet("1 comments since, involving test.").isPresent());
-        assertTrue(findQuiet("2 comments since, involving User 1, User 2.").isPresent());
+        awaitCondition(() -> existsQuiet("1 comments since, involving test."));
+        awaitCondition(() -> existsQuiet("2 comments since, involving User 1, User 2."));
     }
 
     private void ensureMetadataDownloadIsTriggered() {
-        TestUtils.awaitCondition(() ->
-            findQuiet("Getting metadata for dummy/dummy...").isPresent());
+        awaitCondition(() -> existsQuiet("Getting metadata for dummy/dummy..."));
     }
 
     private void ensureMetadataIsReceived() {
-        TestUtils.awaitCondition(() ->
-            findQuiet("Received metadata from dummy/dummy!").isPresent());
+        awaitCondition(() -> existsQuiet("Received metadata from dummy/dummy!"));
     }
 
     private void updated24() {
@@ -45,18 +38,15 @@ public class MetadataUpdateTest extends UITest {
         FilterTextField field = find("#dummy/dummy_col0_filterTextField");
 
         // Select everything in the field
-        doubleClick(field);
-        doubleClick(field);
+        click(field);
+        selectAll();
 
-        type(qualifier);
-        press(KeyCode.SHIFT).press(KeyCode.SEMICOLON).release(KeyCode.SEMICOLON).release(KeyCode.SHIFT);
-        type("24");
+        type(String.format("%s:24", qualifier));
         push(KeyCode.ENTER);
     }
 
     private void resetRepo() {
         UI.events.triggerEvent(UpdateDummyRepoEvent.resetRepo("dummy/dummy"));
-        PlatformEx.waitOnFxThread();
     }
 }
 

--- a/src/test/java/unstable/ModelUpdateUITest.java
+++ b/src/test/java/unstable/ModelUpdateUITest.java
@@ -1,19 +1,19 @@
 package unstable;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
 import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
 
 import guitests.UITest;
-import org.loadui.testfx.utils.FXTestUtils;
 import ui.UI;
 import ui.listpanel.ListPanel;
 import util.PlatformEx;
 import util.events.testevents.UILogicRefreshEvent;
 import util.events.testevents.UpdateDummyRepoEvent;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-
-import static org.junit.Assert.assertEquals;
 
 public class ModelUpdateUITest extends UITest {
 
@@ -25,51 +25,46 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void addIssueTest() throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
-        FutureTask countIssues = new FutureTask(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(11, countIssues.get());
+        assertEquals(11, countIssues.get().intValue());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void addMultipleIssuesTest() throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         addIssue();
         addIssue();
-        FutureTask countIssues = new FutureTask(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(13, countIssues.get());
+        assertEquals(13, countIssues.get().intValue());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void countIssuesTest() throws InterruptedException, ExecutionException {
         addIssue();
         resetRepo();
-        FutureTask countIssues = new FutureTask(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(10, countIssues.get());
+        assertEquals(10, countIssues.get().intValue());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void deleteIssueTest() throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         addIssue();
         deleteIssue(1);
-        FutureTask countIssues = new FutureTask(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(11, countIssues.get());
+        assertEquals(11, countIssues.get().intValue());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void deleteMultipleIssuesTest() throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
@@ -77,9 +72,9 @@ public class ModelUpdateUITest extends UITest {
         addIssue();
         deleteIssue(1);
         deleteIssue(2);
-        FutureTask countIssues = new FutureTask(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(11, countIssues.get());
+        assertEquals(11, countIssues.get().intValue());
     }
 
     // TODO no way to check correctness of these events as of yet as they are not reflected on the UI

--- a/src/test/java/unstable/ModelUpdateUITest.java
+++ b/src/test/java/unstable/ModelUpdateUITest.java
@@ -25,7 +25,8 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    public void addIssueTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_panel_addedIssuesShowUp()
+        throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
@@ -34,7 +35,8 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    public void addMultipleIssuesTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_panel_multipleAddedIssuesShowUp()
+        throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         addIssue();
@@ -45,7 +47,8 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    public void countIssuesTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_panel_correctNumberOfIssuesShown()
+        throws InterruptedException, ExecutionException {
         addIssue();
         resetRepo();
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
@@ -54,7 +57,8 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    public void deleteIssueTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_panel_deletedIssuesNoLongerShowUp()
+        throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         addIssue();
@@ -65,7 +69,8 @@ public class ModelUpdateUITest extends UITest {
     }
 
     @Test
-    public void deleteMultipleIssuesTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_panel_multipleDeletedIssuesNoLongerShowUp()
+        throws InterruptedException, ExecutionException {
         resetRepo();
         addIssue();
         addIssue();
@@ -79,7 +84,7 @@ public class ModelUpdateUITest extends UITest {
 
     // TODO no way to check correctness of these events as of yet as they are not reflected on the UI
     @Test
-    public void otherTriggersTest() throws InterruptedException, ExecutionException {
+    public void modelUpdate_events_eventsTriggerChanges() throws InterruptedException, ExecutionException {
         UI.events.triggerEvent(UpdateDummyRepoEvent.newLabel("dummy/dummy"));
         UI.events.triggerEvent(new UILogicRefreshEvent());
         sleep(EVENT_DELAY);
@@ -108,18 +113,18 @@ public class ModelUpdateUITest extends UITest {
         sleep(EVENT_DELAY);
     }
 
-    public void resetRepo() {
+    private void resetRepo() {
         UI.events.triggerEvent(UpdateDummyRepoEvent.resetRepo("dummy/dummy"));
         sleep(EVENT_DELAY);
     }
 
-    public void addIssue() {
+    private void addIssue() {
         UI.events.triggerEvent(UpdateDummyRepoEvent.newIssue("dummy/dummy"));
         UI.events.triggerEvent(new UILogicRefreshEvent());
         sleep(EVENT_DELAY);
     }
 
-    public void deleteIssue(int itemId) {
+    private void deleteIssue(int itemId) {
         UI.events.triggerEvent(UpdateDummyRepoEvent.deleteIssue("dummy/dummy", itemId));
         UI.events.triggerEvent(new UILogicRefreshEvent());
         sleep(EVENT_DELAY);

--- a/src/test/java/unstable/UpdateIssuesTest.java
+++ b/src/test/java/unstable/UpdateIssuesTest.java
@@ -29,17 +29,15 @@ public class UpdateIssuesTest extends UITest {
         click("#dummy/dummy_col0_filterTextField");
         type("updated:24");
         push(KeyCode.ENTER);
-        PlatformEx.waitOnFxThread();
 
         // Updated view should contain Issue 9 and 10, which was commented on recently (as part of default test dataset)
-        TestUtils.awaitCondition(() -> 2 == countIssuesShown());
-        assertEquals(3496, getApiCount(apiBox.getText())); // 4 calls for issues 9 and 10.
+        TestUtils.awaitCondition(() -> 3496 == getApiCount(apiBox.getText())); // 4 calls for issues 9 and 10.
+        assertEquals(2, countIssuesShown());
 
         // After updating, issue with ID 5 should have title Issue 5.1
         updateIssue(5, "Issue 5.1"); // 2 calls for issue 5, 1 for issue 9, 1 for issue 10 when refreshing UI.
         click("#dummy/dummy_col0_filterTextField");
         push(KeyCode.ENTER); // 1 call for issue 5, 1 for issue 9, 1 for issue 10.
-        PlatformEx.waitOnFxThread();
 
         // Updated view should now contain Issue 5.1, Issue 9 and Issue 10.
         TestUtils.awaitCondition(() -> 3489 == getApiCount(apiBox.getText()));
@@ -50,13 +48,11 @@ public class UpdateIssuesTest extends UITest {
         UI.events.triggerEvent(new UILogicRefreshEvent()); // 1 call for issues 5, 9, 10.
         click("#dummy/dummy_col0_filterTextField");
         push(KeyCode.ENTER); // 1 call for issues 5, 9, 10.
-        PlatformEx.waitOnFxThread();
         TestUtils.awaitCondition(() -> 3483 == getApiCount(apiBox.getText()));
         assertEquals(3, countIssuesShown());
 
         click("#dummy/dummy_col0_filterTextField");
         push(KeyCode.ENTER); // 1 call for issues 5, 9, 10.
-        PlatformEx.waitOnFxThread();
         TestUtils.awaitCondition(() -> 3480 == getApiCount(apiBox.getText()));
     }
 
@@ -71,9 +67,8 @@ public class UpdateIssuesTest extends UITest {
         PlatformEx.waitOnFxThread();
     }
 
-    @SuppressWarnings("unchecked")
     public int countIssuesShown() throws InterruptedException, ExecutionException {
-        FutureTask<Integer> countIssues = new FutureTask<Integer>(((ListPanel) 
+        FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel)
                 TestController.getUI().getPanelControl().getPanel(0))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
         return countIssues.get();


### PR DESCRIPTION
Fixes #952.

On hindsight, accumulating test output in an issue didn't really do anything to fix the problems.

This fixes a few unstable tests and lays the groundwork for fixing the remaining ones. I'll make issues for each of the latter group. In future, we should probably make issues for individual unstable tests and stable ones that we see failing randomly.

Most of them weren't being synchronised properly. The remaining unstable ones have deeper issues than just lack of synchronisation.