### PR TITLE
`BoardAutoCreator` should not prompt for save if there is no need to #1461

### DIFF
--- a/src/main/java/prefs/PanelInfo.java
+++ b/src/main/java/prefs/PanelInfo.java
@@ -2,6 +2,9 @@ package prefs;
 
 import java.util.Objects;
 
+/**
+ * Represents the information about a Panel. Contains two String attributes {@code name} and {@code filter}.
+ */
 public class PanelInfo {
 
     private final String name;

--- a/src/main/java/prefs/PanelInfo.java
+++ b/src/main/java/prefs/PanelInfo.java
@@ -3,7 +3,7 @@ package prefs;
 import java.util.Objects;
 
 /**
- * Represents the information about a Panel. Contains two String attributes {@code name} and {@code filter}.
+ * Represents the information about a Panel.
  */
 public class PanelInfo {
 

--- a/src/main/java/prefs/PanelInfo.java
+++ b/src/main/java/prefs/PanelInfo.java
@@ -1,5 +1,7 @@
 package prefs;
 
+import java.util.Objects;
+
 public class PanelInfo {
 
     private final String name;
@@ -23,4 +25,16 @@ public class PanelInfo {
         return this.filter;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        PanelInfo panelInfo = (PanelInfo) object;
+        return Objects.equals(name, panelInfo.name) && Objects.equals(filter, panelInfo.filter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, filter);
+    }
 }

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -233,6 +233,11 @@ public class Preferences { // NOPMD
         save();
     }
 
+    public void clearLastOpenBoardPanelInfos() {
+        sessionConfig.clearLastOpenBoardPanelInfos();
+        save();
+    }
+
     public List<PanelInfo> getBoardPanels(String boardName) {
         return sessionConfig.getBoardPanels(boardName);
     }

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -205,6 +205,14 @@ public class Preferences { // NOPMD
         return sessionConfig.getLastOpenBoard();
     }
 
+    public void setLastOpenBoardPanelInfos(List<PanelInfo> panelInfos) {
+        sessionConfig.setLastOpenBoardPanelInfos(panelInfos);
+    }
+
+    public Optional<List<PanelInfo>> getLastOpenBoardPanelInfos() {
+        return sessionConfig.getLastOpenBoardPanelInfos();
+    }
+
     /**
      * Switches the board to the next one. Cycles through the boards one at a time.
      * @return The new board selected

--- a/src/main/java/prefs/SessionConfig.java
+++ b/src/main/java/prefs/SessionConfig.java
@@ -103,6 +103,10 @@ public class SessionConfig {
         lastOpenBoard = Optional.empty();
     }
 
+    public void clearLastOpenBoardPanelInfos() {
+        lastOpenBoardPanelInfos = Optional.empty();
+    }
+
     public void clearAllBoards() {
         clearLastOpenBoard();
         savedBoards.clear();

--- a/src/main/java/prefs/SessionConfig.java
+++ b/src/main/java/prefs/SessionConfig.java
@@ -30,6 +30,7 @@ public class SessionConfig {
     private String lastLoginUsername = "";
     private byte[] lastLoginPassword = new byte[0];
     private Optional<String> lastOpenBoard = Optional.empty();
+    private Optional<List<PanelInfo>> lastOpenBoardPanelInfos = Optional.empty();
     private final Map<String, List<PanelInfo>> savedBoards = new LinkedHashMap<>();
     private final Map<String, Map<Integer, LocalDateTime>> markedReadTimes = new HashMap<>();
     private Map<String, String> keyboardShortcuts = new HashMap<>();
@@ -88,6 +89,14 @@ public class SessionConfig {
 
     public Optional<String> getLastOpenBoard() {
         return lastOpenBoard;
+    }
+
+    public Optional<List<PanelInfo>> getLastOpenBoardPanelInfos() {
+        return lastOpenBoardPanelInfos;
+    }
+
+    public void setLastOpenBoardPanelInfos(List<PanelInfo> lastOpenBoardPanelInfos) {
+        this.lastOpenBoardPanelInfos = Optional.of(lastOpenBoardPanelInfos);
     }
 
     public void clearLastOpenBoard() {

--- a/src/main/java/ui/BoardAutoCreator.java
+++ b/src/main/java/ui/BoardAutoCreator.java
@@ -62,21 +62,21 @@ public class BoardAutoCreator {
         Menu autoCreate = new Menu("Auto-create");
         MenuItem sample = new MenuItem(SAMPLE_BOARD);
         sample.setOnAction(e -> {
-            saveBoardAfterUserConfirmation(SAMPLE_BOARD);
+            saveBoardAfterUserConfirmationIfNeeded(SAMPLE_BOARD);
             createSampleBoard(true);
         });
         autoCreate.getItems().add(sample);
 
         MenuItem milestone = new MenuItem(MILESTONES);
         milestone.setOnAction(e -> {
-            saveBoardAfterUserConfirmation(MILESTONES);
+            saveBoardAfterUserConfirmationIfNeeded(MILESTONES);
             createMilestoneBoard();
         });
         autoCreate.getItems().add(milestone);
 
         MenuItem workAllocation = new MenuItem(WORK_ALLOCATION);
         workAllocation.setOnAction(e -> {
-            saveBoardAfterUserConfirmation(WORK_ALLOCATION);
+            saveBoardAfterUserConfirmationIfNeeded(WORK_ALLOCATION);
             createWorkAllocationBoard();
         });
         autoCreate.getItems().add(workAllocation);
@@ -84,8 +84,11 @@ public class BoardAutoCreator {
         return autoCreate;
     }
 
-    private void saveBoardAfterUserConfirmation(String boardName) {
-        if (isSaveBoardDialogResponsePositive(boardName)) ui.getMenuControl().saveBoardAs();
+    private void saveBoardAfterUserConfirmationIfNeeded(String boardName) {
+        boolean isNeeded = !prefs.getLastOpenBoardPanelInfos().isPresent()
+                        || !prefs.getLastOpenBoardPanelInfos().get().equals(panelControl.getCurrentPanelInfos());
+
+        if (isNeeded && isSaveBoardDialogResponsePositive(boardName)) ui.getMenuControl().saveBoard();
     }
 
     private boolean isSaveBoardDialogResponsePositive(String boardName) {
@@ -202,8 +205,10 @@ public class BoardAutoCreator {
     }
 
     private void triggerBoardSaveEventSequence(String boardName) {
-        prefs.addBoard(boardName, panelControl.getCurrentPanelInfos());
+        List<PanelInfo> currentPanelInfos = panelControl.getCurrentPanelInfos();
+        prefs.addBoard(boardName, currentPanelInfos);
         prefs.setLastOpenBoard(boardName);
+        prefs.setLastOpenBoardPanelInfos(currentPanelInfos);
         TestController.getUI().triggerEvent(new BoardSavedEvent());
         logger.info("Auto-created board, saved as \"" + boardName + "\"");
         TestController.getUI().updateTitle();

--- a/src/main/java/ui/BoardAutoCreator.java
+++ b/src/main/java/ui/BoardAutoCreator.java
@@ -85,10 +85,12 @@ public class BoardAutoCreator {
     }
 
     private void saveBoardAfterUserConfirmationIfNeeded(String boardName) {
-        boolean isNeeded = !prefs.getLastOpenBoardPanelInfos().isPresent()
-                        || !prefs.getLastOpenBoardPanelInfos().get().equals(panelControl.getCurrentPanelInfos());
+        boolean isOpenBoardDifferentFromSavedBoard = !prefs.getLastOpenBoardPanelInfos().isPresent()
+                || !prefs.getLastOpenBoardPanelInfos().get().equals(panelControl.getCurrentPanelInfos());
 
-        if (isNeeded && isSaveBoardDialogResponsePositive(boardName)) ui.getMenuControl().saveBoard();
+        if (isOpenBoardDifferentFromSavedBoard && isSaveBoardDialogResponsePositive(boardName)) {
+            ui.getMenuControl().saveBoard();
+        }
     }
 
     private boolean isSaveBoardDialogResponsePositive(String boardName) {

--- a/src/main/java/ui/BoardAutoCreator.java
+++ b/src/main/java/ui/BoardAutoCreator.java
@@ -62,21 +62,21 @@ public class BoardAutoCreator {
         Menu autoCreate = new Menu("Auto-create");
         MenuItem sample = new MenuItem(SAMPLE_BOARD);
         sample.setOnAction(e -> {
-            saveBoardAfterUserConfirmationIfNeeded(SAMPLE_BOARD);
+            promptToSaveBoardIfNeeded(SAMPLE_BOARD);
             createSampleBoard(true);
         });
         autoCreate.getItems().add(sample);
 
         MenuItem milestone = new MenuItem(MILESTONES);
         milestone.setOnAction(e -> {
-            saveBoardAfterUserConfirmationIfNeeded(MILESTONES);
+            promptToSaveBoardIfNeeded(MILESTONES);
             createMilestoneBoard();
         });
         autoCreate.getItems().add(milestone);
 
         MenuItem workAllocation = new MenuItem(WORK_ALLOCATION);
         workAllocation.setOnAction(e -> {
-            saveBoardAfterUserConfirmationIfNeeded(WORK_ALLOCATION);
+            promptToSaveBoardIfNeeded(WORK_ALLOCATION);
             createWorkAllocationBoard();
         });
         autoCreate.getItems().add(workAllocation);
@@ -84,7 +84,7 @@ public class BoardAutoCreator {
         return autoCreate;
     }
 
-    private void saveBoardAfterUserConfirmationIfNeeded(String boardName) {
+    private void promptToSaveBoardIfNeeded(String boardName) {
         boolean isOpenBoardDifferentFromSavedBoard = !prefs.getLastOpenBoardPanelInfos().isPresent()
                 || !prefs.getLastOpenBoardPanelInfos().get().equals(panelControl.getCurrentPanelInfos());
 

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -89,7 +89,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Called upon the Boards > New being clicked
+     * Logs the user action and creates a new board
      */
     private void onBoardNew() {
         logger.info("Menu: Boards > New");
@@ -133,7 +133,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Called upon the Boards > Save being clicked
+     * Logs the user action and saves the current board
      */
     private void onBoardSave() {
         logger.info("Menu: Boards > Save");
@@ -141,7 +141,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Tries to save current board. If current board is dangling, it calls {@code saveBoardAs()}
+     * Tries to save current board. If current board has not been saved before, it calls {@code saveBoardAs()}
      */
     public final void saveBoard() {
         if (!prefs.getLastOpenBoard().isPresent()) {
@@ -162,7 +162,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Called upon the Boards > Save as being clicked
+     * Logs the user action and triggers "Save as" on the current board
      */
     private void onBoardSaveAs() {
         logger.info("Menu: Boards > Save as");
@@ -191,7 +191,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Called upon the Boards > Open being clicked
+     * Logs the user action and opens the board that user requested
      */
     private void onBoardOpen(String boardName, List<PanelInfo> panelInfos) {
         logger.info("Menu: Boards > Open > " + boardName);
@@ -216,7 +216,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Called upon the Boards > Delete being clicked
+     * Logs the user action and deletes the board that user requested
      */
     private void onBoardDelete(String boardName) {
         logger.info("Menu: Boards > Delete > " + boardName);
@@ -224,7 +224,7 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Delete the board named {@boardName}
+     * Deletes the board named {@boardName}
      *
      * @param boardName name of the board to delete
      */

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -89,19 +89,25 @@ public class MenuControl extends MenuBar {
     }
 
     /**
-     * Creates an empty board. User will be prompted to
-     * confirm the action if there are unclosed panels.
+     * Called upon the Boards > New being clicked
      */
     private void onBoardNew() {
         logger.info("Menu: Boards > New");
+        newBoard();
+    }
 
+    /**
+     * Creates an empty board. User will be prompted to
+     * confirm the action if there are unclosed panels
+     */
+    public final void newBoard() {
         if (!isNewBoardCreationDialogConfirmed()) {
             logger.info("New board creation cancelled");
             return;
         }
 
         panels.closeAllPanels();
-        onBoardSaveAs();
+        saveBoardAs();
     }
 
     /**
@@ -126,11 +132,20 @@ public class MenuControl extends MenuBar {
                 response.get().getButtonData() == ButtonData.OK_DONE;
     }
 
+    /**
+     * Called upon the Boards > Save being clicked
+     */
     private void onBoardSave() {
         logger.info("Menu: Boards > Save");
+        saveBoard();
+    }
 
+    /**
+     * Tries to save current board. If current board is dangling, it calls {@code saveBoardAs()}
+     */
+    public final void saveBoard() {
         if (!prefs.getLastOpenBoard().isPresent()) {
-            onBoardSaveAs();
+            saveBoardAs();
             return;
         }
 
@@ -178,14 +193,23 @@ public class MenuControl extends MenuBar {
     /**
      * Called upon the Boards > Open being clicked
      */
-    private void onBoardOpen(String boardName, List<PanelInfo> panelInfo) {
+    private void onBoardOpen(String boardName, List<PanelInfo> panelInfos) {
         logger.info("Menu: Boards > Open > " + boardName);
+        openBoard(boardName, panelInfos);
+    }
 
+    /**
+     * Opens the board named {@code boardName}.
+     *
+     * @param boardName name of the board
+     * @param panelInfos list of panel infos of the board
+     */
+    public final void openBoard(String boardName, List<PanelInfo> panelInfos) {
         panels.closeAllPanels();
-        panels.openPanels(panelInfo);
+        panels.openPanels(panelInfos);
         panels.selectFirstPanel();
         prefs.setLastOpenBoard(boardName);
-        prefs.setLastOpenBoardPanelInfos(panelInfo);
+        prefs.setLastOpenBoardPanelInfos(panelInfos);
         ui.updateTitle();
 
         ui.triggerEvent(new UsedReposChangedEvent());
@@ -196,7 +220,15 @@ public class MenuControl extends MenuBar {
      */
     private void onBoardDelete(String boardName) {
         logger.info("Menu: Boards > Delete > " + boardName);
+        deleteBoard(boardName);
+    }
 
+    /**
+     * Delete the board named {@boardName}
+     *
+     * @param boardName name of the board to delete
+     */
+    public final void deleteBoard(String boardName) {
         Alert dlg = new Alert(AlertType.CONFIRMATION, "");
         dlg.initModality(Modality.APPLICATION_MODAL);
         dlg.setTitle("Confirmation");
@@ -210,6 +242,7 @@ public class MenuControl extends MenuBar {
                     prefs.getLastOpenBoard().get().equals(boardName)) {
 
                 prefs.clearLastOpenBoard();
+                prefs.clearLastOpenBoardPanelInfos();
             }
             ui.triggerEvent(new BoardSavedEvent());
             logger.info(boardName + " was deleted");

--- a/src/main/java/ui/MenuControl.java
+++ b/src/main/java/ui/MenuControl.java
@@ -141,6 +141,7 @@ public class MenuControl extends MenuBar {
         }
 
         prefs.addBoard(prefs.getLastOpenBoard().get(), panelList);
+        prefs.setLastOpenBoardPanelInfos(panelList);
         ui.triggerEvent(new BoardSavedEvent());
         logger.info("Board " + prefs.getLastOpenBoard().get() + " saved");
     }
@@ -167,6 +168,7 @@ public class MenuControl extends MenuBar {
             String boardName = response.get().trim();
             prefs.addBoard(boardName, panelList);
             prefs.setLastOpenBoard(boardName);
+            prefs.setLastOpenBoardPanelInfos(panelList);
             ui.triggerEvent(new BoardSavedEvent());
             logger.info("New board " + boardName + " saved");
             ui.updateTitle();
@@ -183,6 +185,7 @@ public class MenuControl extends MenuBar {
         panels.openPanels(panelInfo);
         panels.selectFirstPanel();
         prefs.setLastOpenBoard(boardName);
+        prefs.setLastOpenBoardPanelInfos(panelInfo);
         ui.updateTitle();
 
         ui.triggerEvent(new UsedReposChangedEvent());

--- a/src/test/java/guitests/BoardAutoCreatorTest.java
+++ b/src/test/java/guitests/BoardAutoCreatorTest.java
@@ -47,6 +47,7 @@ public class BoardAutoCreatorTest extends UITest {
         pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
         pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
         pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
+        PlatformEx.waitOnFxThread();
         assertEquals(panelCount + 3, panelControl.getPanelCount());
 
         // create milestones board
@@ -58,6 +59,11 @@ public class BoardAutoCreatorTest extends UITest {
         // save as "New Board"
         clickOn("OK");
 
+        PlatformEx.waitOnFxThread();
+        assertNodeExists(hasText("Milestones board has been created and loaded.\n\n"
+                + "It is saved under the name \"Milestones\"."));
+        clickOn("OK");
+
         assertEquals(2, panelControl.getNumberOfSavedBoards());
         assertEquals(5, panelControl.getPanelCount());
 
@@ -65,6 +71,45 @@ public class BoardAutoCreatorTest extends UITest {
         traverseMenu("Boards", "Open", "New Board");
         PlatformEx.waitOnFxThread();
         assertEquals(panelCount + 3, panelControl.getPanelCount());
+
+        traverseMenu("Boards", "Delete", "Milestones");
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
+        traverseMenu("Boards", "Delete", "New Board");
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
+    }
+
+    @Test
+    public void boardAutoCreator_clickNoInSavePrompt_currentBoardSaved() {
+        int panelCount = panelControl.getPanelCount();
+        assertEquals(0, panelControl.getNumberOfSavedBoards());
+
+        // create 3 new panels
+        pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
+        pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
+        pushKeys(KeyboardShortcuts.CREATE_RIGHT_PANEL);
+        PlatformEx.waitOnFxThread();
+        assertEquals(panelCount + 3, panelControl.getPanelCount());
+
+        // create milestones board
+        traverseMenu("Boards", "Auto-create", "Milestones");
+        PlatformEx.waitOnFxThread();
+        waitUntilNodeAppears(String.format(SAVE_MESSAGE, "Milestones"));
+        // do not opt to save current board
+        clickOn("No");
+
+        PlatformEx.waitOnFxThread();
+        assertNodeExists(hasText("Milestones board has been created and loaded.\n\n"
+                + "It is saved under the name \"Milestones\"."));
+        clickOn("OK");
+
+        assertEquals(1, panelControl.getNumberOfSavedBoards());
+        assertEquals(5, panelControl.getPanelCount());
+
+        traverseMenu("Boards", "Delete", "Milestones");
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
     }
 
     @Test
@@ -76,6 +121,8 @@ public class BoardAutoCreatorTest extends UITest {
         PlatformEx.waitOnFxThread();
         waitUntilNodeAppears(String.format(SAVE_MESSAGE, "Milestones"));
         clickOn("No");
+
+        PlatformEx.waitOnFxThread();
         assertNodeExists(hasText("Milestones board has been created and loaded.\n\n"
                 + "It is saved under the name \"Milestones\"."));
         clickOn("OK");
@@ -97,6 +144,10 @@ public class BoardAutoCreatorTest extends UITest {
         assertEquals("Next Milestone", panelInfos.get(2).getPanelName());
         assertEquals("Next Next Milestone", panelInfos.get(3).getPanelName());
         assertEquals("Next Next Next Milestone", panelInfos.get(4).getPanelName());
+
+        traverseMenu("Boards", "Delete", "Milestones");
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
     }
 
     @Test
@@ -108,6 +159,8 @@ public class BoardAutoCreatorTest extends UITest {
         PlatformEx.waitOnFxThread();
         waitUntilNodeAppears(String.format(SAVE_MESSAGE, "Work Allocation"));
         clickOn("No");
+
+        PlatformEx.waitOnFxThread();
         assertNodeExists(hasText("Work Allocation board has been created and loaded.\n\n"
                 + "It is saved under the name \"Work Allocation\"."));
         clickOn("OK");
@@ -129,6 +182,10 @@ public class BoardAutoCreatorTest extends UITest {
         assertEquals("Work allocated to User 11", panelInfos.get(2).getPanelName());
         assertEquals("Work allocated to User 12", panelInfos.get(3).getPanelName());
         assertEquals("Work allocated to User 2", panelInfos.get(4).getPanelName());
+
+        traverseMenu("Boards", "Delete", "Work Allocation");
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
     }
 
     @Test
@@ -141,6 +198,10 @@ public class BoardAutoCreatorTest extends UITest {
         waitUntilNodeAppears(SAMPLE_BOARD_DIALOG);
         clickOn("OK");
         verifyBoard(panelControl, BoardAutoCreator.getSamplePanelDetails());
+
+        traverseMenu("Boards", "Delete", SAMPLE_BOARD);
+        waitUntilNodeAppears("OK");
+        clickOn("OK");
     }
 
     /**


### PR DESCRIPTION
Fixes #1461

Now it will only prompt for save if current board is dirty, or current board has not been saved before. 

If current board is a dirty saved board, it will trigger `Save`. 

If current board has not been saved before, it will trigger `Save as`.