### PR TITLE
More obvious sign of filter syntax problem #1301

### DIFF
--- a/src/main/java/ui/components/FilterTextField.java
+++ b/src/main/java/ui/components/FilterTextField.java
@@ -26,6 +26,11 @@ public class FilterTextField extends TextField {
     // Specialised to HubTurbo's filter syntax.
     private static final String WORD_BOUNDARY_REGEX = "[ (:)]";
 
+    // Background colours of FilterTextField.
+    // The background colour set depends on whether the text in the textfield is a valid filter.
+    private static final String VALID_FILTER_STYLE = "-fx-control-inner-background: white";
+    private static final String INVALID_FILTER_STYLE = "-fx-control-inner-background: #EE8993";
+
     // Callback functions
     private Runnable cancel = () -> {};
     private Function<String, String> confirm = (s) -> s;
@@ -51,8 +56,10 @@ public class FilterTextField extends TextField {
             boolean wasError = false;
             try {
                 Parser.parse(getText());
+                setStyleForValidFilter();
             } catch (ParseException e) {
                 wasError = true;
+                setStyleForInvalidFilter();
             }
             return ValidationResult.fromErrorIf(this, "Parse error", wasError);
         });
@@ -91,6 +98,20 @@ public class FilterTextField extends TextField {
                 }
             }
         });
+    }
+
+    /**
+     * Sets the style of FilterTextField to the style for valid filter
+     */
+    public final void setStyleForValidFilter() {
+        this.setStyle(VALID_FILTER_STYLE);
+    }
+
+    /**
+     * Sets the style of FilterTextField to the style for invalid filter
+     */
+    public final void setStyleForInvalidFilter() {
+        this.setStyle(INVALID_FILTER_STYLE);
     }
 
     /**

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -177,11 +177,13 @@ public abstract class FilterPanel extends AbstractPanel {
             FilterExpression filter = Parser.parse(filterString);
             if (filter != null) {
                 this.applyFilterExpression(filter);
+                filterTextField.setStyleForValidFilter();
             } else {
                 this.applyFilterExpression(Qualifier.EMPTY);
             }
         } catch (FilterException ex) {
             this.applyFilterExpression(Qualifier.EMPTY);
+            filterTextField.setStyleForInvalidFilter();
             // Overrides message in status bar
             UI.status.displayMessage(getUniquePanelName(
                 panelMenuBar.getPanelName()) + ": " + ex.getMessage());


### PR DESCRIPTION
Fixes #1301. 

The background colour of the filter text field will change to red when the filter is invalid. Otherwise, the background colour is white. 

The check whether to change the background color happens when 
 - the user presses enter 
 - the filter in the text field changes  

Screenshot
![image](https://cloud.githubusercontent.com/assets/12397473/13492403/c483064e-e172-11e5-96d1-8acd9f52568a.png)
