### PR TITLE
Supports repo as criteria to id filter #1238

### DIFF
--- a/src/main/java/filter/Parser.java
+++ b/src/main/java/filter/Parser.java
@@ -204,11 +204,6 @@ public final class Parser {
         }
     }
 
-    /**
-     * Checks if this is an enhanced id lookup i.e id:test/test#111
-     * @param type
-     * @return
-     */
     private boolean isCompoundId(QualifierType type, Token token) {
         return type == QualifierType.ID && token.getType() == TokenType.COMPOUND_ID;
     }
@@ -295,7 +290,7 @@ public final class Parser {
 
     /**
      * Parses filter for conjunction lookup of repo and id i.e id:test/test#id
-     * @return 
+     * @return filter expression
      */
     private FilterExpression parseCompoundId() {
         String repoId = consume().getValue();

--- a/src/main/java/filter/Parser.java
+++ b/src/main/java/filter/Parser.java
@@ -181,7 +181,7 @@ public final class Parser {
     private FilterExpression parseQualifierContent(QualifierType type) {
         if (type == QualifierType.SORT) {
             return parseSortKeys();
-        } else if (isCompoundId(type, lookAhead())) {
+        } else if (isCompoundIdToken(type, lookAhead())) {
             return parseCompoundId();
         } else if (isRangeOperatorToken(lookAhead())) {
             // < > <= >= [number range | date range]
@@ -204,8 +204,8 @@ public final class Parser {
         }
     }
 
-    private boolean isCompoundId(QualifierType type, Token token) {
-        return type == QualifierType.ID && token.getType() == TokenType.COMPOUND_ID;
+    private boolean isCompoundIdToken(QualifierType type, Token token) {
+        return type == QualifierType.ID && token.getType() == TokenType.COMPOUND_ID_PREFIX;
     }
 
     private boolean isKeywordToken(Token token) {

--- a/src/main/java/filter/lexer/Lexer.java
+++ b/src/main/java/filter/lexer/Lexer.java
@@ -21,6 +21,7 @@ public class Lexer {
             // These have higher priority than Symbol
             new Rule("\\d{4}-\\d{1,2}-\\d{1,2}", TokenType.DATE), // YYYY-MM?-DD?
             new Rule("[A-Za-z]+(-[A-Za-z]+)*\\s*:", TokenType.QUALIFIER),
+            new Rule("[A-Za-z0-9#][/A-Za-z0-9.'+-]+#", TokenType.COMPOUND_ID),
             new Rule(";", TokenType.SEMICOLON),
             new Rule("[A-Za-z0-9#][/A-Za-z0-9.'+-]*", TokenType.SYMBOL),
 

--- a/src/main/java/filter/lexer/Lexer.java
+++ b/src/main/java/filter/lexer/Lexer.java
@@ -12,6 +12,9 @@ public class Lexer {
 
     private static final boolean SKIP_WHITESPACE = true;
     private static final Pattern NO_WHITESPACE = Pattern.compile("\\S");
+    private static final String ALPHANUMERIC = "[a-zA-Z0-9]";
+    private static final String VALID_USERNAME = String.format(
+           "%s[-a-zA-Z0-9]*%s", ALPHANUMERIC, ALPHANUMERIC);
 
     private final List<Rule> rules = Arrays.asList(
             new Rule("AND|&&?", TokenType.AND),
@@ -21,7 +24,7 @@ public class Lexer {
             // These have higher priority than Symbol
             new Rule("\\d{4}-\\d{1,2}-\\d{1,2}", TokenType.DATE), // YYYY-MM?-DD?
             new Rule("[A-Za-z]+(-[A-Za-z]+)*\\s*:", TokenType.QUALIFIER),
-            new Rule("[A-Za-z0-9#][/A-Za-z0-9.'+-]+#", TokenType.COMPOUND_ID),
+            new Rule(String.format("%s/[A-Za-z0-9-]+#", VALID_USERNAME), TokenType.COMPOUND_ID_PREFIX),
             new Rule(";", TokenType.SEMICOLON),
             new Rule("[A-Za-z0-9#][/A-Za-z0-9.'+-]*", TokenType.SYMBOL),
 

--- a/src/main/java/filter/lexer/TokenType.java
+++ b/src/main/java/filter/lexer/TokenType.java
@@ -20,5 +20,6 @@ public enum TokenType {
     GTE,
     QUALIFIER,
     STAR,
+    COMPOUND_ID,
     DATE
 }

--- a/src/main/java/filter/lexer/TokenType.java
+++ b/src/main/java/filter/lexer/TokenType.java
@@ -20,6 +20,6 @@ public enum TokenType {
     GTE,
     QUALIFIER,
     STAR,
-    COMPOUND_ID,
+    COMPOUND_ID_PREFIX,
     DATE
 }

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -71,28 +71,32 @@ public class FilterEvalTests {
 
     @Test
     public void satisfiesId_validCompoundId() {
-        TurboIssue issue1 = new TurboIssue("dummy/dummy", 1, "1");
+        TurboIssue issue = new TurboIssue("dummy/dummy", 1, "1");
        
-        assertFalse(matches("id:test/test#1", issue1));
-        assertFalse(matches("id:dummy/dummy#2", issue1));
-        assertTrue(matches("id:dummy/dummy#1", issue1));
-    }
-
-    @Test
-    public void satisfiesId_compoundIdWithRangeOperator() {
-        TurboIssue issue1 = new TurboIssue("dummy/dummy", 5, "5");
-        TurboIssue issue2 = new TurboIssue("dummy/dummy", 4, "4");
-       
-        assertTrue(matches("id:dummy/dummy#>4", issue1));
-        assertTrue(matches("id:dummy/dummy#3 .. 6", issue2));
+        assertFalse(matches("id:test/test#1", issue));
+        assertFalse(matches("id:dummy/dummy#2", issue));
+        assertTrue(matches("id:dummy/dummy#1", issue));
     }
 
     @Test
     public void satisfiesId_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.ID, "id:something");
+    }
 
-        // test: compound id lookup
-        verifySemanticException(QualifierType.ID, "id:dummy/dummy#hello");
+    @Test
+    public void satisfiesId_compoundIdWithRangeOperator() {
+        TurboIssue issue = new TurboIssue("dummy/dummy", 4, "4");
+       
+        assertTrue(matches("id:dummy/dummy#>3", issue));
+        assertTrue(matches("id:dummy/dummy#>=4", issue));
+        assertTrue(matches("id:dummy/dummy#<6", issue));
+        assertTrue(matches("id:dummy/dummy#<=6", issue));
+        assertTrue(matches("id:dummy/dummy#3 .. 6", issue));
+    }
+
+    @Test
+    public void satisfiesId_invalidCompoundIdInputs_throwSemanticException() {
+        verifySemanticException(QualifierType.ID, "id:test/test#something");
     }
 
     private void testForPresenceOfKeywords(String prefix, TurboIssue issue) {
@@ -832,8 +836,8 @@ public class FilterEvalTests {
      * Confirms that the input causes a Semantic Exception to be thrown
      * with correct error message. Test fails if it doesn't.
      */
-    public void verifySemanticException(QualifierType type, String invalidInput) {
-        TurboIssue issue = new TurboIssue(REPO, 1, "");
+    private void verifySemanticException(QualifierType type, String invalidInput) {
+        TurboIssue issue = new TurboIssue(REPO, 1, "1");
         thrown.expect(SemanticException.class);
         thrown.expectMessage(
             String.format(SemanticException.ERROR_MESSAGE, type, type.getDescriptionOfValidInputs()));

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -70,8 +70,19 @@ public class FilterEvalTests {
     }
 
     @Test
+    public void satisfiesId_validCompoundId() {
+        TurboIssue issue1 = new TurboIssue("dummy/dummy", 1, "1");
+       
+        assertFalse(matches("id:test/test#1", issue1));
+        assertTrue(matches("id:dummy/dummy#1", issue1));
+    }
+
+    @Test
     public void satisfiesId_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.ID, "id:something");
+
+        // test: compound id lookup
+        verifySemanticException(QualifierType.ID, "id:dummy/dummy#hello");
     }
 
     private void testForPresenceOfKeywords(String prefix, TurboIssue issue) {
@@ -768,6 +779,9 @@ public class FilterEvalTests {
     @Test
     public void satisfiesRepo_invalidInputs_throwSemanticException() {
         verifySemanticException(QualifierType.REPO, "repo:2011-1-1");
+        
+        // test: compound id lookup
+        verifySemanticException(QualifierType.REPO, "id:2011#1");
     }
 
     @Test

--- a/src/test/java/tests/FilterEvalTests.java
+++ b/src/test/java/tests/FilterEvalTests.java
@@ -74,7 +74,17 @@ public class FilterEvalTests {
         TurboIssue issue1 = new TurboIssue("dummy/dummy", 1, "1");
        
         assertFalse(matches("id:test/test#1", issue1));
+        assertFalse(matches("id:dummy/dummy#2", issue1));
         assertTrue(matches("id:dummy/dummy#1", issue1));
+    }
+
+    @Test
+    public void satisfiesId_compoundIdWithRangeOperator() {
+        TurboIssue issue1 = new TurboIssue("dummy/dummy", 5, "5");
+        TurboIssue issue2 = new TurboIssue("dummy/dummy", 4, "4");
+       
+        assertTrue(matches("id:dummy/dummy#>4", issue1));
+        assertTrue(matches("id:dummy/dummy#3 .. 6", issue2));
     }
 
     @Test

--- a/src/test/java/tests/FilterLexerTests.java
+++ b/src/test/java/tests/FilterLexerTests.java
@@ -4,52 +4,53 @@ import filter.ParseException;
 import filter.lexer.Lexer;
 import filter.lexer.Token;
 import filter.lexer.TokenType;
+
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class FilterLexerTests {
+
     @Test
-    public void lexer() {
-        assertEquals(new Lexer("").lex(), Arrays.asList(
+    public void lex_generalInputs() {
+
+        assertEquals(getTokens(""), Arrays.asList(
             new Token(TokenType.EOF, "")));
-        assertEquals(new Lexer("a' b' c'").lex(), Arrays.asList(
+
+        assertEquals(getTokens("a' b' c'"), Arrays.asList(
             new Token(TokenType.SYMBOL, "a'"),
             new Token(TokenType.SYMBOL, "b'"),
             new Token(TokenType.SYMBOL, "c'"),
             new Token(TokenType.EOF, "")));
+    }
 
-        // Repo names
-        assertEquals(new Lexer("test/test").lex(), Arrays.asList(
-            new Token(TokenType.SYMBOL, "test/test"),
-            new Token(TokenType.EOF, "")));
+    @Test
+    public void lex_repoIds() {
+        assertEquals(getTokens("test/test"), 
+            Arrays.asList(new Token(TokenType.SYMBOL, "test/test"), new Token(TokenType.EOF, "")));
+    }
 
-        // Forward slashes cannot begin symbols, so this won't work
-        try {
-            new Lexer("repo:\"test / test\"").lex();
-        } catch (ParseException ignored) {}
+    @Test
+    public void lex_sortingKeys() {
 
-        // Sorting keys
-        // Commas aren't valid symbol names and may only appear in the body of a `sort` qualifier
-        try {
-            new Lexer("a,b").lex();
-        } catch (ParseException ignored) {}
-
-        assertEquals(new Lexer("sort: a, b ").lex(), Arrays.asList(
+        assertEquals(getTokens("sort: a, b "), Arrays.asList(
             new Token(TokenType.QUALIFIER, "sort:"),
             new Token(TokenType.SYMBOL, "a"),
             new Token(TokenType.COMMA, ","),
             new Token(TokenType.SYMBOL, "b"),
             new Token(TokenType.EOF, "")));
-        assertEquals(new Lexer("sort-self-other: a, b ").lex(), Arrays.asList(
+
+        assertEquals(getTokens("sort-self-other: a, b "), Arrays.asList(
                 new Token(TokenType.QUALIFIER, "sort-self-other:"),
                 new Token(TokenType.SYMBOL, "a"),
                 new Token(TokenType.COMMA, ","),
                 new Token(TokenType.SYMBOL, "b"),
                 new Token(TokenType.EOF, "")));
-        assertEquals(new Lexer("---sort-self-other: a, b ").lex(), Arrays.asList(
+
+        assertEquals(getTokens("---sort-self-other: a, b "), Arrays.asList(
                 new Token(TokenType.NOT, "-"),
                 new Token(TokenType.NOT, "-"),
                 new Token(TokenType.NOT, "-"),
@@ -58,25 +59,48 @@ public class FilterLexerTests {
                 new Token(TokenType.COMMA, ","),
                 new Token(TokenType.SYMBOL, "b"),
                 new Token(TokenType.EOF, "")));
-        assertEquals(new Lexer("sort: a , - b").lex(), Arrays.asList(
+
+        assertEquals(getTokens("sort: a , - b"), Arrays.asList(
             new Token(TokenType.QUALIFIER, "sort:"),
             new Token(TokenType.SYMBOL, "a"),
             new Token(TokenType.COMMA, ","),
             new Token(TokenType.NOT, "-"),
             new Token(TokenType.SYMBOL, "b"),
             new Token(TokenType.EOF, "")));
+    }
 
-        // milestone aliases
-        assertEquals(new Lexer("milestone:curr-1").lex(), Arrays.asList(
+    @Test
+    public void lex_milestoneAliases() {
+
+        assertEquals(getTokens("milestone:curr-1"), Arrays.asList(
                 new Token(TokenType.QUALIFIER, "milestone:"),
                 new Token(TokenType.SYMBOL, "curr-1"),
                 new Token(TokenType.EOF, "")
         ));
-        assertEquals(new Lexer("milestone:curr+1").lex(), Arrays.asList(
+
+        assertEquals(getTokens("milestone:curr+1"), Arrays.asList(
                 new Token(TokenType.QUALIFIER, "milestone:"),
                 new Token(TokenType.SYMBOL, "curr+1"),
                 new Token(TokenType.EOF, "")
         ));
     }
 
+    @Test
+    public void lex_compoundId() {
+
+        assertEquals(getTokens("id:test/test#1"), Arrays.asList(
+                new Token(TokenType.QUALIFIER, "id:"),
+                new Token(TokenType.COMPOUND_ID, "test/test#"),
+                new Token(TokenType.SYMBOL, "1"),
+                new Token(TokenType.EOF, "")
+        ));
+    }
+
+    /**
+     * @param query
+     * @return list of tokens after lexing
+     */
+    private List<Token> getTokens(String query) {
+        return new Lexer(query).lex();
+    }
 }

--- a/src/test/java/tests/FilterLexerTests.java
+++ b/src/test/java/tests/FilterLexerTests.java
@@ -1,6 +1,5 @@
 package tests;
 
-import filter.ParseException;
 import filter.lexer.Lexer;
 import filter.lexer.Token;
 import filter.lexer.TokenType;
@@ -11,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class FilterLexerTests {
 
@@ -29,6 +29,7 @@ public class FilterLexerTests {
 
     @Test
     public void lex_repoIds() {
+
         assertEquals(getTokens("test/test"), 
             Arrays.asList(new Token(TokenType.SYMBOL, "test/test"), new Token(TokenType.EOF, "")));
     }
@@ -94,6 +95,9 @@ public class FilterLexerTests {
                 new Token(TokenType.SYMBOL, "1"),
                 new Token(TokenType.EOF, "")
         ));
+
+        // test: at least one symbol preceedes "#"
+        assertFalse(getTokens("id:#1").contains(new Token(TokenType.COMPOUND_ID, "#")));
     }
 
     /**


### PR DESCRIPTION
Fixes #1238 

## Summary
1. Added new rule to match "#" in `Lexer`
2. Added parsing of `CompoundId` in `parseQualifierContent`

## Tested
1. Supports `id:hubturbo/hubturbo#123 ; test/test#12`

## Todo
- [x] determine edge cases for matching of "#"
- [x] write unit tests