### PR TITLE
Replace manual menu navigation in tests with clickMenu() #1094

### DIFF
--- a/src/test/java/guitests/BoardAutoCreatorTest.java
+++ b/src/test/java/guitests/BoardAutoCreatorTest.java
@@ -40,7 +40,7 @@ public class BoardAutoCreatorTest extends UITest {
 
         assertEquals(panelControl.getNumberOfSavedBoards(), 0);
 
-        clickMenu("Boards", "Auto-create", "Milestones");
+        traverseMenu("Boards", "Auto-create", "Milestones");
 
         PlatformEx.waitOnFxThread();
         assertNodeExists(hasText("Milestones board has been created and loaded.\n\n" +
@@ -70,7 +70,7 @@ public class BoardAutoCreatorTest extends UITest {
     public void workAllocationBoardAutoCreationTest() {
         assertEquals(panelControl.getNumberOfSavedBoards(), 0);
 
-        clickMenu("Boards", "Auto-create", "Work Allocation");
+        traverseMenu("Boards", "Auto-create", "Work Allocation");
 
         PlatformEx.waitOnFxThread();
         assertNodeExists(hasText("Work Allocation board has been created and loaded.\n\n" +
@@ -100,7 +100,7 @@ public class BoardAutoCreatorTest extends UITest {
     public void sampleBoardAutoCreationTest() {
         assertEquals(panelControl.getNumberOfSavedBoards(), 0);
 
-        clickMenu("Boards", "Auto-create", SAMPLE_BOARD);
+        traverseMenu("Boards", "Auto-create", SAMPLE_BOARD);
 
         waitUntilNodeAppears(SAMPLE_BOARD_DIALOG);
         click("OK");

--- a/src/test/java/guitests/BoardTests.java
+++ b/src/test/java/guitests/BoardTests.java
@@ -37,36 +37,39 @@ public class BoardTests extends UITest {
     @Test
     public void duplicateNameTest() {
         // Save the current board
-        clickMenu("Boards", "Save as");
+        traverseMenu("Boards", "Save as");
+        waitUntilNodeAppears(hasText("OK"));
         // Use the default 'New Board' as board name
         // Workaround since we are unable to get text field into focus on Travis
         click("OK");
-        assertEquals(1, panelControl.getPanelCount());
+        waitAndAssertEquals(1, panelControl::getPanelCount);
 
         // Create a new panel, then save with the same name
         // Expected: Dialog shown to confirm duplicate name
-        clickMenu("Panels", "Create");
-        clickMenu("Boards", "Save as");
+        traverseMenu("Panels", "Create");
+        traverseMenu("Boards", "Save as");
+        waitUntilNodeAppears(hasText("OK"));
         click("OK");
         waitUntilNodeAppears(hasText("A board by the name 'New Board' already exists."));
 
         // Overwrite previous board, then open the board again
         // Expected: the board should contain 2 panels
         click("Yes");
-        clickMenu("Boards", "Open", "New Board");
-        assertEquals(2, panelControl.getPanelCount());
+        traverseMenu("Boards", "Open", "New Board");
+        waitAndAssertEquals(2, panelControl::getPanelCount);
 
 
         // Create a new panel, then save with the same name to show warning dialog,
         // don't save and try to reopen board
         // Expected: Board is not overwritten, should contain 2 panels
-        clickMenu("Panels", "Create");
-        assertEquals(3, panelControl.getPanelCount());
-        clickMenu("Boards", "Save as");
+        traverseMenu("Panels", "Create");
+        waitAndAssertEquals(3, panelControl::getPanelCount);
+        traverseMenu("Boards", "Save as");
+        waitUntilNodeAppears(hasText("OK"));
         click("OK");
         click("No");
         click("Cancel");
-        clickMenu("Boards", "Open", "New Board");
-        assertEquals(2, panelControl.getPanelCount());
+        traverseMenu("Boards", "Open", "New Board");
+        waitAndAssertEquals(2, panelControl::getPanelCount);
     }
 }

--- a/src/test/java/guitests/PanelMenuCreatorTest.java
+++ b/src/test/java/guitests/PanelMenuCreatorTest.java
@@ -45,30 +45,30 @@ public class PanelMenuCreatorTest extends UITest{
 
     @Test
     public void createPanelTest(){
-        clickMenu("Panels", "Create");
+        traverseMenu("Panels", "Create");
 
-        assertEquals(panelControl.getPanelCount(), 2);
-        assertEquals(panelControl.getCurrentlySelectedPanel(), Optional.of(1));
+        waitAndAssertEquals(2, panelControl::getPanelCount);
+        assertEquals(Optional.of(1), panelControl.getCurrentlySelectedPanel());
 
-        clickMenu("Panels", "Create (Left)");
-        assertEquals(panelControl.getPanelCount(), 3);
-        assertEquals(panelControl.getCurrentlySelectedPanel(), Optional.of(0));
+        traverseMenu("Panels", "Create (Left)");
+        waitAndAssertEquals(3, panelControl::getPanelCount);
+        assertEquals(Optional.of(0), panelControl.getCurrentlySelectedPanel());
 
-        clickMenu("Panels", "Close");
-        clickMenu("Panels", "Close");
+        traverseMenu("Panels", "Close");
+        traverseMenu("Panels", "Close");
     }
 
     private void customizedPanelMenuItemTest(String panelName, String panelFilter){
         PlatformEx.waitOnFxThread();
-        clickMenu("Panels", "Auto-create", panelName);
+        traverseMenu("Panels", "Auto-create", panelName);
 
-        assertEquals(panelControl.getPanelCount(), 2);
-        assertEquals(panelControl.getCurrentlySelectedPanel(), Optional.of(1));
+        waitAndAssertEquals(2, panelControl::getPanelCount);
+        assertEquals(Optional.of(1), panelControl.getCurrentlySelectedPanel());
 
         PanelInfo panelInfo = panelControl.getCurrentPanelInfos().get(1);
-        assertEquals(panelInfo.getPanelFilter(), panelFilter);
-        assertEquals(panelInfo.getPanelName(), panelName);
-        clickMenu("Panels", "Close");
+        waitAndAssertEquals(panelFilter, panelInfo::getPanelFilter);
+        assertEquals(panelName, panelInfo.getPanelName());
+        traverseMenu("Panels", "Close");
     }
 
 }

--- a/src/test/java/guitests/PanelRenameTest.java
+++ b/src/test/java/guitests/PanelRenameTest.java
@@ -126,8 +126,8 @@ public class PanelRenameTest extends UITest {
         assertEquals("Panel", panelNameText5.getText());
         
         // Quitting to update json
-        click("File");
-        push(KeyCode.DOWN).push(KeyCode.DOWN).push(KeyCode.ENTER);
+        traverseMenu("File", "Quit");
+        push(KeyCode.ENTER);
         sleep(EVENT_DELAY);
     }
 }

--- a/src/test/java/guitests/RepositorySelectorTest.java
+++ b/src/test/java/guitests/RepositorySelectorTest.java
@@ -103,38 +103,26 @@ public class RepositorySelectorTest extends UITest {
         assertEquals("dummy4/dummy4", primaryRepo);
 
         // we check if deleting used repo does not remove it
-        click("Repos");
-        push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
-        push(KeyCode.DOWN);
-        push(KeyCode.DOWN); // first used repo
+        traverseMenu("Repos", "Remove", "dummy4/dummy4 [in use, not removable]"); // first used repo
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
         assertEquals(4, comboBox.getItems().size());
 
         // we check if delete repo works
-        click("Boards"); // trigger clicking "Repos"
-        click("Repos");
-        push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
+        traverseMenu("Repos", "Remove", "dummy/dummy");
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
         assertEquals(3, comboBox.getItems().size());
 
         // we check again if deleting used repo does not remove it
-        click("Repos");
-        push(KeyCode.DOWN);
-        push(KeyCode.RIGHT);
-        push(KeyCode.DOWN);
-        push(KeyCode.DOWN); // second used repo
+        traverseMenu("Repos", "Remove", "dummy2/dummy2 [in use, not removable]"); // second used repo
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
         assertEquals(3, comboBox.getItems().size());
 
         // exit program
-        click("Boards"); // trigger clicking "Quit"
-        click("File");
-        click("Quit");
+        traverseMenu("File", "Quit");
+        push(KeyCode.ENTER);
 
         // testing that the correct repo was saved in the json
         // check if the test JSON is still there...


### PR DESCRIPTION
closes #1094 

I replaced `push(KeyCode)` with `clickMenu()`.

There are some cases that needs manual traverse.
1. click() inside clickMenu() cannot handle duplicate menu names (ex. `New` and `Boards / New`)
2. click() will move mouse in straight line, so it may go over another menu and trigger it. It usually happens for diagonal move towards submenu.

These cases are left to use manual traverse.

One more remark..
From line 168, the comment says it deletes `empty` and then `Board 1`, but it actually was deleting `Board 1` and then `empty`. This branch follows the comment and deletes `empty` first and then `Board 1`.
