### PR TITLE
Exception thrown from asynchronous filtering in UpdateController is not caught #1322

### DIFF
--- a/src/main/java/backend/UpdateController.java
+++ b/src/main/java/backend/UpdateController.java
@@ -59,7 +59,7 @@ public class UpdateController {
 
             if (toUpdate.isEmpty()) {
                 // If no issues requiring metadata update, just run the filter and sort.
-                logic.updateUI(processPanels(filterPanels));
+                logic.updateUI(processFilters(filterExprs));
                 return;
             }
 
@@ -74,7 +74,7 @@ public class UpdateController {
                             + results.size() + " repos"))
                     .thenCompose(n -> logic.getRateLimitResetTime())
                     .thenApply(logic::updateRemainingRate)
-                    .thenRun(() -> logic.updateUI(processPanels(filterPanels))); // Then filter the second time.
+                    .thenRun(() -> logic.updateUI(processFilters(filterExprs))); // Then filter the second time.
         });
     }
 
@@ -116,20 +116,19 @@ public class UpdateController {
     }
 
     /**
-     * Filters, sorts and counts issues within the model according to the given panels' filter expressions.
+     * Filters, sorts and counts issues within the model according to the given filter expressions
      * In here, "processed" is equivalent to "filtered, sorted and counted".
      *
-     * @param filterPanels Filter panels to process.
+     * @param filterExprs Filter expressions
      * @return Filter expressions and their corresponding issues after filtering, sorting and counting.
      */
