### PR TITLE
Milestone picker: pick next milestone by default #1408

### DIFF
--- a/src/main/java/ui/components/pickers/MilestonePickerDialog.java
+++ b/src/main/java/ui/components/pickers/MilestonePickerDialog.java
@@ -43,10 +43,15 @@ public class MilestonePickerDialog extends Dialog<MilestonePickerDialogResponse>
         state = new MilestonePickerState(originalMilestones);
         initUI();
         setupKeyEvents();
+        setInputFieldToDefaultMilestone();
+    }
 
-        getExistingMilestone(originalMilestones)
-                .map(PickerMilestone::getTitle)
-                .ifPresent(this::fillInputFieldWithMilestoneName);
+    /**
+     * Fills the input field of milestone picker dialog with default milestone's title
+     */
+    private void setInputFieldToDefaultMilestone() {
+        Optional<PickerMilestone> defaultMilestone = PickerMilestone.getDefaultMilestone(originalMilestones);
+        defaultMilestone.map(PickerMilestone::getTitle).ifPresent(this::fillInputFieldWithMilestoneName);
     }
 
     private boolean areFromSameRepo(TurboIssue issue, List<TurboMilestone> milestones) {
@@ -99,9 +104,9 @@ public class MilestonePickerDialog extends Dialog<MilestonePickerDialogResponse>
     private void setConfirmResultConverter() {
         setResultConverter((dialogButton) -> {
             List<PickerMilestone> finalList = state.getCurrentMilestonesList();
-            if (hasSelectedMilestone(finalList)) {
-                return new MilestonePickerDialogResponse(dialogButton,
-                                                         Optional.of(getSelectedMilestone(finalList).get().getId()));
+            Optional<PickerMilestone> selectedMilestone = PickerMilestone.getSelectedMilestone(finalList);
+            if (selectedMilestone.isPresent()) {
+                return new MilestonePickerDialogResponse(dialogButton, Optional.of(selectedMilestone.get().getId()));
             }
             return new MilestonePickerDialogResponse(dialogButton, Optional.empty());
         });
@@ -146,9 +151,9 @@ public class MilestonePickerDialog extends Dialog<MilestonePickerDialogResponse>
 
     private void populateAssignedMilestone(List<PickerMilestone> pickerMilestoneList, FlowPane assignedMilestonePane) {
         assignedMilestonePane.getChildren().clear();
-        updateExistingMilestone(getExistingMilestone(pickerMilestoneList), assignedMilestonePane);
+        updateExistingMilestone(PickerMilestone.getExistingMilestone(pickerMilestoneList), assignedMilestonePane);
         addAssignmentIndicator(assignedMilestonePane);
-        updateNewlyAssignedMilestone(getSelectedMilestone(pickerMilestoneList), assignedMilestonePane);
+        updateNewlyAssignedMilestone(PickerMilestone.getSelectedMilestone(pickerMilestoneList), assignedMilestonePane);
     }
 
     private void populateMatchingMilestones(List<PickerMilestone> matchingMilestoneList, VBox matchingMilestones) {
@@ -272,25 +277,6 @@ public class MilestonePickerDialog extends Dialog<MilestonePickerDialogResponse>
         milestoneBox.setMaxHeight(30);
         milestoneBox.setStyle("-fx-border-radius: 3;-fx-border-style: dotted;-fx-alignment:center");
         return milestoneBox;
-    }
-
-    private Optional<PickerMilestone> getExistingMilestone(List<PickerMilestone> milestoneList) {
-        return milestoneList.stream()
-                .filter(PickerMilestone::isExisting)
-                .findAny();
-    }
-
-    private boolean hasSelectedMilestone(List<PickerMilestone> milestoneList) {
-        return milestoneList.stream()
-                .filter(PickerMilestone::isSelected)
-                .findAny()
-                .isPresent();
-    }
-
-    private Optional<PickerMilestone> getSelectedMilestone(List<PickerMilestone> milestoneList) {
-        return milestoneList.stream()
-                .filter(PickerMilestone::isSelected)
-                .findAny();
     }
 
 }

--- a/src/main/java/ui/components/pickers/MilestonePickerDialog.java
+++ b/src/main/java/ui/components/pickers/MilestonePickerDialog.java
@@ -105,10 +105,7 @@ public class MilestonePickerDialog extends Dialog<MilestonePickerDialogResponse>
         setResultConverter((dialogButton) -> {
             List<PickerMilestone> finalList = state.getCurrentMilestonesList();
             Optional<PickerMilestone> selectedMilestone = PickerMilestone.getSelectedMilestone(finalList);
-            if (selectedMilestone.isPresent()) {
-                return new MilestonePickerDialogResponse(dialogButton, Optional.of(selectedMilestone.get().getId()));
-            }
-            return new MilestonePickerDialogResponse(dialogButton, Optional.empty());
+            return new MilestonePickerDialogResponse(dialogButton, selectedMilestone.map(PickerMilestone::getId));
         });
     }
 

--- a/src/main/java/ui/components/pickers/PickerMilestone.java
+++ b/src/main/java/ui/components/pickers/PickerMilestone.java
@@ -100,12 +100,24 @@ public class PickerMilestone extends TurboMilestone implements Comparable<Picker
         milestone.getStyleClass().add("labels-removed"); // add strikethrough
     }
 
