### PR TITLE
Issue filter will be wrong when user click on other panel while typing #1127

### DIFF
--- a/src/main/java/ui/issuepanel/FilterPanel.java
+++ b/src/main/java/ui/issuepanel/FilterPanel.java
@@ -7,6 +7,8 @@ import static ui.components.KeyboardShortcuts.MINIMIZE_WINDOW;
 import static ui.components.KeyboardShortcuts.SWITCH_BOARD;
 import filter.expression.QualifierType;
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import ui.GUIController;
 import ui.GuiElement;
 import ui.components.PanelMenuBar;
@@ -26,12 +28,14 @@ import javafx.scene.input.KeyEvent;
 import ui.TestController;
 import ui.UI;
 import ui.components.FilterTextField;
+import util.DialogMessage;
 import util.events.*;
 import util.events.testevents.UIComponentFocusEvent;
 import prefs.PanelInfo;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
 
 /**
  * A FilterPanel is an AbstractPanel meant for containing issues and an accompanying filter text field,
@@ -85,7 +89,7 @@ public abstract class FilterPanel extends AbstractPanel {
             }
         });
     }
-    
+
     private void setFocusToFilterBox() {
         if (TestController.isTestMode()) {
             ui.triggerEvent(new UIComponentFocusEvent(UIComponentFocusEvent.EventType.FILTER_BOX));
@@ -130,7 +134,16 @@ public abstract class FilterPanel extends AbstractPanel {
                 Platform.runLater(() -> ui.triggerEvent(new ApplyingFilterEvent(this)));
                 applyStringFilter(text);
                 return text;
-            });
+            })
+            .setOnUnsavedChanges(() ->
+                DialogMessage.showYesNoWarningDialog(
+                        "Warning",
+                        "Panel Change",
+                        "Would you like to update your current panel to the new input?",
+                        "New Input",
+                        "Quit"));
+
+
         filterTextField.setId(guiController.getDefaultRepo() + "_col" + panelIndex + "_filterTextField");
         filterTextField.setMinWidth(388);
         filterTextField.setMaxWidth(388);


### PR DESCRIPTION
From a UX perspective, it is quite weird/annoying to have dialog boxes popping up to ask the user whether he wants to change the panel or not. For example, when you search in google and then click elsewhere. There isn't any search performed unless enter is pressed.

This is a 'prototype' for #1127 