### PR TITLE
Refactor KeyboardShortcuts and fix Findbugs violations #874

### DIFF
--- a/src/main/java/ui/components/KeyboardShortcuts.java
+++ b/src/main/java/ui/components/KeyboardShortcuts.java
@@ -34,24 +34,11 @@ public final class KeyboardShortcuts {
     private static Map<String, String> keyboardShortcuts = null;
     private static Set<KeyCodeCombination> assignedKeys = null;
 
-    // customizable keyboard shortcuts
-    // ui.listpanel.ListPanel
-    public static KeyCodeCombination markAsRead;
-    public static KeyCodeCombination markAsUnread;
-
-    public static KeyCodeCombination scrollToTop;
-    public static KeyCodeCombination scrollToBottom;
-    public static KeyCodeCombination scrollUp;
-    public static KeyCodeCombination scrollDown;
-
-    //ui.issuepanel.PanelControl
-    public static KeyCodeCombination leftPanel;
-    public static KeyCodeCombination rightPanel;
-
-    // ui.components.NavigableListView
-    static KeyCodeCombination upIssue;
-    static KeyCodeCombination downIssue;
-
+    // key lookup for customizable keyboard shortcuts
+    public enum KeyboardShortcutKey {
+        MARK_AS_READ, MARK_AS_UNREAD, SCROLL_TO_TOP, SCROLL_TO_BOTTOM,
+        SCROLL_UP, SCROLL_DOWN, LEFT_PANEL, RIGHT_PANEL, UP_ISSUE, DOWN_ISSUE;
+    }
     // non-customizable keyboard shortcuts
     // ui.listpanel.ListPanel
     public static final KeyCodeCombination JUMP_TO_FIRST_ISSUE =
@@ -177,17 +164,31 @@ public final class KeyboardShortcuts {
         assignedKeys.add(MANAGE_ASSIGNEES);
     }
 
-    private static void getKeyboardShortcutsFromHashMap() {
-        markAsRead = getKeyCodeCombination("MARK_AS_READ");
-        markAsUnread = getKeyCodeCombination("MARK_AS_UNREAD");
-        scrollToTop = getKeyCodeCombination("SCROLL_TO_TOP");
-        scrollToBottom = getKeyCodeCombination("SCROLL_TO_BOTTOM");
-        scrollUp = getKeyCodeCombination("SCROLL_UP");
-        scrollDown = getKeyCodeCombination("SCROLL_DOWN");
-        leftPanel = getKeyCodeCombination("LEFT_PANEL");
-        rightPanel = getKeyCodeCombination("RIGHT_PANEL");
-        upIssue = getKeyCodeCombination("UP_ISSUE");
-        downIssue = getKeyCodeCombination("DOWN_ISSUE");
+    public static KeyCodeCombination getKeyboardShortcut(KeyboardShortcutKey key) {
+        switch (key) {
+            case MARK_AS_READ:
+                return getKeyCodeCombination("Mark_AS_READ");
+            case MARK_AS_UNREAD:
+                return getKeyCodeCombination("MARK_AS_UNREAD");
+            case SCROLL_TO_TOP:
+                return getKeyCodeCombination("SCROLL_TO_TOP");
+            case SCROLL_TO_BOTTOM:
+                return getKeyCodeCombination("SCROLL_TO_BOTTOM");
+            case SCROLL_UP:
+                return getKeyCodeCombination("SCROLL_UP");
+            case SCROLL_DOWN:
+                return getKeyCodeCombination("SCROLL_DOWN");
+            case LEFT_PANEL:
+                return getKeyCodeCombination("LEFT_PANEL");
+            case RIGHT_PANEL:
+                return getKeyCodeCombination("RIGHT_PANEL");
+            case UP_ISSUE:
+                return getKeyCodeCombination("UP_ISSUE");
+            case DOWN_ISSUE:
+                return getKeyCodeCombination("DOWN_ISSUE");
+            default:
+                return null;
+        }
     }
 
     public static void loadKeyboardShortcuts(Preferences prefs) {
@@ -214,7 +215,6 @@ public final class KeyboardShortcuts {
             keyboardShortcuts = prefs.getKeyboardShortcuts();
         }
         addNonCustomizableShortcutKeys();
-        getKeyboardShortcutsFromHashMap();
         prefs.setKeyboardShortcuts(keyboardShortcuts);
     }
 

--- a/src/main/java/ui/components/NavigableListView.java
+++ b/src/main/java/ui/components/NavigableListView.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 
 import static ui.components.KeyboardShortcuts.FIRST_ISSUE;
 import static ui.components.KeyboardShortcuts.LAST_ISSUE;
+import ui.components.KeyboardShortcuts.KeyboardShortcutKey;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -166,9 +167,11 @@ public abstract class NavigableListView<T> extends ScrollableListView<T> {
                 }
             }
             if (e.getCode() == KeyCode.UP || e.getCode() == KeyCode.DOWN ||
-                    KeyboardShortcuts.upIssue.match(e) || KeyboardShortcuts.downIssue.match(e)) {
+                    KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.UP_ISSUE).match(e) ||
+                    KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.DOWN_ISSUE).match(e)) {
                 e.consume();
-                handleUpDownKeys(e.getCode() == KeyCode.DOWN || KeyboardShortcuts.downIssue.match(e));
+                handleUpDownKeys(e.getCode() == KeyCode.DOWN ||
+                        KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.DOWN_ISSUE).match(e));
                 assert selectedIndex.isPresent() : "handleUpDownKeys doesn't set selectedIndex!";
                 if (!e.isShiftDown()) {
                     logger.info("Enter key selection on item index " + selectedIndex.get());

--- a/src/main/java/ui/issuepanel/PanelControl.java
+++ b/src/main/java/ui/issuepanel/PanelControl.java
@@ -13,6 +13,7 @@ import prefs.PanelInfo;
 import ui.GUIController;
 import ui.UI;
 import ui.components.KeyboardShortcuts;
+import ui.components.KeyboardShortcuts.KeyboardShortcutKey;
 import ui.listpanel.ListPanel;
 import util.events.*;
 
@@ -251,8 +252,9 @@ public class PanelControl extends HBox {
     }
     private void setupKeyEvents() {
         addEventHandler(KeyEvent.KEY_PRESSED, event -> {
-            if (KeyboardShortcuts.rightPanel.match(event) || KeyboardShortcuts.leftPanel.match(event)) {
-                handleKeys(KeyboardShortcuts.rightPanel.match(event));
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.RIGHT_PANEL).match(event) ||
+                    KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.LEFT_PANEL).match(event)) {
+                handleKeys(KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.RIGHT_PANEL).match(event));
                 assert currentlySelectedPanel.isPresent() : "handleKeys doesn't set selectedIndex!";
             }
         });

