### PR TITLE
User can give an alias to a repo #784

### DIFF
--- a/src/main/java/backend/Logic.java
+++ b/src/main/java/backend/Logic.java
@@ -11,6 +11,7 @@ import javafx.application.Platform;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.Logger;
 import prefs.Preferences;
+import prefs.RepoInfo;
 import ui.GuiElement;
 import ui.TestController;
 import ui.UI;
@@ -105,6 +106,7 @@ public class Logic {
      * @return
      */
     public CompletableFuture<Boolean> openPrimaryRepository(String repoId) {
+        logger.info("Opening primary repository: " + repoId);
         return openRepository(repoId, Optional.empty());
     }
 
@@ -116,12 +118,20 @@ public class Logic {
      * <p>
      * Shortly before this method terminates, an AppliedFilterEvent will be triggered
      *
-     * @param repoId
+     * @param repoIdOrAlias string that could be either a repo Id or a repo alias
      * @param panel  panel that opened the repository
      * @return
      */
-    public CompletableFuture<Boolean> openRepositoryFromFilter(String repoId, FilterPanel panel) {
-        return openRepository(repoId, Optional.of(panel));
+    public CompletableFuture<Boolean> openRepositoryFromFilter(String repoIdOrAlias, FilterPanel panel) {
+        logger.info("Opening repository from filter: " + repoIdOrAlias);
+
+        Optional<RepoInfo> repo = prefs.getRepoByIdOrAlias(repoIdOrAlias);
+        if (repo.isPresent()) {
+            logger.info(repoIdOrAlias + " matches " + repo.toString());
+            return openRepository(repo.get().getId(), Optional.of(panel));
+        }
+        // TODO: throw an error message if repo is optional empty
+        return openRepository(repoIdOrAlias, Optional.of(panel));
     }
 
     /**

--- a/src/main/java/backend/RepoIO.java
+++ b/src/main/java/backend/RepoIO.java
@@ -13,6 +13,7 @@ import backend.resource.serialization.SerializableModel;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.egit.github.core.Issue;
+import prefs.RepoInfo;
 import ui.UI;
 import util.HTLog;
 import util.events.ShowErrorDialogEvent;
@@ -126,6 +127,10 @@ public class RepoIO {
                 .thenCompose(newModel -> updateModel(newModel, false, remainingTries))
                 .thenApply(model -> {
                     storedRepos.add(repoId);
+                    // TODO: add something here that also updates the prefs with the newly downloaded repo
+                    UI.prefs.addRepo(new RepoInfo(repoId));
+                    logger.info("Updated the repo collection in prefs as well");
+                    logger.info(UI.prefs.getRepos().toString());
                     return model;
                 })
                 .exceptionally(withResult(new Model(repoId)));

--- a/src/main/java/backend/RepoIO.java
+++ b/src/main/java/backend/RepoIO.java
@@ -108,7 +108,10 @@ public class RepoIO {
     }
 
     public CompletableFuture<Boolean> removeRepository(String repoId) {
+        // remove from the cache
         storedRepos.remove(repoId);
+        // remove from the prefs
+        UI.prefs.removeRepo(new RepoInfo(repoId));
         return jsonStore.removeStoredRepo(repoId);
     }
 
@@ -126,8 +129,9 @@ public class RepoIO {
         return repoSource.downloadRepository(repoId)
                 .thenCompose(newModel -> updateModel(newModel, false, remainingTries))
                 .thenApply(model -> {
+                    // adds new repo to the cache
                     storedRepos.add(repoId);
-                    // TODO: add something here that also updates the prefs with the newly downloaded repo
+                    // add new repo to the prefs
                     UI.prefs.addRepo(new RepoInfo(repoId));
                     logger.info("Updated the repo collection in prefs as well");
                     logger.info(UI.prefs.getRepos().toString());

--- a/src/main/java/backend/UpdateController.java
+++ b/src/main/java/backend/UpdateController.java
@@ -144,7 +144,7 @@ public class UpdateController {
             boolean hasUpdatedQualifier = Qualifier.hasUpdatedQualifier(filterExpr);
 
             try {
-                FilterExpression filterExprNoAlias = Qualifier.replaceMilestoneAliases(models, filterExpr);
+                FilterExpression filterExprNoAlias = Qualifier.replaceAliases(models, filterExpr);
 
                 List<TurboIssue> processedIssues = allModelIssues.stream()
                         .filter(issue -> Qualifier.process(models,

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -301,6 +301,12 @@ public class Preferences { // NOPMD
 
     public void addRepo(RepoInfo repo) {
         userConfig.addRepo(repo);
+        save();
+    }
+
+    public void removeRepo(RepoInfo repo) {
+        userConfig.removeRepo(repo);
+        save();
     }
 
     public void getRepoById(String repoId) {

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -6,6 +6,7 @@ import org.eclipse.egit.github.core.RepositoryId;
 import util.FileHelper;
 import util.HTLog;
 import util.JsonHelper;
+import util.Utility;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -309,15 +310,28 @@ public class Preferences { // NOPMD
         save();
     }
 
-    public void getRepoById(String repoId) {
-        userConfig.getRepoById(repoId);
+    public Optional<RepoInfo> getRepoByIdOrAlias(String repoIdOrAlias) {
+        // if the string matches a repo id format, treat it as a repo id
+        if (Utility.isWellFormedRepoId(repoIdOrAlias)) {
+            return getRepoById(repoIdOrAlias);
+        }
+        // else treat it as an alias
+        return getRepoByAlias(repoIdOrAlias);
     }
 
-    public void getRepoByAlias(String repoAlias) {
-        userConfig.getRepoByAlias(repoAlias);
+    public Optional<RepoInfo> getRepoById(String repoId) {
+        return Optional.ofNullable(userConfig.getRepoById(repoId));
+    }
+
+    public Optional<RepoInfo> getRepoByAlias(String repoAlias) {
+        return Optional.ofNullable(userConfig.getRepoByAlias(repoAlias));
     }
 
     public List<RepoInfo> getRepos() {
         return userConfig.getRepos();
+    }
+
+    public boolean isExistingAlias(String repoAlias) {
+        return userConfig.isExistingAlias(repoAlias);
     }
 }

--- a/src/main/java/prefs/Preferences.java
+++ b/src/main/java/prefs/Preferences.java
@@ -298,4 +298,20 @@ public class Preferences { // NOPMD
     public Optional<LocalDateTime> getMarkedReadAt(String repoId, int issue) {
         return sessionConfig.getMarkedReadAt(repoId, issue);
     }
+
+    public void addRepo(RepoInfo repo) {
+        userConfig.addRepo(repo);
+    }
+
+    public void getRepoById(String repoId) {
+        userConfig.getRepoById(repoId);
+    }
+
+    public void getRepoByAlias(String repoAlias) {
+        userConfig.getRepoByAlias(repoAlias);
+    }
+
+    public List<RepoInfo> getRepos() {
+        return userConfig.getRepos();
+    }
 }

--- a/src/main/java/prefs/RepoInfo.java
+++ b/src/main/java/prefs/RepoInfo.java
@@ -1,0 +1,54 @@
+package prefs;
+
+import com.google.common.base.Objects;
+
+public class RepoInfo {
+    private String id;
+    private String alias;
+
+    public RepoInfo(String id) {
+        this.id = id;
+        this.alias = "";
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getAlias() {
+        return this.alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RepoInfo repoInfo = (RepoInfo) o;
+        return Objects.equal(id, repoInfo.id) &&
+                Objects.equal(alias, repoInfo.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, alias);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append(id);
+        sb.append(", ");
+        sb.append(alias);
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/prefs/RepoInfo.java
+++ b/src/main/java/prefs/RepoInfo.java
@@ -33,7 +33,7 @@ public class RepoInfo {
     }
 
     public boolean hasSameRepoId(RepoInfo repo) {
-        return repo.getId().equals(this.getId());
+        return repo.getId().toLowerCase().equals(this.getId().toLowerCase());
     }
 
     public boolean hasSameAlias(RepoInfo repo) {
@@ -43,7 +43,7 @@ public class RepoInfo {
         if (repo.getAlias() == null || repo.getAlias().isEmpty()) {
             return false;
         }
-        return repo.getAlias().equals(this.getAlias());
+        return repo.getAlias().toLowerCase().equals(this.getAlias().toLowerCase());
     }
 
     @Override

--- a/src/main/java/prefs/RepoInfo.java
+++ b/src/main/java/prefs/RepoInfo.java
@@ -27,6 +27,20 @@ public class RepoInfo {
         this.alias = alias;
     }
 
+    public boolean hasSameRepoId(RepoInfo repo) {
+        return repo.getId().equals(this.getId());
+    }
+
+    public boolean hasSameAlias(RepoInfo repo) {
+        if (this.getAlias() == null || this.getAlias().isEmpty()) {
+            return false;
+        }
+        if (repo.getAlias() == null || repo.getAlias().isEmpty()) {
+            return false;
+        }
+        return repo.getAlias().equals(this.getAlias());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/prefs/RepoInfo.java
+++ b/src/main/java/prefs/RepoInfo.java
@@ -11,6 +11,11 @@ public class RepoInfo {
         this.alias = "";
     }
 
+    public RepoInfo(String id, String alias) {
+        this.id = id;
+        this.alias = alias;
+    }
+
     public String getId() {
         return this.id;
     }

--- a/src/main/java/prefs/UserConfig.java
+++ b/src/main/java/prefs/UserConfig.java
@@ -1,7 +1,47 @@
 package prefs;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Represents user-defined settings.
  */
 public class UserConfig {
+
+    private static final Logger logger = LogManager.getLogger(UserConfig.class.getName());
+
+    private List<RepoInfo> repos = new ArrayList<>();
+
+    public List<RepoInfo> getRepos() {
+        return repos;
+    }
+
+    public void addRepo(RepoInfo repo) {
+        if (repos.stream().noneMatch(e -> e.equals(repo))) {
+            repos.add(repo);
+        }
+    }
+
+    public void removeRepo(RepoInfo repo) {
+        repos.removeIf((e) -> e.equals(repo));
+    }
+
+    public RepoInfo getRepoById(String repoId) {
+        return repos.stream()
+                    .filter(e -> e.getId() == repoId)
+                    .collect(Collectors.toList())
+                    .get(0);
+    }
+
+    public RepoInfo getRepoByAlias(String repoAlias) {
+        return repos.stream()
+                    .filter(e -> e.getAlias() == repoAlias)
+                    .collect(Collectors.toList())
+                    .get(0);
+    }
+
 }

--- a/src/main/java/prefs/UserConfig.java
+++ b/src/main/java/prefs/UserConfig.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,14 +21,31 @@ public class UserConfig {
         return repos;
     }
 
+    /**
+     * Adds a repo to the repo list only if the repo does not already exist in the list.
+     *
+     * Existence in the list is defined as having the same repo ID or the same alias as
+     * another repo already in the list. This check makes the addition run in O(n).
+     *
+     * The final result should still be that the repo to be added will be in the repo
+     * list anyway.
+     * @param repo The repo object to be added to the list.
+     */
     public void addRepo(RepoInfo repo) {
-        if (repos.stream().noneMatch(e -> e.equals(repo))) {
+        logger.info("Attempting to add repo: " + repo.toString());
+        if (repos.stream().noneMatch(e -> (e.hasSameRepoId(repo) || e.hasSameAlias(repo)))) {
             repos.add(repo);
+            logger.info("Added repo: " + repo.toString());
+        } else {
+            logger.info("Repo already exists: " + repo.toString());
         }
     }
 
     public void removeRepo(RepoInfo repo) {
-        repos.removeIf((e) -> e.equals(repo));
+        logger.info("Current list: " + repos.toString());
+        logger.info("Attempting to remove repo: " + repo.toString());
+        repos.removeIf(e -> (e.hasSameRepoId(repo) || e.hasSameAlias(repo)));
+        logger.info("Current list: " + repos.toString());
     }
 
     public RepoInfo getRepoById(String repoId) {

--- a/src/main/java/prefs/UserConfig.java
+++ b/src/main/java/prefs/UserConfig.java
@@ -49,17 +49,29 @@ public class UserConfig {
     }
 
     public RepoInfo getRepoById(String repoId) {
-        return repos.stream()
-                    .filter(e -> e.getId() == repoId)
-                    .collect(Collectors.toList())
-                    .get(0);
+        List<RepoInfo> matchingRepos = repos.stream()
+                .filter(e -> e.getId().toLowerCase().equals(repoId.toLowerCase()))
+                .collect(Collectors.toList());
+        if (matchingRepos.isEmpty()) {
+            return null;
+        }
+        return matchingRepos.get(0);
     }
 
     public RepoInfo getRepoByAlias(String repoAlias) {
-        return repos.stream()
-                    .filter(e -> e.getAlias() == repoAlias)
-                    .collect(Collectors.toList())
-                    .get(0);
+        List<RepoInfo> matchingRepos = repos.stream()
+                .filter(e -> e.getAlias().toLowerCase().equals(repoAlias.toLowerCase()))
+                .collect(Collectors.toList());
+        if (matchingRepos.isEmpty()) {
+            return null;
+        }
+        return matchingRepos.get(0);
     }
 
+    public boolean isExistingAlias(String repoAlias) {
+        List<RepoInfo> matchingRepos = repos.stream()
+                                            .filter(e -> e.getAlias().toLowerCase().equals(repoAlias.toLowerCase()))
+                                            .collect(Collectors.toList());
+        return !matchingRepos.isEmpty();
+    }
 }

--- a/src/main/java/ui/UI.java
+++ b/src/main/java/ui/UI.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.controlsfx.control.NotificationPane;
 import prefs.Preferences;
+import prefs.RepoInfo;
 import ui.components.HTStatusBar;
 import ui.components.KeyboardShortcuts;
 import ui.components.StatusUI;
@@ -174,10 +175,16 @@ public class UI extends Application implements EventDispatcher {
         menuBar.setDisable(disable);
     }
 
+    private void updatePrefsRepoList() {
+        // update the prefs with the currently stored repos
+        logic.getStoredRepos().stream().forEach((storedRepoId) -> prefs.addRepo(new RepoInfo(storedRepoId)));
+    }
+
     private void showMainWindow(String repoId) {
         //We infer this is the first time HT is being used if there are no repo data stored at the start up.
         //This check needs to be done at the very beginning of the startup, before HT downloads any repo data.
         boolean isAFirstTimeUser = logic.getStoredRepos().isEmpty();
+
         logic.openPrimaryRepository(repoId);
         logic.setDefaultRepo(repoId);
         triggerEvent(new PrimaryRepoChangedEvent(repoId));
@@ -251,6 +258,8 @@ public class UI extends Application implements EventDispatcher {
                                         status::updateTimeToRefresh, logic::refresh, TimeUnit.SECONDS);
         refreshTimer.start();
         undoController = new UndoController(notificationController);
+
+        updatePrefsRepoList();
     }
 
     private void initUI(Stage stage) {

--- a/src/main/java/ui/components/pickers/PickerRepository.java
+++ b/src/main/java/ui/components/pickers/PickerRepository.java
@@ -4,6 +4,7 @@ import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Border;
+import prefs.RepoInfo;
 
 /**
  * This class represents a repository in RepositoryPicker.
@@ -14,6 +15,7 @@ import javafx.scene.layout.Border;
 public class PickerRepository implements Comparable<PickerRepository> {
 
     private final String repositoryId;
+    private final String repositoryAlias;
     private boolean isSelected = false;
 
     private static final int REPO_LABEL_PREFERRED_WIDTH = 340;
@@ -23,8 +25,9 @@ public class PickerRepository implements Comparable<PickerRepository> {
     public static final String SELECTED_REPO_LABEL_STYLE = "-fx-background-color: lightgreen; -fx-border-color:black;";
     public static final String DEFAULT_REPO_LABEL_STYLE = "-fx-background-color: lightblue;";
 
-    public PickerRepository(String repositoryId) {
-        this.repositoryId = repositoryId;
+    public PickerRepository(RepoInfo repository) {
+        this.repositoryId = repository.getId();
+        this.repositoryAlias = repository.getAlias();
     }
 
     public String getRepositoryId() {

--- a/src/main/java/ui/components/pickers/PickerRepository.java
+++ b/src/main/java/ui/components/pickers/PickerRepository.java
@@ -34,16 +34,28 @@ public class PickerRepository implements Comparable<PickerRepository> {
         return repositoryId;
     }
 
+    public String getRepositoryAlias() {
+        return repositoryAlias;
+    }
+
+    private boolean hasRepositoryAlias() {
+        return this.repositoryAlias != null && !this.repositoryAlias.isEmpty();
+    }
+
     public Node getNode() {
         Label repoLabel = new Label();
         repoLabel.setPrefWidth(REPO_LABEL_PREFERRED_WIDTH);
         repoLabel.setPadding(DEFAULT_REPO_LABEL_PADDING);
 
-        if (isSelected) {
-            repoLabel.setText(repositoryId);
-            repoLabel.setStyle(COMMON_REPO_LABEL_STYLE + SELECTED_REPO_LABEL_STYLE);
+        if (hasRepositoryAlias()) {
+            repoLabel.setText(repositoryId + " (" + repositoryAlias + ")");
         } else {
             repoLabel.setText(repositoryId);
+        }
+
+        if (isSelected) {
+            repoLabel.setStyle(COMMON_REPO_LABEL_STYLE + SELECTED_REPO_LABEL_STYLE);
+        } else {
             repoLabel.setStyle(COMMON_REPO_LABEL_STYLE + DEFAULT_REPO_LABEL_STYLE);
         }
 

--- a/src/main/java/ui/components/pickers/RepositoryPicker.java
+++ b/src/main/java/ui/components/pickers/RepositoryPicker.java
@@ -27,14 +27,9 @@ public class RepositoryPicker {
     }
 
     private void showRepositoryPicker() {
-        Set<String> storedRepos1 = ui.logic.getStoredRepos();
-        // should also have a set of aliased repos
-        // then show all the stored repos
-        // but for repos with aliases, show the alias instead
-        // scratch that
-        // should show a set of repos that is taken from Repos
-        List<RepoInfo> storedRepos = UI.prefs.getRepos();
-        new RepositoryPickerDialog(storedRepos, this::pickRepository, (repoId) -> ui.logic.isRepositoryValid(repoId));
+        // Shows the repo list in the prefs
+        List<RepoInfo> repoList = UI.prefs.getRepos();
+        new RepositoryPickerDialog(repoList, this::pickRepository, (repoId) -> ui.logic.isRepositoryValid(repoId));
     }
 
     private void pickRepository(Optional<String> repoId) {

--- a/src/main/java/ui/components/pickers/RepositoryPicker.java
+++ b/src/main/java/ui/components/pickers/RepositoryPicker.java
@@ -1,10 +1,13 @@
 package ui.components.pickers;
 
+import backend.interfaces.Repo;
 import javafx.application.Platform;
 import javafx.stage.Stage;
+import prefs.RepoInfo;
 import ui.UI;
 import util.events.ShowRepositoryPickerEventHandler;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -24,7 +27,13 @@ public class RepositoryPicker {
     }
 
     private void showRepositoryPicker() {
-        Set<String> storedRepos = ui.logic.getStoredRepos();
+        Set<String> storedRepos1 = ui.logic.getStoredRepos();
+        // should also have a set of aliased repos
+        // then show all the stored repos
+        // but for repos with aliases, show the alias instead
+        // scratch that
+        // should show a set of repos that is taken from Repos
+        List<RepoInfo> storedRepos = UI.prefs.getRepos();
         new RepositoryPickerDialog(storedRepos, this::pickRepository, (repoId) -> ui.logic.isRepositoryValid(repoId));
     }
 

--- a/src/main/java/ui/components/pickers/RepositoryPickerDialog.java
+++ b/src/main/java/ui/components/pickers/RepositoryPickerDialog.java
@@ -193,7 +193,7 @@ public class RepositoryPickerDialog {
 
         TextField repoIdField = new TextField();
         repoIdField.setPromptText("Repository ID");
-        PasswordField repoAliasField = new PasswordField();
+        TextField repoAliasField = new TextField();
         repoAliasField.setPromptText("Alias (Optional)");
 
         grid.add(new Label("Repository ID:"), 0, 0);

--- a/src/main/java/ui/components/pickers/RepositoryPickerDialog.java
+++ b/src/main/java/ui/components/pickers/RepositoryPickerDialog.java
@@ -11,6 +11,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import prefs.RepoInfo;
 import ui.IdGenerator;
 import util.DialogMessage;
 import util.Futures;
@@ -45,14 +46,14 @@ public class RepositoryPickerDialog {
     private TextField userInputTextField;
     private RepositoryPickerState state;
 
-    public RepositoryPickerDialog(Set<String> storedRepos, Consumer<Optional<String>> onCloseCallback,
+    public RepositoryPickerDialog(List<RepoInfo> storedRepos, Consumer<Optional<String>> onCloseCallback,
                                   Function<String, CompletableFuture<Boolean>> repoValidator) {
         this.onCloseCallback = onCloseCallback;
         this.repoValidator = repoValidator;
         initUi(storedRepos);
     }
 
-    private void initUi(Set<String> storedRepos) {
+    private void initUi(List<RepoInfo> storedRepos) {
         state = new RepositoryPickerState(storedRepos);
 
         initialiseDialog();
@@ -194,7 +195,8 @@ public class RepositoryPickerDialog {
                         return Futures.unit(false);
                     }
 
-                    Platform.runLater(() -> addRepositoryToState(repoId));
+                    RepoInfo repo = new RepoInfo(repoId);
+                    Platform.runLater(() -> addRepositoryToState(repo));
                     return CompletableFuture.completedFuture(true);
                 }).exceptionally(e -> {
                     Platform.runLater(() -> DialogMessage.showErrorDialog("Error checking the validity of " + repoId,
@@ -203,8 +205,8 @@ public class RepositoryPickerDialog {
                 });
     }
 
-    private void addRepositoryToState(String repoId) {
-        state.addRepository(repoId);
+    private void addRepositoryToState(RepoInfo repo) {
+        state.addRepository(repo);
         updateUserQuery(userInputTextField.getText());
     }
 

--- a/src/main/java/ui/components/pickers/RepositoryPickerState.java
+++ b/src/main/java/ui/components/pickers/RepositoryPickerState.java
@@ -1,5 +1,8 @@
 package ui.components.pickers;
 
+import org.apache.regexp.RE;
+import prefs.RepoInfo;
+
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -12,7 +15,7 @@ public class RepositoryPickerState {
     private final List<PickerRepository> repositories = new ArrayList<>();
     private final List<PickerRepository> suggestedRepositories = new ArrayList<>();
 
-    public RepositoryPickerState(Set<String> storedRepositories) {
+    public RepositoryPickerState(List<RepoInfo> storedRepositories) {
         assert !storedRepositories.isEmpty() : "There should be at least one existing repository";
         storedRepositories.stream()
                 .forEach(repo -> repositories.add(new PickerRepository(repo)));
@@ -47,12 +50,12 @@ public class RepositoryPickerState {
      * it will be ignored. This method also invalidates suggestedRepositoryList by clearing it as the current
      * suggestedRepositories might become invalid.
      */
-    public void addRepository(String repoId) {
-        if (getPickerRepositoryById(repositories, repoId).isPresent()) {
+    public void addRepository(RepoInfo repo) {
+        if (getPickerRepositoryById(repositories, repo.getId()).isPresent()) {
             return;
         }
 
-        repositories.add(new PickerRepository(repoId));
+        repositories.add(new PickerRepository(repo));
         Collections.sort(repositories);
         suggestedRepositories.clear();
     }

--- a/src/main/java/ui/components/pickers/RepositoryPickerState.java
+++ b/src/main/java/ui/components/pickers/RepositoryPickerState.java
@@ -150,7 +150,9 @@ public class RepositoryPickerState {
     }
 
     private boolean isMatching(PickerRepository repo, String query) {
-        return repo.getRepositoryId().toLowerCase().contains(query.toLowerCase());
+        boolean isIdMatching = repo.getRepositoryId().toLowerCase().contains(query.toLowerCase());
+        boolean isAliasMatching = repo.getRepositoryAlias().toLowerCase().contains(query.toLowerCase());
+        return isIdMatching || isAliasMatching;
     }
 
 }

--- a/src/main/java/util/Utility.java
+++ b/src/main/java/util/Utility.java
@@ -51,6 +51,12 @@ public final class Utility {
                 && repoId.equals(repositoryId.generateId());
     }
 
+    public static boolean isWellFormedRepoAlias(String repoAlias) {
+        return repoAlias != null
+                && !repoAlias.isEmpty()
+                && repoAlias.matches("^[a-zA-Z0-9]*$");
+    }
+
     public static Optional<String> readFile(String fileName) {
         boolean validPath = !(fileName == null || fileName.isEmpty());
         if (validPath) {

--- a/src/test/java/tests/RepositoryPickerStateTests.java
+++ b/src/test/java/tests/RepositoryPickerStateTests.java
@@ -1,6 +1,7 @@
 package tests;
 
 import org.junit.Test;
+import prefs.RepoInfo;
 import ui.components.pickers.PickerRepository;
 import ui.components.pickers.RepositoryPickerState;
 
@@ -20,9 +21,9 @@ public class RepositoryPickerStateTests {
     public void processUserQuery_queryIsEmpty_queryNotAddedToSuggestedRepos() {
         RepositoryPickerState state = createRepoPickerStateFromRepoIds("atom/atom", "HubTurbo/HubTurbo", "org/repoId");
         state.processUserQuery("");
-        PickerRepository repoA = new PickerRepository("atom/atom");
-        PickerRepository repoB = new PickerRepository("HubTurbo/HubTurbo");
-        PickerRepository repoC = new PickerRepository("org/repoId");
+        PickerRepository repoA = new PickerRepository(new RepoInfo("atom/atom"));
+        PickerRepository repoB = new PickerRepository(new RepoInfo("HubTurbo/HubTurbo"));
+        PickerRepository repoC = new PickerRepository(new RepoInfo("org/repoId"));
         List<PickerRepository> expected = Arrays.asList(repoA, repoB, repoC);
         assertEquals(expected, state.getSuggestedRepositories());
     }
@@ -31,18 +32,20 @@ public class RepositoryPickerStateTests {
     public void processUserQuery_queryMatchesExistingRepo_queryNotAddedToSuggestedRepos() {
         RepositoryPickerState state = createRepoPickerStateFromRepoIds("atom/atom", "HubTurbo/HubTurbo", "org/repoId");
         state.processUserQuery("atom/atom");
-        PickerRepository repoA = new PickerRepository("atom/atom");
+        PickerRepository repoA = new PickerRepository(new RepoInfo("atom/atom"));
         List<PickerRepository> expected = Arrays.asList(repoA);
         assertEquals(expected, state.getSuggestedRepositories());
     }
 
     @Test
     public void processUserQuery_queryIsNotEmpty_matchingRepoAddedToSuggestedList() {
-        Set<String> existingRepositories = new HashSet<>(Arrays.asList("atom/atom", "atom/tree-view", "org/repoId"));
+        //Set<String> existingRepositories = new HashSet<>(Arrays.asList("atom/atom", "atom/tree-view", "org/repoId"));
+        List<RepoInfo> existingRepositories
+                = Arrays.asList(new RepoInfo("atom/atom"), new RepoInfo("atom/tree-view"), new RepoInfo("org/repoId"));
         RepositoryPickerState state = new RepositoryPickerState(existingRepositories);
         state.processUserQuery("atom");
-        PickerRepository repoA = new PickerRepository("atom/atom");
-        PickerRepository repoB = new PickerRepository("atom/tree-view");
+        PickerRepository repoA = new PickerRepository(new RepoInfo("atom/atom"));
+        PickerRepository repoB = new PickerRepository(new RepoInfo("atom/tree-view"));
         List<PickerRepository> expected = Arrays.asList(repoA, repoB);
         assertEquals(expected, state.getSuggestedRepositories());
         state.processUserQuery("z");
@@ -97,7 +100,7 @@ public class RepositoryPickerStateTests {
         state.setSelectedRepositoryInSuggestedList("org/repoId");
         List<String> expectedRepoIds = Arrays.asList("atom/atom", "HubTurbo/HubTurbo", "org/repoId");
         List<PickerRepository> expected = expectedRepoIds.stream()
-                                          .map(repoId -> new PickerRepository(repoId))
+                                          .map(repoId -> new PickerRepository(new RepoInfo(repoId)))
                                           .collect(Collectors.toList());
         assertEquals(expected, state.getSuggestedRepositories());
     }
@@ -123,11 +126,11 @@ public class RepositoryPickerStateTests {
     public void addRepository_suggestedRepositoriesCleared() {
         RepositoryPickerState state = createRepoPickerStateFromRepoIds("atom/atom", "atom/tree-view", "org/repoId");
         state.processUserQuery("a");
-        PickerRepository repoA = new PickerRepository("atom/atom");
-        PickerRepository repoB = new PickerRepository("atom/tree-view");
+        PickerRepository repoA = new PickerRepository(new RepoInfo("atom/atom"));
+        PickerRepository repoB = new PickerRepository(new RepoInfo("atom/tree-view"));
         List<PickerRepository> expected = Arrays.asList(repoA, repoB);
         assertEquals(expected, state.getSuggestedRepositories());
-        state.addRepository("atom/status-bar");
+        state.addRepository(new RepoInfo("atom/status-bar"));
         assertEquals(0, state.getSuggestedRepositories().size());
     }
 
@@ -135,10 +138,10 @@ public class RepositoryPickerStateTests {
     public void addRepository_processInputAfterAdding_newRepoAddedToSuggestedRepositories() {
         RepositoryPickerState state = createRepoPickerStateFromRepoIds("atom/atom", "atom/tree-view", "org/repoId");
         state.processUserQuery("a");
-        PickerRepository repoA = new PickerRepository("atom/atom");
-        PickerRepository repoB = new PickerRepository("atom/tree-view");
-        PickerRepository repoD = new PickerRepository("atom/status-bar");
-        state.addRepository("atom/status-bar");
+        PickerRepository repoA = new PickerRepository(new RepoInfo("atom/atom"));
+        PickerRepository repoB = new PickerRepository(new RepoInfo("atom/tree-view"));
+        PickerRepository repoD = new PickerRepository(new RepoInfo("atom/status-bar"));
+        state.addRepository(new RepoInfo("atom/status-bar"));
         assertEquals(0, state.getSuggestedRepositories().size());
         state.processUserQuery("a");
         List<PickerRepository> expected = Arrays.asList(repoA, repoD, repoB);
@@ -146,7 +149,9 @@ public class RepositoryPickerStateTests {
     }
 
     private RepositoryPickerState createRepoPickerStateFromRepoIds(String... repoId) {
-        Set<String> existingRepositories = new HashSet<>(Arrays.asList(repoId));
+        //Set<String> existingRepositories = new HashSet<>(Arrays.asList(repoId));
+        List<RepoInfo> existingRepositories
+                = Arrays.asList(repoId).stream().map(e -> new RepoInfo(e)).collect(Collectors.toList());
         return new RepositoryPickerState(existingRepositories);
     }
 


### PR DESCRIPTION
Fixes #784

Still in progress.

1. Assign an alias when adding a new repo
2. Refer to the repo by its alias in the panel filter
3. Repo aliases are alphanumeric and case insensitive. No spaces or slashes, so it cannot be confused with (github) repo ids.
4. Prefs keep track of all added repos. Aliases are stored with the repos in prefs. Additional info can be stored as well, like color coding. But this is a feature for the prefs, not of repo aliases.