### PR TITLE
Minor refactoring of Label Picker #1318 #1324

### DIFF
--- a/src/main/java/backend/resource/TurboLabel.java
+++ b/src/main/java/backend/resource/TurboLabel.java
@@ -95,6 +95,17 @@ public class TurboLabel implements Comparable<TurboLabel> {
         return firstMatchingLabel.get();
     }
 
+    /**
+     * @param allLabels
+     * @param names
+     * @return list of labels in allLabels that matches list of names
+     */
+    public static List<TurboLabel> generateLabels(List<TurboLabel> allLabels, List<String> names) {
+        return allLabels.stream()
+            .filter(label -> names.contains(label.getFullName()))
+            .collect(Collectors.toList());
+    }
+
     public static List<String> getLabelsNameList(List<TurboLabel> labels) {
         return labels.stream()
                 .map(TurboLabel::getFullName)
@@ -149,17 +160,6 @@ public class TurboLabel implements Comparable<TurboLabel> {
         newMatchedLabels = filterByNameQuery(newMatchedLabels, extractedNames[2]);
         newMatchedLabels = filterByGroupQuery(newMatchedLabels, extractedNames[0]);
         return newMatchedLabels;
-    }
-
-    /**
-     * A label is matching if:
-     * the label's group contains keyword's group and label's name contains keyword's name
-     * @param allLabels
-     * @param keyword
-     * @return true if there is at least 1 matching label for the keyword
-     */
-    public static final boolean hasMatchedLabel(List<TurboLabel> allLabels, String keyword) {
-        return !getMatchedLabels(allLabels, keyword).isEmpty();
     }
 
     /**

--- a/src/main/java/backend/resource/TurboLabel.java
+++ b/src/main/java/backend/resource/TurboLabel.java
@@ -95,18 +95,8 @@ public class TurboLabel implements Comparable<TurboLabel> {
         return firstMatchingLabel.get();
     }
 
-    /**
-     * @param allLabels
-     * @param names
-     * @return list of labels in allLabels that matches list of names
-     */
-    public static List<TurboLabel> generateLabels(List<TurboLabel> allLabels, List<String> names) {
-        return allLabels.stream()
-            .filter(label -> names.contains(label.getFullName()))
-            .collect(Collectors.toList());
-    }
 
-    public static List<String> getLabelsNameList(List<TurboLabel> labels) {
+    public static List<String> getLabelNames(List<TurboLabel> labels) {
         return labels.stream()
                 .map(TurboLabel::getFullName)
                 .collect(Collectors.toList());
@@ -160,6 +150,17 @@ public class TurboLabel implements Comparable<TurboLabel> {
         newMatchedLabels = filterByNameQuery(newMatchedLabels, extractedNames[2]);
         newMatchedLabels = filterByGroupQuery(newMatchedLabels, extractedNames[0]);
         return newMatchedLabels;
+    }
+
+    /**
+     * @param allLabels
+     * @param labelNames
+     * @return list of labels in allLabels that matches list of label names
+     */
+    public static List<TurboLabel> getMatchedLabels(List<TurboLabel> allLabels, List<String> labelNames) {
+        return allLabels.stream()
+            .filter(label -> labelNames.contains(label.getFullName()))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -275,7 +275,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         setResultConverter(dialogButton -> {
             if (dialogButton == confirmButtonType) {
                 // Ensures the last keyword in the query is toggled after confirmation
-                queryField.appendText(" ");
+                if (!queryField.isDisabled()) queryField.appendText(" ");
                 return TurboLabel.getLabelsNameList(state.getAssignedLabels());
             }
             return null;
@@ -332,7 +332,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
     private void handleLabelClick(String labelName) {
         queryField.setDisable(true);
         state.updateAssignedLabels(
-            Optional.of(TurboLabel.getFirstMatchingTurboLabel(allLabels, labelName)));
+            Optional.of(TurboLabel.getMatchedLabels(allLabels, labelName).get(0)));
         populatePanes(state);
     }
 }

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -252,7 +252,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
      * @param stage
      */
     private final void positionDialog(Stage stage) {
-        setX(stage.getX() + stage.getWidth() / 2 - getWidth() / 2);
+        setX(stage.getX() + stage.getWidth() / 2);
         setY(stage.getY() + stage.getHeight() / 2 - getHeight() / 2);
     }
 

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -81,6 +81,8 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         initModality(Modality.APPLICATION_MODAL);
         setTitle("Edit Labels for " + (issue.isPullRequest() ? "PR #" : "Issue #") +
                 issue.getId() + " in " + issue.getRepoId());
+        // Ensures height and width of dialog has been initialized before positioning
+        Platform.runLater(() -> positionDialog(stage));
     }
 
     private void setDialogPaneContent(TurboIssue issue) {
@@ -245,6 +247,15 @@ public class LabelPickerDialog extends Dialog<List<String>> {
                 .faded(!matchedLabels.contains(repoLabel))
                 .highlighted(suggestion.isPresent() && suggestion.get().equals(repoLabel))
                 .selected(assignedLabels.contains(repoLabel)));
+    }
+
+    /**
+     * Positions dialog based on width and height of stage
+     * @param stage
+     */
+    private final void positionDialog(Stage stage) {
+        setX(stage.getX() + stage.getWidth() / 2 - getWidth() / 2);
+        setY(stage.getY() + stage.getHeight() / 2 - getHeight() / 2);
     }
 
     private void createMainLayout() {

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -71,7 +71,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         title.setTooltip(createTitleTooltip(issue));
         createButtons();
 
-        state = new LabelPickerState(TurboLabel.generateLabels(allLabels, issue.getLabels()), allLabels, "");
+        state = new LabelPickerState(TurboLabel.getMatchedLabels(allLabels, issue.getLabels()), allLabels, "");
         populatePanes(state);
     }
 
@@ -183,7 +183,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
 
     private final boolean hasNewSuggestion(List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         return suggestion.isPresent() 
-            && !(TurboLabel.generateLabels(allLabels, issue.getLabels())).contains(suggestion.get()) 
+            && !(TurboLabel.getMatchedLabels(allLabels, issue.getLabels())).contains(suggestion.get()) 
             && !addedLabels.contains(suggestion.get());
     }
 
@@ -248,7 +248,8 @@ public class LabelPickerDialog extends Dialog<List<String>> {
     }
 
     /**
-     * Positions dialog based on width and height of stage
+     * Positions dialog based on width and height of stage to avoid dialog appearing off-screen on certain computers
+     * if default position is used
      * @param stage
      */
     private final void positionDialog(Stage stage) {
@@ -276,7 +277,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
             if (dialogButton == confirmButtonType) {
                 // Ensures the last keyword in the query is toggled after confirmation
                 if (!queryField.isDisabled()) queryField.appendText(" ");
-                return TurboLabel.getLabelsNameList(state.getAssignedLabels());
+                return TurboLabel.getLabelNames(state.getAssignedLabels());
             }
             return null;
         });
@@ -325,14 +326,14 @@ public class LabelPickerDialog extends Dialog<List<String>> {
      */
     private final void handleUserInput(String query) {
         state = new LabelPickerState(
-            TurboLabel.generateLabels(allLabels, issue.getLabels()), allLabels, query.toLowerCase());
+            TurboLabel.getMatchedLabels(allLabels, issue.getLabels()), allLabels, query.toLowerCase());
         populatePanes(state);
     }
 
     private void handleLabelClick(String labelName) {
         queryField.setDisable(true);
-        state.updateAssignedLabels(
-            Optional.of(TurboLabel.getMatchedLabels(allLabels, labelName).get(0)));
+        TurboLabel.getMatchedLabels(allLabels, labelName)
+            .stream().findFirst().ifPresent(state::updateAssignedLabels);
         populatePanes(state);
     }
 }

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -321,7 +321,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
 
     private void handleLabelClick(PickerLabel label) {
         queryField.setDisable(true);
-        state.updateAssignedLabels(label);
+        state.updateAssignedLabels(Optional.of(label));
         populatePanes(state);
     }
 }

