### PR TITLE
F1 key doesn't work when the focus is in a filter box #1167

### DIFF
--- a/src/main/java/browserview/BrowserComponent.java
+++ b/src/main/java/browserview/BrowserComponent.java
@@ -220,6 +220,14 @@ public class BrowserComponent {
     }
 
     /**
+    * Navigates to HubTurbo filters doc page, run on separate thread.
+    */
+    public void showFilterDocs() {
+        logger.info("Showing filters documentation page");
+        runBrowserOperation(() -> driver.get(GitHubURL.FILTERS_PAGE, false));
+    }
+
+    /**
      * Navigates to the GitHub changelog page.
      * Run on a separate thread.
      */

--- a/src/main/java/ui/components/FilterTextField.java
+++ b/src/main/java/ui/components/FilterTextField.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static ui.components.KeyboardShortcuts.SHOW_DOCS;
+
 /**
  * A field augmented with the ability to revert edits, autocompletion, on-the-fly error
  * checking, and callbacks for various actions.
@@ -32,8 +34,9 @@ public class FilterTextField extends TextField {
     public static final String INVALID_FILTER_STYLE = "-fx-control-inner-background: #EE8993";
 
     // Callback functions
-    private Runnable cancel = () -> {};
-    private Function<String, String> confirm = (s) -> s;
+    private Runnable onCancel = () -> {};
+    private Runnable onShowDocs = () -> {};
+    private Function<String, String> onConfirm = (s) -> s;
 
     // For reverting edits
     private String previousText;
@@ -43,6 +46,7 @@ public class FilterTextField extends TextField {
 
     // For on-the-fly parsing and checking
     private final ValidationSupport validationSupport = new ValidationSupport();
+
 
     public FilterTextField(String initialText) {
         super(initialText);
@@ -81,10 +85,10 @@ public class FilterTextField extends TextField {
             }
         });
         setOnKeyPressed(e -> {
-             if (e.getCode() == KeyCode.TAB) {
+            if (e.getCode() == KeyCode.TAB) {
                  // Disable tab for UI traversal
                  e.consume();
-             }
+            }
         });
         setOnKeyReleased(e -> {
             e.consume();
@@ -92,10 +96,15 @@ public class FilterTextField extends TextField {
                 confirmEdit();
             } else if (e.getCode() == KeyCode.ESCAPE) {
                 if (getText().equals(previousText)) {
-                    cancel.run();
+                    onCancel.run();
                 } else {
                     revertEdit();
                 }
+            }
+        });
+        addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+            if (SHOW_DOCS.match(event)) {
+                onShowDocs.run();
             }
         });
     }
@@ -226,11 +235,11 @@ public class FilterTextField extends TextField {
     }
 
     /**
-     * Commits the current contents of the field. This triggers its 'confirm' callback.
+     * Commits the current contents of the field. This triggers its 'onConfirm' callback.
      */
     private void confirmEdit() {
         previousText = getText();
-        String newText = confirm.apply(getText());
+        String newText = onConfirm.apply(getText());
         int caretPosition = getCaretPosition();
         setText(newText);
         positionCaret(caretPosition);
@@ -245,21 +254,30 @@ public class FilterTextField extends TextField {
     }
 
     /**
-     * Sets the 'cancel' callback, which will be called with Esc is pressed and there is
+     * Sets the 'onCancel' callback, which will be called with Esc is pressed and there is
      * no edit to revert.
      */
-    public FilterTextField setOnCancel(Runnable cancel) {
-        this.cancel = cancel;
+    public FilterTextField setOnCancel(Runnable onCancel) {
+        this.onCancel = onCancel;
         return this;
     }
 
     /**
-     * Sets the 'confirm' callback, which will be called when Enter is pressed, or when the
+     * Sets the 'onConfirm' callback, which will be called when Enter is pressed, or when the
      * contents of the field are manually set with {@link #setFilterText}. The callback will
      * be passed the current contents of the field.
      */
-    public FilterTextField setOnConfirm(Function<String, String> confirm) {
-        this.confirm = confirm;
+    public FilterTextField setOnConfirm(Function<String, String> onConfirm) {
+        this.onConfirm = onConfirm;
+        return this;
+    }
+    
+    /**
+     * Sets the 'onShowDocs' callback, which will be called when the user triggers the show_docs
+     * keyboard shortcut event.
+     */
+    public FilterTextField setOnShowDocs(Runnable onShowDocs) {
+        this.onShowDocs = onShowDocs;
         return this;
     }
 

--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -125,12 +125,13 @@ public abstract class FilterPanel extends AbstractPanel {
 
     private Node createFilterBox() {
         filterTextField = new FilterTextField("")
+                .setOnCancel(this::requestFocus)
+                .setOnShowDocs(ui.getBrowserComponent()::showFilterDocs)
                 .setOnConfirm((text) -> {
                     Platform.runLater(() -> ui.triggerEvent(new ApplyingFilterEvent(this)));
                     applyStringFilter(text);
                     return text;
-                })
-                .setOnCancel(this::requestFocus);
+                });
         filterTextField.setId(guiController.getDefaultRepo() + "_col" + panelIndex + "_filterTextField");
         filterTextField.setMinWidth(388);
         filterTextField.setMaxWidth(388);

--- a/src/main/java/util/GitHubURL.java
+++ b/src/main/java/util/GitHubURL.java
@@ -3,10 +3,11 @@ package util;
 public final class GitHubURL {
 
     public static final String LOGIN_PAGE = "https://github.com/login";
-    public static final String DOCS_PAGE =
-            "https://github.com/HubTurbo/HubTurbo/blob/release/docs/userGuide.md";
-    public static final String KEYBOARD_SHORTCUTS_PAGE =
-            "https://github.com/HubTurbo/HubTurbo/blob/release/docs/keyboardShortcuts.md";
+
+    private static final String RELEASE_BLOB_PREFIX = "https://github.com/HubTurbo/HubTurbo/blob/release/";
+    public static final String DOCS_PAGE = RELEASE_BLOB_PREFIX + "docs/userGuide.md";
+    public static final String FILTERS_PAGE = RELEASE_BLOB_PREFIX + "docs/filters.md";
+    public static final String KEYBOARD_SHORTCUTS_PAGE = RELEASE_BLOB_PREFIX + "docs/keyboardShortcuts.md";
 
     public static String getPathForAllIssues(String repoId) {
         return String.format("https://github.com/%s/issues", repoId);

--- a/src/test/java/guitests/FilterTextFieldTest.java
+++ b/src/test/java/guitests/FilterTextFieldTest.java
@@ -3,15 +3,26 @@ package guitests;
 import static junit.framework.TestCase.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
 import javafx.scene.input.KeyCode;
+import org.loadui.testfx.utils.FXTestUtils;
 import ui.TestController;
+import ui.UI;
 import ui.components.FilterTextField;
 import ui.issuepanel.FilterPanel;
+import util.GitHubURL;
+import util.events.testevents.NavigateToPageEventHandler;
 
 public class FilterTextFieldTest extends UITest {
+
+    @Override
+    public void launchApp() {
+        FXTestUtils.launchApp(
+            TestUI.class, "--test=true", "--bypasslogin=true", "--testchromedriver=true");
+    }
 
     @Test
     public void inputsTest() {
@@ -57,6 +68,15 @@ public class FilterTextFieldTest extends UITest {
 
         push(KeyCode.ESCAPE);
         awaitCondition(() -> toggle.get() % 2 == 1);
+    }
+
+    @Test
+    public void showDocs_filterTextFieldInFocus_navigateToFilterDocsPage() {
+        AtomicReference<String> url = new AtomicReference<>();
+        UI.events.registerEvent((NavigateToPageEventHandler) e -> url.set(e.url));
+        getFirstPanelField();
+        push(KeyCode.F1);
+        waitAndAssertEquals(GitHubURL.FILTERS_PAGE, url::get);
     }
 
     @Test
@@ -115,19 +135,6 @@ public class FilterTextFieldTest extends UITest {
         awaitCondition(() -> field.getText().equals(" assigne e "));
     }
 
-    private FilterTextField getFirstPanelField() {
-        FilterPanel issuePanel = (FilterPanel) TestController.getUI().getPanelControl().getPanel(0);
-        FilterTextField field = issuePanel.getFilterTextField();
-        waitUntilNodeAppears(field);
-        click(issuePanel.getFilterTextField());
-        return field;
-    }
-
-    private void clearField() {
-        selectAll();
-        push(KeyCode.BACK_SPACE);
-    }
-
     private void testCompletions(FilterTextField field) {
         // Basic completion
         clearField();
@@ -158,6 +165,14 @@ public class FilterTextFieldTest extends UITest {
         awaitCondition(() -> field.getText().equals("closedt"));
     }
 
+    private FilterTextField getFirstPanelField() {
+        FilterPanel issuePanel = (FilterPanel) TestController.getUI().getPanelControl().getPanel(0);
+        FilterTextField field = issuePanel.getFilterTextField();
+        waitUntilNodeAppears(field);
+        click(issuePanel.getFilterTextField());
+        return field;
+    }
+
     private void testValidFilterStyleApplied(String filter) {
         FilterTextField field = getFirstPanelField();
         clearField();
@@ -177,5 +192,10 @@ public class FilterTextFieldTest extends UITest {
         clearField();
         type(filter).push(KeyCode.ENTER);
         assertTrue(field.getStyle().contains(FilterTextField.INVALID_FILTER_STYLE));
+    }
+
+    private void clearField() {
+        selectAll();
+        push(KeyCode.BACK_SPACE);
     }
 }


### PR DESCRIPTION
Fixes #1167.

**REVIEW**

**Current status**:
When filter text box is in focus, pressing <kbd>F1</kbd> redirects the browser component to the filter docs page.

**Work done**: 
- ~~`FilterPanel` now passes its `UI` reference to `FilterTextField`~~
- ~~`FilterTextField` now maintains a final field to hold the `UI`reference~~
- ~~`FilterTextField` setup method now includes handling for the `KeyboardShortcuts.SHOW_DOCS` key combination (<kbd>F1</kbd>), which calls UI's browser's`BrowserComponent.showDocs()` method.~~
- ~~The above handling code is copied from a [slice](https://github.com/HubTurbo/HubTurbo/blob/880d65c081505c9e8a547c29d188293a56c5de24/src/main/java/ui/listpanel/ListPanel.java#L171-L173) of `ListPanel.setupKeyboardShorcuts()`~~
- Make F1 link to 'filters' section of docs
- Change implementation: expose help key press callback hook on `FilterTextField` to decouple from rest of app
- All instantiations of `FilterTextField` now register the correct callback for help key press
- Regression testing under `guitests.FilterTextFieldTest`

**Future**:
null