### PR TITLE
Issue count is not showing up on all panels #1501

### DIFF
--- a/src/main/java/ui/components/NavigableListView.java
+++ b/src/main/java/ui/components/NavigableListView.java
@@ -96,19 +96,19 @@ public abstract class NavigableListView<T> extends ScrollableListView<T> {
         }
         boolean itemFound = index > -1;
 
+        // Figure out what is selected based on previous and current state
         if (itemFound) {
-            // Select that item
+            // Maintain selection
             getSelectionModel().clearAndSelect(index);
             selectedIndex = Optional.of(index);
             // Do not trigger event; selection did not conceptually change
         } else {
             // The item disappeared
-            if (getItems().size() == 0) {
-                // No more items in the list
+            if (getItems().isEmpty()) {
+                // Nothing can be selected
                 selectedIndex = Optional.empty();
-            } else {
-                // The list is non-empty, so we can be sure that we're selecting something
-                // The current index is the same as the next, due to the item disappearing
+            } else if (selectedIndex.isPresent()){
+                // Consider what is currently selected to be the new selection
                 int lastIndex = getItems().size() - 1;
                 int nextIndex = Math.min(selectedIndex.get(), lastIndex);
 


### PR DESCRIPTION
Fixes #1501 

Exact scenario to reproduce the problem:
1) On a panel with issues, click on any of them.
2) On the same panel, key in a filter expression that will result in zero issues showing up.
3) Click on the same panel listview again for a few times (like you are clicking an empty issue in the empty panel)
4) key in a filter expression that will result in non-empty panel.
5) issue count not shown.

NavigableListView.java: Line 113
` int nextIndex = Math.min(selectedIndex.get(), lastIndex);`

selectedIndex.get() throws an exception as the value is null. Therefore the issue count is not updated.
I believe the selectedIndex was set to null when there is an empty selection on the panel listview.