+    /**
+     * Gets the existing milestone from the milestoneList
+     *
+     * @param milestoneList
+     * @return Optional of existing milestone
+     */
     public static Optional<PickerMilestone> getExistingMilestone(List<PickerMilestone> milestoneList) {
         return milestoneList.stream()
                 .filter(PickerMilestone::isExisting)
                 .findAny();
     }
 
+    /**
+     * Gets the selected milestone from the milestoneList
+     *
+     * @param milestoneList
+     * @return Optional of selected milestone
+     */
     public static Optional<PickerMilestone> getSelectedMilestone(List<PickerMilestone> milestoneList) {
         return milestoneList.stream()
                 .filter(PickerMilestone::isSelected)
@@ -113,13 +125,13 @@ public class PickerMilestone extends TurboMilestone implements Comparable<Picker
     }
 
     /**
-     * Gets the default milestone
+     * Gets the default milestone from the sortedMilestoneList
      * If there is an existing milestone, default milestone is the existing milestone
      * Else it is the first open milestone that is not overdue
      * Precondition: sortedMilestoneList needs to be sorted in its natural order
      *
      * @param sortedMilestoneList
-     * @return
+     * @return Optional of default milestone
      */
     public static Optional<PickerMilestone> getDefaultMilestone(List<PickerMilestone> sortedMilestoneList) {
         return PickerMilestone.getExistingMilestone(sortedMilestoneList)
@@ -129,7 +141,7 @@ public class PickerMilestone extends TurboMilestone implements Comparable<Picker
     }
 
     /**
-     * Gets the the first PickerMilestone that is open and not overdue
+     * Gets the the first PickerMilestone that is open and not overdue from the sortedMilestoneList
      * Precondition: sortedMilestoneList needs to be sorted in its natural order
      *
      * @param sortedMilestoneList

--- a/src/main/java/ui/components/pickers/PickerMilestone.java
+++ b/src/main/java/ui/components/pickers/PickerMilestone.java
@@ -7,6 +7,9 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.text.Font;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * This class handles the statuses and appearance of the milestones in MilestonePickerDialog
  */
@@ -97,6 +100,47 @@ public class PickerMilestone extends TurboMilestone implements Comparable<Picker
         milestone.getStyleClass().add("labels-removed"); // add strikethrough
     }
 