--- a/src/main/java/ui/listpanel/ListPanel.java
+++ b/src/main/java/ui/listpanel/ListPanel.java
@@ -162,10 +162,11 @@ public class ListPanel extends FilterPanel {
         addEventHandler(KeyEvent.KEY_PRESSED, event -> {
             // Temporary fix for now since markAsRead and Show Related Issue/PR have same keys.
             // Will only work if the key for markAsRead is not the default key E.
-            if (KeyboardShortcuts.markAsRead.match(event) && !SHOW_RELATED_ISSUE_OR_PR.match(event)) {
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.MARK_AS_READ).match(event) &&
+                    !SHOW_RELATED_ISSUE_OR_PR.match(event)) {
                 markAsRead();
             }
-            if (KeyboardShortcuts.markAsUnread.match(event)) {
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.MARK_AS_UNREAD).match(event)) {
                 markAsUnread();
             }
             if (SHOW_DOCS.match(event)) {
@@ -197,14 +198,16 @@ public class ListPanel extends FilterPanel {
                 ui.getBrowserComponent().showContributors();
                 event.consume();
             }
-            if (KeyboardShortcuts.scrollToTop.match(event)) {
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.SCROLL_TO_TOP).match(event)) {
                 ui.getBrowserComponent().scrollToTop();
             }
-            if (KeyboardShortcuts.scrollToBottom.match(event)) {
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.SCROLL_TO_BOTTOM).match(event)) {
                 ui.getBrowserComponent().scrollToBottom();
             }
-            if (KeyboardShortcuts.scrollUp.match(event) || KeyboardShortcuts.scrollDown.match(event)) {
-                ui.getBrowserComponent().scrollPage(KeyboardShortcuts.scrollDown.match(event));
+            if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.SCROLL_UP).match(event) ||
+                    KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.SCROLL_DOWN).match(event)) {
+                ui.getBrowserComponent().scrollPage(
+                        KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.SCROLL_DOWN).match(event));
             }
             if (GOTO_MODIFIER.match(event)) {
                 KeyPress.setLastKeyPressedCodeAndTime(event.getCode());
@@ -265,7 +268,7 @@ public class ListPanel extends FilterPanel {
                 if (KeyPress.isValidKeyCombination(GOTO_MODIFIER.getCode(), event.getCode())) {
                     showRelatedIssueOrPR();
                 // only for default. can remove if default key for MARK_AS_READ_CHANGES
-                } else if (KeyboardShortcuts.markAsRead.match(event)) {
+                } else if (KeyboardShortcuts.getKeyboardShortcut(KeyboardShortcutKey.MARK_AS_READ).match(event)) {
                     markAsRead();
                 }
             }


### PR DESCRIPTION
Fixes #874 

As discussed in #874 and #866, the relevant fields have been changed into method calls. Keyboard shortcut keys are wrapped in an enum for key lookup. This also necessitated updates in the other java files that make use of these shortcut keys.

In line 190 of `KeyboardShortcuts.java`, I returned a `null` value. Is it necessary to replace it with `Optional` instead?