-    private Map<FilterExpression, List<GuiElement>> processPanels(List<FilterPanel> filterPanels) {
+    private Map<FilterExpression, List<GuiElement>> processFilters(List<FilterExpression> filterExprs) {
         MultiModel models = logic.getModels();
         List<TurboIssue> allModelIssues = models.getIssues();
 
         Map<FilterExpression, List<GuiElement>> processed = new HashMap<>();
 
-        filterPanels.stream().distinct().forEach(filterPanel -> {
-            FilterExpression filterExpr = filterPanel.getCurrentFilterExpression();
+        filterExprs.stream().distinct().forEach(filterExpr -> {
             boolean hasUpdatedQualifier = Qualifier.hasUpdatedQualifier(filterExpr);
 
             try {
@@ -145,7 +144,7 @@ public class UpdateController {
 
                 processed.put(filterExpr, processedElements);
             } catch (FilterException e) {
-                Platform.runLater(() -> UI.events.triggerEvent(new FilterExceptionEvent(filterPanel, e.getMessage())));
+                Platform.runLater(() -> UI.events.triggerEvent(new FilterExceptionEvent(filterExpr, e.getMessage())));
             }
         });
 

--- a/src/main/java/backend/UpdateController.java
+++ b/src/main/java/backend/UpdateController.java
@@ -49,7 +49,7 @@ public class UpdateController {
 
         // Filter and sort the issues first even if the metadata is not yet available so that criteria not
         // based on metadata can have immediate effect.
-        logic.updateUI(processFilter(filterExprs));
+        logic.updateUI(processFilters(filterExprs));
 
         // Open specified repos
         openRepositoriesInFilters(filterPanels)

--- a/src/main/java/backend/UpdateController.java
+++ b/src/main/java/backend/UpdateController.java
@@ -110,7 +110,15 @@ public class UpdateController {
         return filterExprs.stream()
                 .filter(Qualifier::hasUpdatedQualifier)
                 .flatMap(filterExpr -> allModelIssues.stream()
-                        .filter(issue -> Qualifier.process(models, filterExpr, issue)))
+                        .filter(issue -> {
+                            try {
+                                return Qualifier.process(models, filterExpr, issue);
+                            } catch (FilterException e) {
+                                Platform.runLater(() -> UI.events.triggerEvent(
+                                        new FilterExceptionEvent(filterExpr, e.getMessage())));
+                                return false;
+                            }
+                        }))
                 .distinct()
                 .collect(Collectors.groupingBy(TurboIssue::getRepoId));
     }

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -106,6 +106,7 @@ public abstract class FilterPanel extends AbstractPanel {
         ui.registerEvent((PrimaryRepoOpenedEventHandler) this::stopLoadingAnimationIfApplicable);
         ui.registerEvent((ApplyingFilterEventHandler) this::startLoadingAnimationIfApplicable);
         ui.registerEvent((AppliedFilterEventHandler) this::stopLoadingAnimationIfApplicable);
+        ui.registerEvent((FilterExceptionEventHandler) this::handleFilterException);
     }
 
     private final ModelUpdatedEventHandler onModelUpdate = e -> {
@@ -182,11 +183,7 @@ public abstract class FilterPanel extends AbstractPanel {
                 this.applyFilterExpression(Qualifier.EMPTY);
             }
         } catch (FilterException ex) {
-            this.applyFilterExpression(Qualifier.EMPTY);
-            filterTextField.setStyleForInvalidFilter();
-            // Overrides message in status bar
-            UI.status.displayMessage(getUniquePanelName(
-                panelMenuBar.getPanelName()) + ": " + ex.getMessage());
+            emptyFilterAndShowError(ex.getMessage());
         }
     }
 
@@ -229,6 +226,17 @@ public abstract class FilterPanel extends AbstractPanel {
     protected abstract void startLoadingAnimationIfApplicable(ApplyingFilterEvent e);
 
     protected abstract void stopLoadingAnimationIfApplicable(AppliedFilterEvent e);
+
+    private void handleFilterException(FilterExceptionEvent e) {
+        if (e.panel != this) return;
+        emptyFilterAndShowError(e.exceptionMessage);
+    }
+
+    private void emptyFilterAndShowError(String exceptionMessage) {
+        this.applyFilterExpression(Qualifier.EMPTY);
+        filterTextField.setStyleForInvalidFilter();
+        UI.status.displayMessage(getUniquePanelName(panelMenuBar.getPanelName()) + ": " + exceptionMessage);
+    }
 
     public void setFilterByString(String filterString) {
         filterTextField.setFilterText(filterString);

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -228,7 +228,7 @@ public abstract class FilterPanel extends AbstractPanel {
     protected abstract void stopLoadingAnimationIfApplicable(AppliedFilterEvent e);
 
     private void handleFilterException(FilterExceptionEvent e) {
-        if (e.panel != this) return;
+        if (e.filterExpr != getCurrentFilterExpression()) return;
         emptyFilterAndShowError(e.exceptionMessage);
     }
 

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -228,7 +228,7 @@ public abstract class FilterPanel extends AbstractPanel {
     protected abstract void stopLoadingAnimationIfApplicable(AppliedFilterEvent e);
 
     private void handleFilterException(FilterExceptionEvent e) {
-        if (e.filterExpr != getCurrentFilterExpression()) return;
+        if (!e.filterExpr.equals(getCurrentFilterExpression())) return;
         emptyFilterAndShowError(e.exceptionMessage);
     }
 

--- a/src/main/java/util/events/FilterExceptionEvent.java
+++ b/src/main/java/util/events/FilterExceptionEvent.java
@@ -6,8 +6,8 @@ import filter.expression.FilterExpression;
  * This class is meant to indicate that there is an exception thrown during the filtering of issues
  */
 public class FilterExceptionEvent extends Event {
-    public FilterExpression filterExpr;
-    public String exceptionMessage;
+    public final FilterExpression filterExpr;
+    public final String exceptionMessage;
 
     public FilterExceptionEvent(FilterExpression filterExpr, String exceptionMessage) {
         this.filterExpr = filterExpr;

--- a/src/main/java/util/events/FilterExceptionEvent.java
+++ b/src/main/java/util/events/FilterExceptionEvent.java
@@ -1,0 +1,16 @@
+package util.events;
+
+import ui.issuepanel.FilterPanel;
+
+/**
+ * This class is meant to indicate that there is an exception thrown during the filtering of issues
+ */
+public class FilterExceptionEvent extends Event {
+    public FilterPanel panel;
+    public String exceptionMessage;
+
+    public FilterExceptionEvent(FilterPanel panel, String exceptionMessage) {
+        this.panel = panel;
+        this.exceptionMessage = exceptionMessage;
+    }
+}

--- a/src/main/java/util/events/FilterExceptionEvent.java
+++ b/src/main/java/util/events/FilterExceptionEvent.java
@@ -1,16 +1,16 @@
 package util.events;
 
-import ui.issuepanel.FilterPanel;
+import filter.expression.FilterExpression;
 
 /**
  * This class is meant to indicate that there is an exception thrown during the filtering of issues
  */
 public class FilterExceptionEvent extends Event {
-    public FilterPanel panel;
+    public FilterExpression filterExpr;
     public String exceptionMessage;
 
-    public FilterExceptionEvent(FilterPanel panel, String exceptionMessage) {
-        this.panel = panel;
+    public FilterExceptionEvent(FilterExpression filterExpr, String exceptionMessage) {
+        this.filterExpr = filterExpr;
         this.exceptionMessage = exceptionMessage;
     }
 }

--- a/src/main/java/util/events/FilterExceptionEventHandler.java
+++ b/src/main/java/util/events/FilterExceptionEventHandler.java
@@ -1,0 +1,9 @@
+package util.events;
+
+import com.google.common.eventbus.Subscribe;
+
+@FunctionalInterface
+public interface FilterExceptionEventHandler extends EventHandler {
+    @Subscribe
+    void handle(FilterExceptionEvent e);
+}

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 import backend.stub.DummyRepoState;
+import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import org.junit.Test;
 import ui.listpanel.ListPanel;
@@ -23,6 +24,20 @@ public class FilterTests extends UITest{
         push(KeyCode.ENTER);
 
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+    }
+
+    @Test
+    public void filterTextField_semanticException_backgroundError() {
+        ListPanel issuePanel = find("#dummy/dummy_col0");
+        TextField textField = find("#dummy/dummy_col0_filterTextField");
+
+        click("#dummy/dummy_col0_filterTextField");
+        selectAll();
+        type("id:buggy");
+        push(KeyCode.ENTER);
+        
+        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertTrue(textField.getStyle().contains("-fx-control-inner-background: #EE8993"));
     }
 
     @Test

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -31,7 +31,7 @@ public class FilterTests extends UITest{
     }
 
     @Test
-    public void filterTextField_semanticException_backgroundError() {
+    public void filterTextField_semanticException_emptyFilter() {
         ListPanel issuePanel = find("#dummy/dummy_col0");
 
         // test semantic exception dummy/dummy_col0_filterTextField");
@@ -76,6 +76,8 @@ public class FilterTests extends UITest{
         PlatformEx.waitOnFxThread();
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel2.getIssueCount());
         assertEquals(1, issuePanel.getIssueCount());
+
+        pushKeys(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN));
     }
 
     @Test

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertEquals;
 import backend.stub.DummyRepoState;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import org.junit.Test;
 import ui.listpanel.ListPanel;
 
@@ -29,15 +31,44 @@ public class FilterTests extends UITest{
     @Test
     public void filterTextField_semanticException_backgroundError() {
         ListPanel issuePanel = find("#dummy/dummy_col0");
-        TextField textField = find("#dummy/dummy_col0_filterTextField");
 
+        // test semantic exception dummy/dummy_col0_filterTextField");
         click("#dummy/dummy_col0_filterTextField");
         selectAll();
         type("id:buggy");
         push(KeyCode.ENTER);
-        
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
-        assertTrue(textField.getStyle().contains("-fx-control-inner-background: #EE8993"));
+    }
+
+    @Test
+    public void filterTextField_multiplePanels_correctPanelFiltered() {
+        ListPanel issuePanel = find("#dummy/dummy_col0");
+
+        // filter panel 1
+        click("#dummy/dummy_col0_filterTextField");
+        selectAll();
+        type("id:4");
+        push(KeyCode.ENTER);
+        assertEquals(1, issuePanel.getIssueCount());
+
+        // create new panel 2
+        pushKeys(new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN));
+        sleep(100);
+        ListPanel issuePanel2 = find("#dummy/dummy_col1");
+
+        // filter once
+        click("#dummy/dummy_col1_filterTextField");
+        type("id:3");
+        push(KeyCode.ENTER);
+        assertEquals(1, issuePanel2.getIssueCount());
+
+        // filter again and check if the correct panel is filtered (and the other panel is untouched)
+        click("#dummy/dummy_col1_filterTextField");
+        selectAll();
+        push(KeyCode.BACK_SPACE);
+        push(KeyCode.ENTER);
+        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel2.getIssueCount());
+        assertEquals(1, issuePanel.getIssueCount());
     }
 
     @Test

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -45,6 +45,20 @@ public class FilterTests extends UITest{
     }
 
     @Test
+    public void filterTextField_tallyMetadataUpdateSemanticException_emptyFilter() {
+        ListPanel issuePanel = find("#dummy/dummy_col0");
+
+        // test semantic exception dummy/dummy_col0_filterTextField");
+        click("#dummy/dummy_col0_filterTextField");
+        selectAll();
+        type("id:buggy u:<24");
+        push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
+
+        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+    }
+
+    @Test
     public void filterTextField_multiplePanels_correctPanelFiltered() {
         ListPanel issuePanel = find("#dummy/dummy_col0");
 

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -10,6 +10,7 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import org.junit.Test;
 import ui.listpanel.ListPanel;
+import util.PlatformEx;
 
 import java.util.Optional;
 
@@ -24,6 +25,7 @@ public class FilterTests extends UITest{
         selectAll();
         type("milestone:");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
 
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
     }
@@ -37,6 +39,8 @@ public class FilterTests extends UITest{
         selectAll();
         type("id:buggy");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
+
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
     }
 
@@ -49,17 +53,19 @@ public class FilterTests extends UITest{
         selectAll();
         type("id:4");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(1, issuePanel.getIssueCount());
 
         // create new panel 2
         pushKeys(new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN));
-        sleep(100);
+        PlatformEx.waitOnFxThread();
         ListPanel issuePanel2 = find("#dummy/dummy_col1");
 
         // filter once
         click("#dummy/dummy_col1_filterTextField");
         type("id:3");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(1, issuePanel2.getIssueCount());
 
         // filter again and check if the correct panel is filtered (and the other panel is untouched)
@@ -67,6 +73,7 @@ public class FilterTests extends UITest{
         selectAll();
         push(KeyCode.BACK_SPACE);
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(DummyRepoState.noOfDummyIssues, issuePanel2.getIssueCount());
         assertEquals(1, issuePanel.getIssueCount());
     }
@@ -200,6 +207,7 @@ public class FilterTests extends UITest{
         selectAll();
         type(milestoneAlias + ":" + currString);
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
 
         assertEquals(1, issuePanel.getIssueCount());
         assertTrue(issuePanel.getElementsList().get(0).getIssue().getMilestone().isPresent());

--- a/src/test/java/guitests/IssuePanelTests.java
+++ b/src/test/java/guitests/IssuePanelTests.java
@@ -30,6 +30,7 @@ import ui.GuiElement;
 import ui.UI;
 import ui.listpanel.ListPanel;
 import ui.listpanel.ListPanelCard;
+import util.PlatformEx;
 import util.Utility;
 import util.events.testevents.UILogicRefreshEvent;
 import util.events.testevents.UpdateDummyRepoEvent;
@@ -49,6 +50,7 @@ public class IssuePanelTests extends UITest {
         selectAll();
         type("sort:date");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         press(JUMP_TO_FIRST_ISSUE);
         push(KeyCode.DOWN).push(KeyCode.DOWN);
         sleep(EVENT_DELAY);
@@ -68,6 +70,7 @@ public class IssuePanelTests extends UITest {
         selectAll();
         type("id:8");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         // Issue #8 was assigned label 11, but it was removed
         try {
             GuiTest.exists("Label 11");
@@ -86,6 +89,7 @@ public class IssuePanelTests extends UITest {
         click("#dummy/dummy_col0_filterTextField");
         selectAll();
         type("id:9 updated:5");
+        PlatformEx.waitOnFxThread();
         push(KeyCode.ENTER);
         waitUntilNodeAppears("Deleted");
         // We should see the "Deleted" label with the proper color despite the label having been deleted.
@@ -170,6 +174,7 @@ public class IssuePanelTests extends UITest {
         selectAll();
         type("id:11");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(true, GuiTest.exists("User 11"));
         // arrow to indicate assignment i.e. author -> assignee
         assertEquals(true, GuiTest.exists("\uf03e"));
@@ -182,6 +187,7 @@ public class IssuePanelTests extends UITest {
         selectAll();
         type("id:12");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         // author should not show since it is an issue
         try {
             GuiTest.exists("User 12");

--- a/src/test/java/guitests/KeyboardShortcutsTest.java
+++ b/src/test/java/guitests/KeyboardShortcutsTest.java
@@ -182,6 +182,7 @@ public class KeyboardShortcutsTest extends UITest {
         click("#dummy/dummy_col1_filterTextField");
         type("id:5");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         press(JUMP_TO_FIRST_ISSUE);
         push(getKeyCode("MARK_AS_READ"));
         // focus should remain at the only issue shown

--- a/src/test/java/guitests/RemovableRepoListAndModelsTest.java
+++ b/src/test/java/guitests/RemovableRepoListAndModelsTest.java
@@ -101,6 +101,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
         selectAll();
         type("repo:dummY/Dummy");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(ui.getCurrentlyUsedRepos().size(), noOfUsedRepo);
         assertEquals(ui.logic.getOpenRepositories().size(), noOfUsedRepo);
         assertEquals(removeRepoMenu.getItems().size(), totalRepoInSystem + 1);
@@ -114,6 +115,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
         selectAll();
         type("repo:dummy2/dummy2");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(ui.getCurrentlyUsedRepos().size(), noOfUsedRepo);
         assertEquals(ui.logic.getOpenRepositories().size(), noOfUsedRepo);
         assertEquals(removeRepoMenu.getItems().size(), totalRepoInSystem + 1);
@@ -128,6 +130,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
         press(KeyCode.SHIFT).press(KeyCode.BACK_SLASH).release(KeyCode.BACK_SLASH).release(KeyCode.SHIFT);
         type(" repo:dummy3/dummy3)");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(ui.getCurrentlyUsedRepos().size(), noOfUsedRepo);
         assertEquals(ui.logic.getOpenRepositories().size(), noOfUsedRepo);
         assertEquals(removeRepoMenu.getItems().size(), totalRepoInSystem + 1);
@@ -143,6 +146,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
         selectAll();
         type("repo:dummy4/dummy4");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(ui.getCurrentlyUsedRepos().size(), noOfUsedRepo);
         assertEquals(ui.logic.getOpenRepositories().size(), noOfUsedRepo);
         assertEquals(removeRepoMenu.getItems().size(), totalRepoInSystem + 1);
@@ -155,6 +159,7 @@ public class RemovableRepoListAndModelsTest extends UITest {
         selectAll();
         type("repo:duMMY/duMMY");
         push(KeyCode.ENTER);
+        PlatformEx.waitOnFxThread();
         assertEquals(ui.getCurrentlyUsedRepos().size(), noOfUsedRepo);
         assertEquals(ui.logic.getOpenRepositories().size(), noOfUsedRepo);
         assertEquals(removeRepoMenu.getItems().size(), totalRepoInSystem + 1); // remove would not decrease

--- a/src/test/java/guitests/UIEventTests.java
+++ b/src/test/java/guitests/UIEventTests.java
@@ -5,10 +5,8 @@ import javafx.scene.input.KeyCode;
 import org.junit.Test;
 import ui.UI;
 import ui.components.KeyboardShortcuts;
-import util.events.IssueCreatedEventHandler;
-import util.events.LabelCreatedEventHandler;
-import util.events.MilestoneCreatedEventHandler;
-import util.events.PanelClickedEventHandler;
+import util.PlatformEx;
+import util.events.*;
 import util.events.testevents.PrimaryRepoChangedEvent;
 import util.events.testevents.PrimaryRepoChangedEventHandler;
 


### PR DESCRIPTION
Fixes #1322.

Created a new event FilterExceptionEvent which is triggered by processPanels (possibly multiple times, once for each erroneous panel) when there is an error in filtering.