### PR TITLE
 Correct variable name to pass checkstyle in DummyRepoState #1366

### DIFF
--- a/src/main/java/backend/stub/DummyRepoState.java
+++ b/src/main/java/backend/stub/DummyRepoState.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 public class DummyRepoState {
 
-    public static final int noOfDummyIssues = 12;
+    public static final int NO_OF_DUMMY_ISSUES = 12;
     private final String dummyRepoId;
 
     private final TreeMap<Integer, TurboIssue> issues = new TreeMap<>();
@@ -50,7 +50,7 @@ public class DummyRepoState {
     }
 
     private void initializeRepoEntities() {
-        for (int i = 0; i < noOfDummyIssues; i++) {
+        for (int i = 0; i < NO_OF_DUMMY_ISSUES; i++) {
             TurboIssue dummyIssue;
             // Issue #7 is a PR
             switch (i) {
@@ -102,7 +102,7 @@ public class DummyRepoState {
         }
 
         // Odd issues are assigned label 1, even issues are assigned label 2
-        for (int i = 1; i <= noOfDummyIssues; i++) {
+        for (int i = 1; i <= NO_OF_DUMMY_ISSUES; i++) {
             issues.get(i).addLabel((i % 2 == 0) ? "Label 2" : "Label 1");
         }
 

--- a/src/test/java/guitests/FilterTests.java
+++ b/src/test/java/guitests/FilterTests.java
@@ -26,7 +26,7 @@ public class FilterTests extends UITest{
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class FilterTests extends UITest{
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class FilterTests extends UITest{
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class FilterTests extends UITest{
         push(KeyCode.BACK_SPACE);
         push(KeyCode.ENTER);
         PlatformEx.waitOnFxThread();
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel2.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel2.getIssueCount());
         assertEquals(1, issuePanel.getIssueCount());
 
         pushKeys(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN));
@@ -167,7 +167,7 @@ public class FilterTests extends UITest{
         type("count:15");
         push(KeyCode.ENTER);
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
 
         //multiple count qualifiers
         click("#dummy/dummy_col0_filterTextField");
@@ -175,7 +175,7 @@ public class FilterTests extends UITest{
         type("count:6 count:9");
         push(KeyCode.ENTER);
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
 
         // Not-a-number
 
@@ -184,7 +184,7 @@ public class FilterTests extends UITest{
         type("count:abcd");
         push(KeyCode.ENTER);
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
 
         // Test with sort qualifier as the second qualifier
 
@@ -213,7 +213,7 @@ public class FilterTests extends UITest{
         type("count:-1");
         push(KeyCode.ENTER);
 
-        assertEquals(DummyRepoState.noOfDummyIssues, issuePanel.getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, issuePanel.getIssueCount());
     }
 
     private void checkCurrWithResult(String milestoneAlias, String currString, ListPanel issuePanel,

--- a/src/test/java/guitests/RangeTest.java
+++ b/src/test/java/guitests/RangeTest.java
@@ -18,7 +18,7 @@ public class RangeTest extends UITest {
         click("#dummy/dummy_col0_filterTextField");
         press(KeyCode.ENTER).release(KeyCode.ENTER);
         sleep(EVENT_DELAY);
-        assertEquals(DummyRepoState.noOfDummyIssues - 5, ((ListPanel) find("#dummy/dummy_col0")).getIssueCount());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES - 5, ((ListPanel) find("#dummy/dummy_col0")).getIssueCount());
     }
 
     @Test

--- a/src/test/java/tests/ModelTests.java
+++ b/src/test/java/tests/ModelTests.java
@@ -148,7 +148,7 @@ public class ModelTests {
         // Resources
         // Issues
         ArrayList<Integer> issueIds = new ArrayList<>();
-        for (int i = 1; i <= DummyRepoState.noOfDummyIssues; i++) {
+        for (int i = 1; i <= DummyRepoState.NO_OF_DUMMY_ISSUES; i++) {
             issueIds.add(i);
         }
         Collections.sort(issueIds); // 1, 2..10
@@ -161,7 +161,7 @@ public class ModelTests {
 
         // Labels
         ArrayList<String> labelNames = new ArrayList<>();
-        for (int i = 1; i <= DummyRepoState.noOfDummyIssues; i++) {
+        for (int i = 1; i <= DummyRepoState.NO_OF_DUMMY_ISSUES; i++) {
             labelNames.add("Label " + i);
         }
         Collections.sort(labelNames); // Label 1, Label 10..12, Label 2..9
@@ -177,7 +177,7 @@ public class ModelTests {
 
         // Milestones
         ArrayList<Integer> milestoneIds = new ArrayList<>();
-        for (int i = 1; i <= DummyRepoState.noOfDummyIssues; i++) {
+        for (int i = 1; i <= DummyRepoState.NO_OF_DUMMY_ISSUES; i++) {
             milestoneIds.add(i);
         }
         Collections.sort(milestoneIds); // 1, 2..10
@@ -193,7 +193,7 @@ public class ModelTests {
 
         // Users
         ArrayList<String> userLogins = new ArrayList<>();
-        for (int i = 1; i <= DummyRepoState.noOfDummyIssues; i++) {
+        for (int i = 1; i <= DummyRepoState.NO_OF_DUMMY_ISSUES; i++) {
             userLogins.add("User " + i);
         }
         Collections.sort(userLogins); // User 1, User 10, User 2..9
@@ -218,7 +218,7 @@ public class ModelTests {
             modelUpdated.getIssueById(-1);
         } catch (AssertionError ignored) {}
 
-        assertEquals(Optional.<TurboIssue>empty(), modelUpdated.getIssueById(DummyRepoState.noOfDummyIssues + 1));
+        assertEquals(Optional.<TurboIssue>empty(), modelUpdated.getIssueById(DummyRepoState.NO_OF_DUMMY_ISSUES + 1));
         assertEquals("Issue 10", modelUpdated.getIssueById(10).get().getTitle());
 
         // Labels
@@ -231,7 +231,7 @@ public class ModelTests {
         } catch (AssertionError ignored) {}
 
         assertEquals(Optional.<TurboLabel>empty(),
-                modelUpdated.getLabelByActualName("Label " + (DummyRepoState.noOfDummyIssues + 1)));
+                modelUpdated.getLabelByActualName("Label " + (DummyRepoState.NO_OF_DUMMY_ISSUES + 1)));
         assertEquals("Label 10", modelUpdated.getLabelByActualName("Label 10").get().getFullName());
 
         // Milestones
@@ -252,11 +252,11 @@ public class ModelTests {
         } catch (AssertionError ignored) {}
 
         assertEquals(Optional.<TurboMilestone>empty(),
-                modelUpdated.getMilestoneById(DummyRepoState.noOfDummyIssues + 1));
+                modelUpdated.getMilestoneById(DummyRepoState.NO_OF_DUMMY_ISSUES + 1));
         assertEquals("Milestone 10", modelUpdated.getMilestoneById(10).get().getTitle());
 
         assertEquals(Optional.<TurboMilestone>empty(),
-                modelUpdated.getMilestoneByTitle("Milestone " + (DummyRepoState.noOfDummyIssues + 1)));
+                modelUpdated.getMilestoneByTitle("Milestone " + (DummyRepoState.NO_OF_DUMMY_ISSUES + 1)));
         assertEquals("Milestone 10", modelUpdated.getMilestoneByTitle("Milestone 10").get().getTitle());
 
         // Users
@@ -269,7 +269,7 @@ public class ModelTests {
         } catch (AssertionError ignored) {}
 
         assertEquals(Optional.<TurboUser>empty(),
-                modelUpdated.getUserByLogin("User " + (DummyRepoState.noOfDummyIssues + 1)));
+                modelUpdated.getUserByLogin("User " + (DummyRepoState.NO_OF_DUMMY_ISSUES + 1)));
         assertEquals("User 10", modelUpdated.getUserByLogin("User 10").get().getLoginName());
     }
 

--- a/src/test/java/tests/StoreTests.java
+++ b/src/test/java/tests/StoreTests.java
@@ -50,13 +50,13 @@ public class StoreTests {
 
         // Repo not stored, "download" from DummySource
         Model dummy1 = testIO.openRepository("dummy1/dummy1").get();
-        assertEquals(DummyRepoState.noOfDummyIssues, dummy1.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, dummy1.getIssues().size());
 
         // Spawn new issue
         UI.events.triggerEvent(UpdateDummyRepoEvent.newIssue("dummy1/dummy1"));
 
         dummy1 = testIO.openRepository("dummy1/dummy1").get();
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, dummy1.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, dummy1.getIssues().size());
 
         // A new file should not have been created as we are using a stub
         if (new File("store/test/dummy1-dummy1.json").isFile()) {
@@ -72,13 +72,13 @@ public class StoreTests {
 
         // Repo currently not stored, "download" from DummySource
         Model dummy1 = testIO.openRepository("dummy1/dummy1").get();
-        assertEquals(DummyRepoState.noOfDummyIssues, dummy1.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, dummy1.getIssues().size());
 
         // Spawn new issue (to be stored in JSON)
         UI.events.triggerEvent(UpdateDummyRepoEvent.newIssue("dummy1/dummy1"));
         // Trigger store
         dummy1 = testIO.updateModel(dummy1, false).get();
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, dummy1.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, dummy1.getIssues().size());
 
         TestUtils.delay(2); // Wait 2 seconds for Gson to convert model to JSON and write
 
@@ -90,13 +90,13 @@ public class StoreTests {
 
         // But since we are indeed loading from the test JSON store, we would end up with 11 issues.
         Model dummy2 = alternateIO.openRepository("dummy1/dummy1").get();
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, dummy2.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, dummy2.getIssues().size());
 
         // It even works if we enter the repo name in different case
         RepoIO repoIO = TestController.createTestingRepoIO(Optional.empty());
         repoIO.setRepoOpControl(TestUtils.createRepoOpControlWithEmptyModels(repoIO));
         Model dummy3 = repoIO.openRepository("DUMMY1/DUMMY1").get();
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, dummy3.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, dummy3.getIssues().size());
 
         UI.status.clear();
     }
@@ -124,7 +124,7 @@ public class StoreTests {
         Model model = repoIO.openRepository("testrepo/testrepo").get();
 
         TestUtils.delay(1); // allow for file to be written
-        assertEquals(DummyRepoState.noOfDummyIssues, model.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, model.getIssues().size());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class StoreTests {
         RepoIO repoIO = TestController.createTestingRepoIO(Optional.empty());
         repoIO.setRepoOpControl(TestUtils.createRepoOpControlWithEmptyModels(repoIO));
         Model model = repoIO.openRepository("nonexistent/nonexistent").get();
-        assertEquals(DummyRepoState.noOfDummyIssues, model.getIssues().size());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, model.getIssues().size());
     }
 
     @Test

--- a/src/test/java/unstable/KeyboardShortcutsTest.java
+++ b/src/test/java/unstable/KeyboardShortcutsTest.java
@@ -48,7 +48,7 @@ public class KeyboardShortcutsTest extends UITest {
         // jump from panel focus to first issue
         // - This is because on startup focus is on panel and not on filter box
         press(JUMP_TO_FIRST_ISSUE);
-        assertEquals(DummyRepoState.noOfDummyIssues, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, selectedIssueId);
         clearSelectedIssueId();
 
         // jump from issue list to filter box
@@ -60,7 +60,7 @@ public class KeyboardShortcutsTest extends UITest {
         // - To ensure shortcut works from filter box, too
         press(JUMP_TO_FIRST_ISSUE);
         press(JUMP_TO_FILTER_BOX);
-        assertEquals(DummyRepoState.noOfDummyIssues, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, selectedIssueId);
         clearSelectedIssueId();
 
         // jump to nth issue using number keys 1-9
@@ -68,7 +68,7 @@ public class KeyboardShortcutsTest extends UITest {
             push(KeyCode.ESCAPE);
             press(JUMP_TO_NTH_ISSUE_KEYS.get(i));
             PlatformEx.waitOnFxThread();
-            assertEquals(DummyRepoState.noOfDummyIssues - (i - 1), selectedIssueId);
+            assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES - (i - 1), selectedIssueId);
             clearSelectedIssueId();
             if (i == 1) {
                 press(JUMP_TO_FILTER_BOX);
@@ -85,17 +85,17 @@ public class KeyboardShortcutsTest extends UITest {
         // jump to first issue
         push(KeyCode.HOME);
         sleep(1000);
-        assertEquals(DummyRepoState.noOfDummyIssues, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, selectedIssueId);
         clearSelectedIssueId();
 
         push(getKeyCode("DOWN_ISSUE"));
-        assertEquals(DummyRepoState.noOfDummyIssues - 1, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES - 1, selectedIssueId);
         clearSelectedIssueId();
         push(getKeyCode("DOWN_ISSUE"));
-        assertEquals(DummyRepoState.noOfDummyIssues - 2, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES - 2, selectedIssueId);
         clearSelectedIssueId();
         push(getKeyCode("UP_ISSUE"));
-        assertEquals(DummyRepoState.noOfDummyIssues - 1, selectedIssueId);
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES - 1, selectedIssueId);
         clearSelectedIssueId();
 
         press(CREATE_RIGHT_PANEL);
@@ -138,10 +138,10 @@ public class KeyboardShortcutsTest extends UITest {
         // wait for issue 9 to appear then click on it
         // issue 9 is chosen instead of issue 10
         // as there is a problem with finding issue 10's node due to it being the first card in the panel
-        waitUntilNodeAppears("#dummy/dummy_col1_" + (DummyRepoState.noOfDummyIssues - 1));
+        waitUntilNodeAppears("#dummy/dummy_col1_" + (DummyRepoState.NO_OF_DUMMY_ISSUES - 1));
         assertEquals("dummy/dummy", repoSelectorComboBox.getValue());
         // test shortcut when focus is on panel
-        click("#dummy/dummy_col1_" + (DummyRepoState.noOfDummyIssues - 1));
+        click("#dummy/dummy_col1_" + (DummyRepoState.NO_OF_DUMMY_ISSUES - 1));
         press(SWITCH_DEFAULT_REPO);
         PlatformEx.waitOnFxThread();
         assertEquals("dummy1/dummy1", repoSelectorComboBox.getValue());

--- a/src/test/java/unstable/ModelUpdateUITest.java
+++ b/src/test/java/unstable/ModelUpdateUITest.java
@@ -32,7 +32,7 @@ public class ModelUpdateUITest extends UITest {
         addIssue();
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, countIssues.get().intValue());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, countIssues.get().intValue());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class ModelUpdateUITest extends UITest {
         addIssue();
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(DummyRepoState.noOfDummyIssues + 3, countIssues.get().intValue());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 3, countIssues.get().intValue());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class ModelUpdateUITest extends UITest {
         resetRepo();
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(DummyRepoState.noOfDummyIssues, countIssues.get().intValue());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES, countIssues.get().intValue());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class ModelUpdateUITest extends UITest {
         deleteIssue(1);
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, countIssues.get().intValue());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, countIssues.get().intValue());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ModelUpdateUITest extends UITest {
         deleteIssue(2);
         FutureTask<Integer> countIssues = new FutureTask<>(((ListPanel) find("#dummy/dummy_col0"))::getIssueCount);
         PlatformEx.runAndWait(countIssues);
-        assertEquals(DummyRepoState.noOfDummyIssues + 1, countIssues.get().intValue());
+        assertEquals(DummyRepoState.NO_OF_DUMMY_ISSUES + 1, countIssues.get().intValue());
     }
 
     // TODO no way to check correctness of these events as of yet as they are not reflected on the UI


### PR DESCRIPTION
Fixes #1366. Changed a constant name from noOfDummyIssues to NO_OF_DUMMY_ISSUES, to conform to coding standards.