+    public static Optional<PickerMilestone> getExistingMilestone(List<PickerMilestone> milestoneList) {
+        return milestoneList.stream()
+                .filter(PickerMilestone::isExisting)
+                .findAny();
+    }
+
+    public static Optional<PickerMilestone> getSelectedMilestone(List<PickerMilestone> milestoneList) {
+        return milestoneList.stream()
+                .filter(PickerMilestone::isSelected)
+                .findAny();
+    }
+
+    /**
+     * Gets the default milestone
+     * If there is an existing milestone, default milestone is the existing milestone
+     * Else it is the first open milestone that is not overdue
+     * Precondition: sortedMilestoneList needs to be sorted in its natural order
+     *
+     * @param sortedMilestoneList
+     * @return
+     */
+    public static Optional<PickerMilestone> getDefaultMilestone(List<PickerMilestone> sortedMilestoneList) {
+        return PickerMilestone.getExistingMilestone(sortedMilestoneList)
+                .map(Optional::of)
+                .orElse(PickerMilestone.getNextOpenMilestone(sortedMilestoneList));
+
+    }
+
+    /**
+     * Gets the the first PickerMilestone that is open and not overdue
+     * Precondition: sortedMilestoneList needs to be sorted in its natural order
+     *
+     * @param sortedMilestoneList
+     * @return Optional of first PickerMilestone that is open and not overdue
+     */
+    private static Optional<PickerMilestone> getNextOpenMilestone(List<PickerMilestone> sortedMilestoneList) {
+        return sortedMilestoneList.stream()
+                .filter(milestone -> !milestone.isOverdue() && milestone.isOpen())
+                .findFirst();
+    }
+
     public void setSelected(boolean isSelected) {
         this.isSelected = isSelected;
     }
@@ -132,15 +176,17 @@ public class PickerMilestone extends TurboMilestone implements Comparable<Picker
             return this.isOpen() ? -1 : 1;
         }
 
-        if (this.getDueDate().equals(milestone.getDueDate())) return 0;
+        // milestones ordered according to their titles if due dates are the same
+        if (this.getDueDate().equals(milestone.getDueDate())) {
+            return this.getTitle().compareTo(milestone.getTitle());
+        }
 
         // milestones with due dates are smaller
         if (!this.getDueDate().isPresent()) return 1;
         if (!milestone.getDueDate().isPresent()) return -1;
 
         // milestones with earlier due dates are smaller
-        return this.getDueDate().get()
-                .isBefore(milestone.getDueDate().get()) ? -1 : 1;
+        return this.getDueDate().get().isBefore(milestone.getDueDate().get()) ? -1 : 1;
     }
 
     @Override

