### PR TITLE
assignee picker: previous and new assignee should not be the same #1479

### DIFF
--- a/src/main/java/ui/IdGenerator.java
+++ b/src/main/java/ui/IdGenerator.java
@@ -39,6 +39,10 @@ public final class IdGenerator {
         return "assigneePickerTextField";
     }
 
+    public static String getAssigneePickerAssignedUserPaneId() {
+        return "assigneePickerAssignedUserPane";
+    }
+
     public static String getPanelCloseButtonId(int panelIndex) {
         return "panel" + panelIndex + "_closeButton";
     }
@@ -115,8 +119,12 @@ public final class IdGenerator {
         return "#" + getMilestonePickerTextFieldId();
     }
 
-    public static String getAssigneePickerFieldIdReference() {
+    public static String getAssigneePickerTextFieldIdReference() {
         return "#" + getAssigneePickerTextFieldId();
+    }
+
+    public static String getAssigneePickerAssignedUserPaneIdReference() {
+        return "#" + getAssigneePickerAssignedUserPaneId();
     }
 
     public static String getPanelCloseButtonIdReference(int panelIndex) {

--- a/src/main/java/ui/components/pickers/AssigneePickerDialog.java
+++ b/src/main/java/ui/components/pickers/AssigneePickerDialog.java
@@ -145,7 +145,7 @@ public class AssigneePickerDialog extends Dialog<AssigneePickerDialog.AssigneePi
 
     private void updateNewlyAddedAssignee(List<PickerAssignee> users, FlowPane assignedUserPane) {
         users.stream()
-                .filter(PickerAssignee::isSelected)
+                .filter(user -> !user.isExisting() && user.isSelected())
                 .forEach(user -> assignedUserPane.getChildren().add(
                         setMouseClickForNode(user.getNewlyAssignedAssigneeNode(),
                                 user.getLoginName())

--- a/src/main/java/ui/components/pickers/AssigneePickerDialog.java
+++ b/src/main/java/ui/components/pickers/AssigneePickerDialog.java
@@ -41,18 +41,7 @@ public class AssigneePickerDialog extends Dialog<AssigneePickerDialog.AssigneePi
         state = new AssigneePickerState(originalUsers);
         initUI();
         setupKeyEvents();
-        fillTextFieldWithExistingAssignee();
         Platform.runLater(() -> positionDialog(stage));
-    }
-
-    private void fillTextFieldWithExistingAssignee() {
-        PickerAssignee.getExistingAssignee(originalUsers)
-                .map(PickerAssignee::getLoginName)
-                .ifPresent(this::fillTextFieldWithUsername);
-    }
-
-    private void fillTextFieldWithUsername(String username) {
-        textField.setText(username);
     }
 
     private void setupKeyEvents() {

--- a/src/main/java/ui/components/pickers/AssigneePickerDialog.java
+++ b/src/main/java/ui/components/pickers/AssigneePickerDialog.java
@@ -12,6 +12,7 @@ import javafx.scene.control.*;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import ui.IdGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -178,6 +179,7 @@ public class AssigneePickerDialog extends Dialog<AssigneePickerDialog.AssigneePi
         assignedUserPane.setHgap(3);
         assignedUserPane.setVgap(5);
         assignedUserPane.setStyle("-fx-border-radius: 3;");
+        assignedUserPane.setId(IdGenerator.getAssigneePickerAssignedUserPaneId());
         return assignedUserPane;
     }
 

--- a/src/main/java/ui/components/pickers/PickerAssignee.java
+++ b/src/main/java/ui/components/pickers/PickerAssignee.java
@@ -56,7 +56,9 @@ public class PickerAssignee extends TurboUser implements Comparable<PickerAssign
 
     public Node getExistingAssigneeNode() {
         Label assignee = getAssigneeLabelWithAvatar();
-        assignee.getStyleClass().add("labels-removed"); // add strikethrough
+        if (!isSelected) {
+            assignee.getStyleClass().add("labels-removed"); // add strikethrough
+        }
         return assignee;
     }
 

--- a/src/test/java/guitests/AssigneePickerTests.java
+++ b/src/test/java/guitests/AssigneePickerTests.java
@@ -18,8 +18,6 @@ public class AssigneePickerTests extends UITest {
     public void showAssigneePicker_typeQuery_displaysCorrectly() {
         triggerAssigneePicker(getIssueCell(0, 9).getIssue());
         clickAssigneePickerTextField();
-        selectAll();
-        push(KeyCode.BACK_SPACE);
         type("world");
         assertEquals("world", getAssigneePickerTextField().getText());
         exitCleanly();
@@ -29,8 +27,6 @@ public class AssigneePickerTests extends UITest {
     public void showAssigneePicker_noAssignee_assigneeAssigned() {
         TurboIssue issue = getIssueCell(0, 9).getIssue();
         triggerAssigneePicker(issue);
-        selectAll();
-        push(KeyCode.BACK_SPACE);
         type("User");
         push(KeyCode.ENTER);
         assertEquals(true, issue.getAssignee().isPresent());

--- a/src/test/java/guitests/AssigneePickerTests.java
+++ b/src/test/java/guitests/AssigneePickerTests.java
@@ -3,6 +3,7 @@ package guitests;
 import backend.resource.TurboIssue;
 import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
+import org.junit.After;
 import org.junit.Test;
 import ui.IdGenerator;
 import ui.UI;
@@ -12,36 +13,59 @@ import static org.junit.Assert.assertEquals;
 
 public class AssigneePickerTests extends UITest {
 
-    private static final String TEXT_FIELD_ID = "#assigneePickerTextField";
-
     @Test
     public void showAssigneePicker_typeQuery_displaysCorrectly() {
         triggerAssigneePicker(getIssueCell(0, 9).getIssue());
         clickAssigneePickerTextField();
         type("world");
         assertEquals("world", getAssigneePickerTextField().getText());
-        exitCleanly();
     }
 
     @Test
-    public void showAssigneePicker_noAssignee_assigneeAssigned() {
+    public void showAssigneePicker_pickAUser_userPickedAssigned() {
         TurboIssue issue = getIssueCell(0, 9).getIssue();
         triggerAssigneePicker(issue);
-        type("User");
+        type("User 1");
         push(KeyCode.ENTER);
-        assertEquals(true, issue.getAssignee().isPresent());
-        exitCleanly();
+        assertEquals("User 1", issue.getAssignee().get());
     }
 
-    private void exitCleanly() {
+    @Test
+    public void showAssigneePicker_pressEnterAfterAssigneePickerShown_existingAssigneeUnassigned() {
+        TurboIssue issue = getIssueCell(0, 9).getIssue();
+        assertEquals(true, issue.getAssignee().isPresent());
+        triggerAssigneePicker(issue);
+        push(KeyCode.ENTER);
+        assertEquals(false, issue.getAssignee().isPresent());
+    }
+
+    @Test
+    public void showAssigneePicker_pressEscAfterAssigneePickerShown_existingAssigneeUnchanged() {
+        TurboIssue issue = getIssueCell(0, 9).getIssue();
+        String existingAssignee = issue.getAssignee().get();
+        triggerAssigneePicker(issue);
         push(KeyCode.ESCAPE);
-        waitUntilNodeDisappears(IdGenerator.getLabelPickerTextFieldIdReference());
+        assertEquals(existingAssignee, issue.getAssignee().get());
+    }
+
+    @Test
+    public void showAssigneePicker_pickExistingAssignee_existingAssigneeWillNotBeANewlyAddedAssignee() {
+        triggerAssigneePicker(getIssueCell(0, 9).getIssue());
+        clickAssigneePickerTextField();
+        type("User 9");
+        assertEquals(2, getAssigneePickerAssignedUserPane().getChildren().size());
+    }
+
+    @After
+    public void exitCleanly() {
+        push(KeyCode.ESCAPE);
+        waitUntilNodeDisappears(IdGenerator.getAssignedLabelsPaneIdReference());
     }
 
     private void triggerAssigneePicker(TurboIssue issue) {
         Platform.runLater(getStage()::hide);
         UI.events.triggerEvent(new ShowAssigneePickerEvent(issue));
-        waitUntilNodeAppears(TEXT_FIELD_ID);
+        waitUntilNodeAppears(IdGenerator.getAssigneePickerTextFieldIdReference());
     }
 
 }

--- a/src/test/java/guitests/UITest.java
+++ b/src/test/java/guitests/UITest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import javafx.scene.layout.FlowPane;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.Matcher;
@@ -365,8 +366,8 @@ public class UITest extends FxRobot {
      * Clicks the assignee picker's TextField
      */
     public void clickAssigneePickerTextField() {
-        waitUntilNodeAppears(IdGenerator.getAssigneePickerFieldIdReference());
-        clickOn(IdGenerator.getAssigneePickerFieldIdReference());
+        waitUntilNodeAppears(IdGenerator.getAssigneePickerTextFieldIdReference());
+        clickOn(IdGenerator.getAssigneePickerTextFieldIdReference());
     }
 
     /**
@@ -387,7 +388,14 @@ public class UITest extends FxRobot {
      * Gets the assignee picker's TextField
      */
     public TextField getAssigneePickerTextField() {
-        return GuiTest.find(IdGenerator.getAssigneePickerFieldIdReference());
+        return GuiTest.find(IdGenerator.getAssigneePickerTextFieldIdReference());
+    }
+
+    /**
+     * Gets the assignee picker's AssignedUserPane
+     */
+    public FlowPane getAssigneePickerAssignedUserPane() {
+        return GuiTest.find(IdGenerator.getAssigneePickerAssignedUserPaneIdReference());
     }
 
     /**


### PR DESCRIPTION
Fixes #1479 

The assignee picker's text field is now initally blank. Pressing enter at this point will unassign the existing assignee.

![image](https://cloud.githubusercontent.com/assets/12397473/14356291/d688ccba-fd16-11e5-954f-539e3a030667.png)

~~**EDIT**~~
~~The existing assignee will not be struck out initially.~~ 
~~If the user presses backspace when the text field is empty, the existing assignee will be struck out. 
If enter is pressed at this point, the existing assignee will be unassigned.~~ 