### PR TITLE
Upload screenshots after Travis failure #1402

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ script:
 after_success:
     - "./gradlew jacocoRootReport coveralls"
 
+after_failure:
+    - "for i in *.png; do curl --upload-file $i https://transfer.sh/$i; done"
+
 branches:
   only:
     - master


### PR DESCRIPTION
Closes #1402 

Uploading the screenshots to [transfer.sh](https://transfer.sh) after Travis fails.

It allows uploading of any file with a simple `curl` command and without an API key. It will keep the files for 14 days which is long enough for our use case.

It will output a list of urls of the files uploaded. 
One good thing about it is that the url preserves the original file name, which make it easier for us to figure out which screenshot that the url refers to.

I have tried `imgur` and `transfer.sh` and this is the comparison table:

| | imgur | transfer.sh |
|:---:|:---:|:---:|
| Preserve filename in URL | :x: | :white_check_mark: |
| Requires API key | :white_check_mark: | :x: |
| Storage Duration | Forever | 14 days |