--- a/src/test/java/tests/PickerMilestoneTest.java
+++ b/src/test/java/tests/PickerMilestoneTest.java
@@ -1,0 +1,119 @@
+package tests;
+
+import backend.resource.TurboMilestone;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import ui.components.pickers.PickerMilestone;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class PickerMilestoneTest {
+
+    private static final String REPO_ID = "test/testrepo";
+
+    private static List<PickerMilestone> listWithNoExistingAndSelected, listWithNoDefaultMilestone,
+            listWithExisting, listWithSelected, listWithNextMilestone, listWithMilestonesWithNoDueDates,
+            listWithMilesonesWithSameDueDates;
+    private static PickerMilestone noDueDateMilestone1, noDueDateMilestone2, openMilestone1, openMilestone2,
+            closedMilestone, existingMilestone, selectedMilestone;
+
+    @BeforeClass
+    public static void initialize() {
+        noDueDateMilestone1 = new PickerMilestone(new TurboMilestone(REPO_ID, 1, "noDueDateMilestone1"));
+
+        noDueDateMilestone2 = new PickerMilestone(new TurboMilestone(REPO_ID, 2, "noDueDateMilestone2"));
+
+        openMilestone1 = new PickerMilestone(new TurboMilestone(REPO_ID, 3, "openMilestone1"));
+        openMilestone1.setDueDate(Optional.of(LocalDate.now().plusDays(1)));
+
+        openMilestone2 = new PickerMilestone(new TurboMilestone(REPO_ID, 4, "openMilestone2"));
+        openMilestone2.setDueDate(Optional.of(LocalDate.now().plusDays(1)));
+
+        closedMilestone = new PickerMilestone(new TurboMilestone(REPO_ID, 5, "closedMilestone"));
+        closedMilestone.setOpen(false);
+
+        existingMilestone = new PickerMilestone(new TurboMilestone(REPO_ID, 6, "existingMilestone"));
+        existingMilestone.setExisting(true);
+
+        selectedMilestone = new PickerMilestone(new TurboMilestone(REPO_ID, 7, "selectedMilestone"));
+        selectedMilestone.setSelected(true);
+
+        listWithNoExistingAndSelected = new ArrayList<>();
+        listWithNoExistingAndSelected.add(openMilestone1);
+        listWithNoExistingAndSelected.add(openMilestone2);
+
+        listWithNoDefaultMilestone = new ArrayList<>();
+        listWithNoDefaultMilestone.add(closedMilestone);
+        listWithNoDefaultMilestone.add(closedMilestone);
+
+        listWithExisting = new ArrayList<>();
+        listWithExisting.add(existingMilestone);
+        listWithExisting.add(openMilestone1);
+
+        listWithSelected = new ArrayList<>();
+        listWithSelected.add(selectedMilestone);
+        listWithSelected.add(openMilestone1);
+
+        listWithNextMilestone = new ArrayList<>();
+        listWithNextMilestone.add(openMilestone1);
+        listWithNextMilestone.add(closedMilestone);
+
+        listWithMilestonesWithNoDueDates = new ArrayList<>();
+        listWithMilestonesWithNoDueDates.add(noDueDateMilestone1);
+        listWithMilestonesWithNoDueDates.add(noDueDateMilestone2);
+
+        listWithMilesonesWithSameDueDates = listWithNoExistingAndSelected;
+    }
+
+    @Test
+    public void getExistingMilestone_noExistingMilestone_returnEmpty() {
+        assertEquals(Optional.empty(), PickerMilestone.getExistingMilestone(listWithNoExistingAndSelected));
+    }
+
+    @Test
+    public void getExistingMilestone_haveExistingMilestone_returnExistingMilestone() {
+        assertEquals(Optional.of(existingMilestone), PickerMilestone.getExistingMilestone(listWithExisting));
+    }
+
+    @Test
+    public void getSelectedMilestone_noSelectedMilestone_returnEmpty() {
+        assertEquals(Optional.empty(), PickerMilestone.getSelectedMilestone(listWithNoExistingAndSelected));
+    }
+
+    @Test
+    public void getSelectedMilestone_haveSelectedMilestone_returnSelectedMilestone() {
+        assertEquals(Optional.of(selectedMilestone), PickerMilestone.getSelectedMilestone(listWithSelected));
+    }
+
+    @Test
+    public void getDefaultMilestone_noDefaultMilestone_returnEmpty() {
+        assertEquals(Optional.empty(), PickerMilestone.getDefaultMilestone(listWithNoDefaultMilestone));
+    }
+
+    @Test
+    public void getDefaultMilestone_haveExistingMilestone_returnExistingMilestone() {
+        assertEquals(Optional.of(existingMilestone), PickerMilestone.getDefaultMilestone(listWithExisting));
+    }
+
+    @Test
+    public void getDefaultMilestone_haveNoExistingButHaveNextMilestone_returnNextMilestone() {
+        assertEquals(Optional.of(openMilestone1), PickerMilestone.getDefaultMilestone(listWithNextMilestone));
+    }
+
+    @Test
+    public void getDefaultMilestone_haveMilestonesWithNoDueDates_returnMilestoneWithLexicographicallySmallerName() {
+        assertEquals(Optional.of(noDueDateMilestone1),
+                PickerMilestone.getDefaultMilestone(listWithMilestonesWithNoDueDates));
+    }
+
+    @Test
+    public void getDefaultMilestone_haveMilestonesWithSameDueDates_returnMilestoneWithLexicographicallySmallerName() {
+        assertEquals(Optional.of(openMilestone1),
+                PickerMilestone.getDefaultMilestone(listWithMilesonesWithSameDueDates));
+    }
+}


### PR DESCRIPTION
Fixes #1408 

Milestone picker pick next milestone by default only when there is no existing milestone. 

The next milestone picked fulfills the 3 criteria:
- It is open 
- It is not overdue 
- It has the nearest due date 

If there no milestones that fulfills the criteria, no milestone will be picked. 