--- a/src/main/java/ui/components/pickers/LabelPickerDialog.java
+++ b/src/main/java/ui/components/pickers/LabelPickerDialog.java
@@ -15,7 +15,6 @@ import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,7 +71,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         title.setTooltip(createTitleTooltip(issue));
         createButtons();
 
-        state = new LabelPickerState(new HashSet<>(issue.getLabels()), allLabels, "");
+        state = new LabelPickerState(TurboLabel.generateLabels(allLabels, issue.getLabels()), allLabels, "");
         populatePanes(state);
     }
 
@@ -106,8 +105,8 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         getDialogPane().getScene().getWindow().sizeToScene();
     }
 
-    private final void populateAssignedLabels(List<String> initialLabels, List<String> removedLabels,
-                                        List<String> addedLabels, Optional<String> suggestion) {
+    private final void populateAssignedLabels(List<TurboLabel> initialLabels, List<TurboLabel> removedLabels,
+                                        List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         assignedLabels.getChildren().clear();
         populateInitialLabels(initialLabels, removedLabels, suggestion);
         populateToBeAddedLabels(addedLabels, suggestion);
@@ -116,16 +115,16 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         }
     }
 
-    private final void populateInitialLabels(List<String> initialLabels, List<String> removedLabels,
-                                       Optional<String> suggestion) {
+    private final void populateInitialLabels(List<TurboLabel> initialLabels, List<TurboLabel> removedLabels,
+                                       Optional<TurboLabel> suggestion) {
         initialLabels.stream()
             .forEach(label -> assignedLabels.getChildren()
             .add(processInitialLabel(label, removedLabels, suggestion)));
     }
 
-    private final Node processInitialLabel(String initialLabel, List<String> removedLabels, 
-                                            Optional<String> suggestion) {
-        TurboLabel repoInitialLabel = TurboLabel.getFirstMatchingTurboLabel(allLabels, initialLabel);
+    private final Node processInitialLabel(TurboLabel initialLabel, List<TurboLabel> removedLabels, 
+                                            Optional<TurboLabel> suggestion) {
+        TurboLabel repoInitialLabel = TurboLabel.getFirstMatchingTurboLabel(allLabels, initialLabel.getFullName());
         if (!removedLabels.contains(initialLabel)) {
             if (suggestion.isPresent() && initialLabel.equals(suggestion.get())) {
                 return getPickerLabelNode(
@@ -147,11 +146,11 @@ public class LabelPickerDialog extends Dialog<List<String>> {
      */
     private final Node getPickerLabelNode(PickerLabel label) {
         Node node = label.getNode();
-        node.setOnMouseClicked(e -> handleLabelClick(label));
+        node.setOnMouseClicked(e -> handleLabelClick(label.getFullName()));
         return node;
     }
 
-    private final void populateToBeAddedLabels(List<String> addedLabels, Optional<String> suggestion) {
+    private final void populateToBeAddedLabels(List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         if (!addedLabels.isEmpty() || hasNewSuggestion(addedLabels, suggestion)) {
             assignedLabels.getChildren().add(new Label("|"));
         }
@@ -159,49 +158,50 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         populateSuggestedLabel(addedLabels, suggestion);
     }
 
-    private final void populateAddedLabels(List<String> addedLabels, Optional<String> suggestion) {
+    private final void populateAddedLabels(List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         addedLabels.stream()
                 .forEach(label -> {
                     assignedLabels.getChildren().add(processAddedLabel(label, suggestion));
                 });
     }
 
-    private final Node processAddedLabel(String addedLabel, Optional<String> suggestion) {
+    private final Node processAddedLabel(TurboLabel addedLabel, Optional<TurboLabel> suggestion) {
         if (!suggestion.isPresent() || !addedLabel.equals(suggestion.get())) {
             return getPickerLabelNode(
-                new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, addedLabel), true));
+                new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, addedLabel.getFullName()), true));
         }
         return getPickerLabelNode(
-                new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, addedLabel), true)
+                new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, addedLabel.getFullName()), true)
                 .faded(true).removed(true));
     }
 
-    private final void populateSuggestedLabel(List<String> addedLabels, Optional<String> suggestion) {
+    private final void populateSuggestedLabel(List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         if (hasNewSuggestion(addedLabels, suggestion)) {
             assignedLabels.getChildren().add(processSuggestedLabel(suggestion.get()));
         }
     }
 
-    private final boolean hasNewSuggestion(List<String> addedLabels, Optional<String> suggestion) {
+    private final boolean hasNewSuggestion(List<TurboLabel> addedLabels, Optional<TurboLabel> suggestion) {
         return suggestion.isPresent() 
-            && !(issue.getLabels()).contains(suggestion.get()) && !addedLabels.contains(suggestion.get());
+            && !(TurboLabel.generateLabels(allLabels, issue.getLabels())).contains(suggestion.get()) 
+            && !addedLabels.contains(suggestion.get());
     }
 
-    private final Node processSuggestedLabel(String suggestedLabel) {
+    private final Node processSuggestedLabel(TurboLabel suggestedLabel) {
         return getPickerLabelNode(
-             new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, suggestedLabel), true)
+             new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, suggestedLabel.getFullName()), true)
              .faded(true));
     }
 
-    private final void populateFeedbackLabels(List<String> assignedLabels, List<String> matchedLabels,
-                                        Optional<String> suggestion) {
+    private final void populateFeedbackLabels(List<TurboLabel> assignedLabels, List<TurboLabel> matchedLabels,
+                                        Optional<TurboLabel> suggestion) {
         feedbackLabels.getChildren().clear();
         populateGroupLabels(assignedLabels, matchedLabels, suggestion);
         populateGrouplessLabels(assignedLabels, matchedLabels, suggestion);
     }
 
-    private final void populateGroupLabels(List<String> finalLabels, List<String> matchedLabels,
-                                     Optional<String> suggestion) {
+    private final void populateGroupLabels(List<TurboLabel> finalLabels, List<TurboLabel> matchedLabels,
+                                     Optional<TurboLabel> suggestion) {
 
         Map<String, FlowPane> groupContent = getGroupContent(finalLabels, matchedLabels, suggestion);
         groupContent.entrySet().forEach(entry -> {
@@ -210,40 +210,38 @@ public class LabelPickerDialog extends Dialog<List<String>> {
         });
     }
 
-    private final Map<String, FlowPane> getGroupContent(List<String> finalLabels, List<String> matchedLabels,
-                                                  Optional<String> suggestion) {
+    private final Map<String, FlowPane> getGroupContent(List<TurboLabel> finalLabels, List<TurboLabel> matchedLabels,
+                                                  Optional<TurboLabel> suggestion) {
         Map<String, FlowPane> groupContent = new HashMap<>();
         allLabels.stream().sorted()
                 .filter(label -> label.isInGroup())
-                .map(label -> new PickerLabel(label, false))
                 .forEach(label -> {
                     String group = label.getGroupName();
                     if (!groupContent.containsKey(group)) {
                         groupContent.put(group, createGroupPane(GROUP_PAD));
                     }
                     groupContent.get(group).getChildren().add(processMatchedLabel(
-                        label.getFullName(), matchedLabels, finalLabels, suggestion));
+                        label, matchedLabels, finalLabels, suggestion));
                 });
         return groupContent;
     }
 
-    private final void populateGrouplessLabels(List<String> finalLabels, List<String> matchedLabels,
-                                         Optional<String> suggestion) {
+    private final void populateGrouplessLabels(List<TurboLabel> finalLabels, List<TurboLabel> matchedLabels,
+                                         Optional<TurboLabel> suggestion) {
         FlowPane groupless = createGroupPane(GROUPLESS_PAD);
         allLabels.stream()
-                .filter(label -> !label.isInGroup())
-                .map(label -> new PickerLabel(label, false))
-                .forEach(label -> groupless.getChildren().add(processMatchedLabel(
-                    label.getFullName(), matchedLabels, finalLabels, suggestion)));
+            .filter(label -> !label.isInGroup())
+            .forEach(label -> groupless.getChildren().add(processMatchedLabel(
+                label, matchedLabels, finalLabels, suggestion)));
 
         feedbackLabels.getChildren().add(groupless);
     }
 
-    private final Node processMatchedLabel(String repoLabel, List<String> matchedLabels, 
-                                            List<String> assignedLabels, Optional<String> suggestion) {
+    private final Node processMatchedLabel(TurboLabel repoLabel, List<TurboLabel> matchedLabels, 
+                                           List<TurboLabel> assignedLabels, Optional<TurboLabel> suggestion) {
 
         return getPickerLabelNode(
-            new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, repoLabel), false)
+            new PickerLabel(TurboLabel.getFirstMatchingTurboLabel(allLabels, repoLabel.getFullName()), false)
                 .faded(!matchedLabels.contains(repoLabel))
                 .highlighted(suggestion.isPresent() && suggestion.get().equals(repoLabel))
                 .selected(assignedLabels.contains(repoLabel)));
@@ -278,7 +276,7 @@ public class LabelPickerDialog extends Dialog<List<String>> {
             if (dialogButton == confirmButtonType) {
                 // Ensures the last keyword in the query is toggled after confirmation
                 queryField.appendText(" ");
-                return state.getAssignedLabels();
+                return TurboLabel.getLabelsNameList(state.getAssignedLabels());
             }
             return null;
         });
@@ -326,13 +324,15 @@ public class LabelPickerDialog extends Dialog<List<String>> {
      * Updates state of the label picker based on the entire query
      */
     private final void handleUserInput(String query) {
-        state = new LabelPickerState(new HashSet<>(issue.getLabels()), allLabels, query.toLowerCase());
+        state = new LabelPickerState(
+            TurboLabel.generateLabels(allLabels, issue.getLabels()), allLabels, query.toLowerCase());
         populatePanes(state);
     }
 
-    private void handleLabelClick(PickerLabel label) {
+    private void handleLabelClick(String labelName) {
         queryField.setDisable(true);
-        state.updateAssignedLabels(Optional.of(label));
+        state.updateAssignedLabels(
+            Optional.of(TurboLabel.getFirstMatchingTurboLabel(allLabels, labelName)));
         populatePanes(state);
     }
 }

--- a/src/main/java/ui/components/pickers/LabelPickerState.java
+++ b/src/main/java/ui/components/pickers/LabelPickerState.java
@@ -11,22 +11,22 @@ import java.util.stream.Collectors;
  */
 public class LabelPickerState {
 
-    private Set<String> initialLabels;
-    private List<String> addedLabels;
-    private List<String> removedLabels;
-    private List<String> matchedLabels;
+    private List<TurboLabel> initialLabels;
+    private List<TurboLabel> addedLabels;
+    private List<TurboLabel> removedLabels;
+    private List<TurboLabel> matchedLabels;
     private List<TurboLabel> allLabels;
     private OptionalInt currentSuggestionIndex;
 
-    public LabelPickerState(Set<String> initialLabels, List<TurboLabel> allLabels, String userInput) {
+    public LabelPickerState(List<TurboLabel> initialLabels, List<TurboLabel> allLabels, String userInput) {
         this(initialLabels, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), allLabels,
                 OptionalInt.empty());
         update(userInput);
     }
 
-    private LabelPickerState(Set<String> initialLabels, List<String> addedLabels, List<String> removedLabels,
-                             List<String> matchedLabels, List<TurboLabel> allLabels, 
-                             OptionalInt currentSuggestionIndex) {
+    private LabelPickerState(List<TurboLabel> initialLabels, List<TurboLabel> addedLabels, 
+                             List<TurboLabel> removedLabels, List<TurboLabel> matchedLabels, 
+                             List<TurboLabel> allLabels, OptionalInt currentSuggestionIndex) {
         this.initialLabels = initialLabels;
         this.addedLabels = addedLabels;
         this.removedLabels = removedLabels;
@@ -59,21 +59,21 @@ public class LabelPickerState {
     public final void updateAssignedLabels(Optional<TurboLabel> label) {
         if (!label.isPresent()) return;
 
-        String labelName = label.get().getFullName();
-        if (isAnInitialLabel(labelName)) {
-            if (isARemovedLabel(labelName)) {
-                removeConflictingLabels(label.get());
-                removedLabels.remove(labelName);
+        TurboLabel selectedLabel = label.get();
+        if (isAnInitialLabel(selectedLabel)) {
+            if (isARemovedLabel(selectedLabel)) {
+                removeConflictingLabels(selectedLabel);
+                removedLabels.remove(selectedLabel);
             } else {
-                removedLabels.add(labelName);
+                removedLabels.add(selectedLabel);
             }
         } else {
-            if (isAnAddedLabel(labelName)) {
-                addedLabels.remove(labelName);
+            if (isAnAddedLabel(selectedLabel)) {
+                addedLabels.remove(selectedLabel);
             } else {
                 // add new label
-                removeConflictingLabels(label.get());
-                addedLabels.add(labelName);
+                removeConflictingLabels(selectedLabel);
+                addedLabels.add(selectedLabel);
             }
         }
     }
@@ -84,8 +84,7 @@ public class LabelPickerState {
      * @param keyword
      */
     private final void updateMatchedLabels(String keyword) {
-        List<TurboLabel> newMatchedLabels = TurboLabel.getMatchedLabels(allLabels, keyword);
-        matchedLabels = TurboLabel.getLabelsNameList(newMatchedLabels);
+        matchedLabels = TurboLabel.getMatchedLabels(allLabels, keyword);
     }
 
     /**
@@ -93,7 +92,7 @@ public class LabelPickerState {
      * @param keyword
      * @param newMatchedLabels
      */
-    private final void updateSuggestionIndex(String keyword, List<String> newMatchedLabels) {
+    private final void updateSuggestionIndex(String keyword, List<TurboLabel> newMatchedLabels) {
         if (keyword.isEmpty() || newMatchedLabels.isEmpty()) {
             currentSuggestionIndex = OptionalInt.empty();
         } else {
@@ -108,8 +107,8 @@ public class LabelPickerState {
     /**
      * @return final list of labels to be assigned
      */
-    public List<String> getAssignedLabels() {
-        List<String> assignedLabels = new ArrayList<>();
+    public List<TurboLabel> getAssignedLabels() {
+        List<TurboLabel> assignedLabels = new ArrayList<>();
         assignedLabels.addAll(initialLabels);
         assignedLabels.addAll(addedLabels);
         assignedLabels.removeAll(removedLabels);
@@ -119,28 +118,28 @@ public class LabelPickerState {
     /**
      * @return the initial list of labels
      */
-    public List<String> getInitialLabels() {
-        return new ArrayList<>(initialLabels);
+    public List<TurboLabel> getInitialLabels() {
+        return initialLabels;
     }
 
     /**
      * @return the list of initial labels that have been removed
      */
-    public List<String> getRemovedLabels() {
+    public List<TurboLabel> getRemovedLabels() {
         return removedLabels;
     }
 
     /**
      * @return the list of labels that are newly added
      */
-    public List<String> getAddedLabels() {
+    public List<TurboLabel> getAddedLabels() {
         return addedLabels;
     }
 
     /**
      * @return the name of the suggested label, if it exists
      */
-    public Optional<String> getCurrentSuggestion() {
+    public Optional<TurboLabel> getCurrentSuggestion() {
         if (currentSuggestionIndex.isPresent()) {
             assert isValidSuggestionIndex();
             return Optional.of(getSuggestedLabel());
@@ -151,7 +150,7 @@ public class LabelPickerState {
     /**
      * @return the names of the labels that match the current query
      */
-    public List<String> getMatchedLabels() {
+    public List<TurboLabel> getMatchedLabels() {
         return matchedLabels;
     }
 
@@ -159,38 +158,38 @@ public class LabelPickerState {
      * Removes labels that belong to the same group as the given label
      * @param label
      */
-    private void removeConflictingLabels(TurboLabel label) {
-        if (!label.isInExclusiveGroup()) return;
+    private void removeConflictingLabels(TurboLabel targetLabel) {
+        if (!targetLabel.isInExclusiveGroup()) return;
 
-        String group = label.getGroupName();
+        String group = targetLabel.getGroupName();
         // Remove from addedLabels
         addedLabels = addedLabels.stream()
-                .filter(name -> !new TurboLabel("", name).getGroupName().equals(group))
+                .filter(label -> !label.getGroupName().equals(group))
                 .collect(Collectors.toList());
 
         // Add to removedLabels all initialLabels that have conflicting group
         removedLabels.addAll(initialLabels.stream()
-                .filter(name -> new TurboLabel("", name).getGroupName().equals(group) 
-                    && !removedLabels.contains(label.getFullName()))
+                .filter(label -> label.getGroupName().equals(group) 
+                    && !removedLabels.contains(targetLabel))
                 .collect(Collectors.toList()));
     }
 
-    private boolean isAnInitialLabel(String name) {
-        return this.initialLabels.contains(name);
+    private boolean isAnInitialLabel(TurboLabel label) {
+        return this.initialLabels.contains(label);
     }
 
-    private boolean isAnAddedLabel(String name) {
-        return this.addedLabels.contains(name);
+    private boolean isAnAddedLabel(TurboLabel label) {
+        return this.addedLabels.contains(label);
     }
 
-    private boolean isARemovedLabel(String name) {
-        return this.removedLabels.contains(name);
+    private boolean isARemovedLabel(TurboLabel label) {
+        return this.removedLabels.contains(label);
     }
 
     /**
      * @return suggested label 
      */
-    private String getSuggestedLabel() {
+    private TurboLabel getSuggestedLabel() {
         return matchedLabels.get(currentSuggestionIndex.getAsInt());
     }
 

--- a/src/main/java/ui/components/pickers/LabelPickerState.java
+++ b/src/main/java/ui/components/pickers/LabelPickerState.java
@@ -42,7 +42,7 @@ public class LabelPickerState {
     private final void update(String userInput) {
         List<String> confirmedKeywords = getConfirmedKeywords(userInput);
         for (String confirmedKeyword : confirmedKeywords) {
-            updateIfMatchesLabel(confirmedKeyword);
+            updateAssignedLabels(Optional.ofNullable(TurboLabel.getMatchedLabels(allLabels, confirmedKeyword).get(0)));
         }
 
         Optional<String> keywordInProgess = getKeywordInProgress(userInput);
@@ -53,26 +53,16 @@ public class LabelPickerState {
     }
 
     /**
-     * Updates current state if there is at least one matching label based on the 
-     * given keyword
-     * @param keyword
-     */
-    private final void updateIfMatchesLabel(String keyword) {
-        if (TurboLabel.hasMatchedLabel(allLabels, keyword)) {
-            updateAssignedLabels(TurboLabel.getFirstMatchingTurboLabel(allLabels, keyword));
-        }
-    }
-
-    /**
      * Updates assignedLabels based on properties of a label 
      * @param label
      */
-    public final void updateAssignedLabels(TurboLabel label) {
-        String labelName = label.getFullName();
+    public final void updateAssignedLabels(Optional<TurboLabel> label) {
+        if (!label.isPresent()) return;
 
+        String labelName = label.get().getFullName();
         if (isAnInitialLabel(labelName)) {
             if (isARemovedLabel(labelName)) {
-                removeConflictingLabels(label);
+                removeConflictingLabels(label.get());
                 removedLabels.remove(labelName);
             } else {
                 removedLabels.add(labelName);
@@ -82,7 +72,7 @@ public class LabelPickerState {
                 addedLabels.remove(labelName);
             } else {
                 // add new label
-                removeConflictingLabels(label);
+                removeConflictingLabels(label.get());
                 addedLabels.add(labelName);
             }
         }

--- a/src/main/java/ui/components/pickers/LabelPickerState.java
+++ b/src/main/java/ui/components/pickers/LabelPickerState.java
@@ -42,7 +42,8 @@ public class LabelPickerState {
     private final void update(String userInput) {
         List<String> confirmedKeywords = getConfirmedKeywords(userInput);
         for (String confirmedKeyword : confirmedKeywords) {
-            updateAssignedLabels(Optional.ofNullable(TurboLabel.getMatchedLabels(allLabels, confirmedKeyword).get(0)));
+            TurboLabel.getMatchedLabels(allLabels, confirmedKeyword)
+                .stream().findFirst().ifPresent(this::updateAssignedLabels);
         }
 
         Optional<String> keywordInProgess = getKeywordInProgress(userInput);
@@ -56,10 +57,7 @@ public class LabelPickerState {
      * Updates assignedLabels based on properties of a label 
      * @param label
      */
-    public final void updateAssignedLabels(Optional<TurboLabel> label) {
-        if (!label.isPresent()) return;
-
-        TurboLabel selectedLabel = label.get();
+    public final void updateAssignedLabels(TurboLabel selectedLabel) {
         if (isAnInitialLabel(selectedLabel)) {
             if (isARemovedLabel(selectedLabel)) {
                 removeConflictingLabels(selectedLabel);

--- a/src/test/java/tests/LabelPickerStateTests.java
+++ b/src/test/java/tests/LabelPickerStateTests.java
@@ -54,21 +54,15 @@ public class LabelPickerStateTests {
 
 
     private LabelPickerState setupState(String userInput, String... labelNames) {
-        return new LabelPickerState(getLabelsFromNames(Arrays.asList(labelNames)), getTestRepoLabels(), userInput);
+        return new LabelPickerState(getLabelsFromNames(labelNames), getTestRepoLabels(), userInput);
     }
 
     private List<TurboLabel> getTestRepoLabels() {
-        List<String> labelNames = getArrayList("priority.high", "priority.medium", "priority.low", 
-                                               "highest", "Problem.Heavy", "f-aaa", "f-bbb");
-        return getLabelsFromNames(labelNames);
+        return getLabelsFromNames("priority.high", "priority.medium", "priority.low", "highest", 
+                                  "Problem.Heavy", "f-aaa", "f-bbb");
     }
 
-    private List<TurboLabel> getLabelsFromNames(List<String> names) {
-        return names.stream().map(name -> new TurboLabel("", name)).collect(Collectors.toList());
+    private List<TurboLabel> getLabelsFromNames(String... names) {
+        return Arrays.asList(names).stream().map(name -> new TurboLabel("", name)).collect(Collectors.toList());
     }
-
-    private List<String> getArrayList(String... labelNames) {
-        return Arrays.asList(labelNames);
-    }
-
 }

--- a/src/test/java/tests/LabelPickerStateTests.java
+++ b/src/test/java/tests/LabelPickerStateTests.java
@@ -5,11 +5,8 @@ import org.junit.Test;
 import backend.resource.TurboLabel;
 import ui.components.pickers.LabelPickerState;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -42,10 +39,10 @@ public class LabelPickerStateTests {
     public void determineState_exclusiveLabels_removeConflictingLabels() {
         LabelPickerState state = setupState("p.medium ", "priority.low");
         assertEquals(1, state.getInitialLabels().size());
-        assertEquals("priority.medium", state.getAddedLabels().get(0));
+        assertEquals(new TurboLabel("", "priority.medium"), state.getAddedLabels().get(0));
         assertEquals(1, state.getAddedLabels().size());
         assertEquals(1, state.getRemovedLabels().size());
-        assertTrue(state.getRemovedLabels().contains("priority.low"));
+        assertTrue(state.getRemovedLabels().contains(new TurboLabel("", "priority.low")));
     }
 
     @Test
@@ -57,18 +54,17 @@ public class LabelPickerStateTests {
 
 
     private LabelPickerState setupState(String userInput, String... labelNames) {
-        return new LabelPickerState(getHashSet(labelNames), getTestRepoLabels(), userInput);
+        return new LabelPickerState(getLabelsFromNames(Arrays.asList(labelNames)), getTestRepoLabels(), userInput);
     }
 
     private List<TurboLabel> getTestRepoLabels() {
         List<String> labelNames = getArrayList("priority.high", "priority.medium", "priority.low", 
                                                "highest", "Problem.Heavy", "f-aaa", "f-bbb");
-
-        return labelNames.stream().map(name -> new TurboLabel("", name)).collect(Collectors.toList());
+        return getLabelsFromNames(labelNames);
     }
 
-    private Set<String> getHashSet(String... labelNames) {
-        return new HashSet<>(Arrays.asList(labelNames));
+    private List<TurboLabel> getLabelsFromNames(List<String> names) {
+        return names.stream().map(name -> new TurboLabel("", name)).collect(Collectors.toList());
     }
 
     private List<String> getArrayList(String... labelNames) {

--- a/src/test/java/tests/TurboLabelTest.java
+++ b/src/test/java/tests/TurboLabelTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -64,7 +65,7 @@ public class TurboLabelTest {
         labels.add(test2);
 
         // Ensures result matches each label actual name even with delimiter
-        assertEquals(Arrays.asList("test.a", "dummy-a"), TurboLabel.getLabelsNameList(labels));
+        assertEquals(Arrays.asList("test.a", "dummy-a"), TurboLabel.getLabelNames(labels));
     }
 
     @Test
@@ -73,6 +74,15 @@ public class TurboLabelTest {
         assertFalse(test.isInGroup());
     }
 
+
+    @Test
+    public void getMatchedLabels_withLabelNames() {
+        List<String> labelNames = Arrays.asList("homework", "lab");
+        List<TurboLabel> labels = labelNames.stream()
+            .map(name -> new TurboLabel("", name)).collect(Collectors.toList());
+        
+        assertEquals(labels, TurboLabel.getMatchedLabels(labels, labelNames));
+    }
 
     private void testWithDelimiter(String delimiter, boolean shouldBeExclusive) {
         // label format: group.name


### PR DESCRIPTION
Fixes #1318, fixes #1324 and fixes #1327

## Changes
- Remove `updateIfMatchesLabel` in favour of `updateAssignedLabels` with `Optional<TurboLabel>` as argument
- Positions dialog to centre of stage upon launched
- Replace `List<String>` with `List<TurboLabel>`

